### PR TITLE
Hide docus default header/footer on legal pages

### DIFF
--- a/website/app/pages/privacy.vue
+++ b/website/app/pages/privacy.vue
@@ -1,5 +1,5 @@
 <script setup>
-definePageMeta({ layout: 'home' })
+definePageMeta({ layout: 'home', header: false, footer: false })
 useHead({ title: 'Privacy Policy' })
 </script>
 

--- a/website/app/pages/terms.vue
+++ b/website/app/pages/terms.vue
@@ -1,5 +1,5 @@
 <script setup>
-definePageMeta({ layout: 'home' })
+definePageMeta({ layout: 'home', header: false, footer: false })
 useHead({ title: 'Terms of Service' })
 </script>
 


### PR DESCRIPTION
The home layout renders Kinotic's own Header and Footer components, but docus's app.vue also renders AppHeader/AppFooter on every route unless the page opts out via meta flags. Without these flags the terms and privacy pages double-stacked both chrome sets — matches what index.vue already does.

https://claude.ai/code/session_01W6yoEtipNrTJHNLxfkeCxC