### PR TITLE
start-server-with-maxWebSocketFrameSize

### DIFF
--- a/structures-core/src/main/java/org/kinotic/structures/api/config/StructuresProperties.java
+++ b/structures-core/src/main/java/org/kinotic/structures/api/config/StructuresProperties.java
@@ -1,10 +1,12 @@
 package org.kinotic.structures.api.config;
 
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
+import java.time.Duration;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang3.Validate;
 import org.kinotic.structures.internal.config.ElasticConnectionInfo;
 import org.kinotic.structures.internal.config.OpenApiSecurityType;
@@ -12,10 +14,10 @@ import org.kinotic.structures.internal.utils.StructuresUtil;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
-import javax.validation.constraints.NotNull;
-import java.time.Duration;
-import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 @Getter
 @Setter
@@ -62,6 +64,11 @@ public class StructuresProperties {
     private OpenApiSecurityType openApiSecurityType = OpenApiSecurityType.NONE;
 
     private int openApiPort = 8080;
+
+    // See 
+    //  https://github.com/Kinotic-Foundation/continuum-framework/blob/develop/continuum-core-vertx/src/main/java/org/kinotic/continuum/internal/config/DefaultContinuumProperties.java
+    // private int maxEventPayloadSize = 1024 * 1024 * 10; // 10MB
+    private int maxWebSocketFrameSize = 1024 * 1024 * 10; // 10MB
 
     private String openApiPath = "/api/";
 

--- a/structures-core/src/main/java/org/kinotic/structures/internal/endpoints/WebServerVerticle.java
+++ b/structures-core/src/main/java/org/kinotic/structures/internal/endpoints/WebServerVerticle.java
@@ -1,20 +1,22 @@
 package org.kinotic.structures.internal.endpoints;
 
+import java.util.Set;
+
+import org.kinotic.structures.api.config.StructuresProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.healthchecks.HealthChecks;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.CorsHandler;
 import io.vertx.ext.web.handler.StaticHandler;
-import org.kinotic.structures.api.config.StructuresProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
-
-import java.util.Set;
 
 /**
  * Created by Navíd Mitchell 🤪on 6/8/23.
@@ -37,7 +39,10 @@ public class WebServerVerticle extends AbstractVerticle{
 
     @Override
     public void start(Promise<Void> startPromise) {
-        server = vertx.createHttpServer();
+        HttpServerOptions opts = new HttpServerOptions();
+        opts.setMaxWebSocketFrameSize(properties.getMaxWebSocketFrameSize());
+
+        server = vertx.createHttpServer(opts);
 
         Router router = Router.router(vertx);
 
@@ -55,13 +60,12 @@ public class WebServerVerticle extends AbstractVerticle{
         // Begin listening for requests
         server.requestHandler(router).listen(properties.getWebServerPort(), ar -> {
             if (ar.succeeded()) {
-                if(log.isDebugEnabled()) {
-                    if(properties.isEnableStaticFileServer()) {
-                        log.debug("Web Server listening on port " + properties.getWebServerPort());
-                        log.debug("Web Server available at http://localhost:" + properties.getWebServerPort() + "/");
-                    }
-                    log.debug("Health checks available at http://localhost:" + properties.getWebServerPort() + properties.getHealthCheckPath());
+                if(properties.isEnableStaticFileServer()) {
+                    log.debug("Web Server listening on port " + properties.getWebServerPort());
+                    log.debug("Web Server available at http://localhost:" + properties.getWebServerPort() + "/");
                 }
+                log.debug("Health checks available at http://localhost:" + properties.getWebServerPort() + properties.getHealthCheckPath());
+                log.debug("Using maxWebSocketFrameSize:" + properties.getMaxWebSocketFrameSize());
                 startPromise.complete();
             } else {
                 startPromise.fail(ar.cause());


### PR DESCRIPTION
Attempt to fix  `Max frame length of 65536 has been exceeded.`

Related code 
https://github.com/eclipse-vertx/vert.x/blob/5a17ab34849e29cd53cf37d7339a54e5d1bdb09d/src/main/java/io/vertx/core/http/HttpServerOptions.java#L69

== Error
```
2023-10-03 15:41:51.377 ERROR 1 --- [ntloop-thread-3] o.k.c.g.i.e.s.DefaultStompServerHandler  : Client Caused Exception

io.netty.handler.codec.http.websocketx.CorruptedWebSocketFrameException: Max frame length of 65536 has been exceeded.
	at io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder.protocolViolation(WebSocket08FrameDecoder.java:427) ~[netty-codec-http-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.handler.codec.http.websocketx.WebSocket08FrameDecoder.decode(WebSocket08FrameDecoder.java:288) ~[netty-codec-http-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:529) ~[netty-codec-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:468) ~[netty-codec-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290) ~[netty-codec-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562) ~[netty-transport-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.94.Final.jar:4.1.94.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.94.Final.jar:4.1.94.Final]
	at java.base/java.lang.Thread.run(Unknown Source) ~[na:na]
```