### PR TITLE
Refresh elastic shard when single delete

### DIFF
--- a/structures-core/src/main/java/org/kinotic/structures/internal/api/services/impl/CrudServiceTemplate.java
+++ b/structures-core/src/main/java/org/kinotic/structures/internal/api/services/impl/CrudServiceTemplate.java
@@ -4,6 +4,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch._types.ErrorResponse;
 import co.elastic.clients.elasticsearch._types.FieldSort;
 import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.core.*;
 import co.elastic.clients.elasticsearch.core.get.GetResult;
@@ -129,7 +130,7 @@ public class CrudServiceTemplate {
                                                         String id,
                                                         Consumer<DeleteRequest.Builder> builderConsumer) {
         return esAsyncClient.delete(builder -> {
-            builder.index(indexName).id(id);
+            builder.index(indexName).id(id).refresh(Refresh.True);
             if (builderConsumer != null) {
                 builderConsumer.accept(builder);
             }


### PR DESCRIPTION
I do not know, if this is correct place and correct solution :) 

When we delete by id, and then query right away, we still get the deleted entity. Therefore we should refresh shard as we do it when update by id to have it available right away.

Note: I would propose as the long term solution to introduce new search param for single mutation operations (update, delete,...) where we can specify the one of the options `true`, `false`, `wait_for`.

This is going against #36.