### PR TITLE
Simplify header navigation by consolidating links to Docs

### DIFF
--- a/website/app/components/Header.vue
+++ b/website/app/components/Header.vue
@@ -44,9 +44,7 @@ watch(isMenuOpen, (val) => {
         </NuxtLink>
 
         <div class="hidden items-center gap-8 lg:flex">
-          <NuxtLink to="/apps/introduction" class="text-[14px] font-medium leading-[120%] text-white transition hover:opacity-80">Guide</NuxtLink>
-          <NuxtLink to="/reference/sdk-packages" class="text-[14px] font-medium leading-[120%] text-white transition hover:opacity-80">Reference</NuxtLink>
-          <NuxtLink to="/test-status" class="text-[14px] font-medium leading-[120%] text-white transition hover:opacity-80">Test Status</NuxtLink>
+          <NuxtLink to="/apps/introduction" class="text-[14px] font-medium leading-[120%] text-white transition hover:opacity-80">Docs</NuxtLink>
           <span class="h-5 w-px bg-white/20"></span>
           <a
             href="https://github.com/kinotic-ai/kinotic"
@@ -103,9 +101,7 @@ watch(isMenuOpen, (val) => {
 
         <div class="flex flex-col justify-between items-center gap-6 h-screen">
           <div class="flex flex-col justify-between items-center gap-8">
-            <NuxtLink to="/apps/introduction" class="text-sm text-[#EDEEF2]" @click="isMenuOpen = false">Guide</NuxtLink>
-            <NuxtLink to="/reference/sdk-packages" class="text-sm text-[#EDEEF2]" @click="isMenuOpen = false">Reference</NuxtLink>
-<!--            <NuxtLink to="/test-status" class="text-sm text-[#EDEEF2]" @click="isMenuOpen = false">Test Status</NuxtLink>-->
+            <NuxtLink to="/apps/introduction" class="text-sm text-[#EDEEF2]" @click="isMenuOpen = false">Docs</NuxtLink>
           </div>
           <a
             href="https://github.com/kinotic-ai/kinotic"


### PR DESCRIPTION
## Summary
This PR simplifies the website header navigation by consolidating multiple navigation links into a single "Docs" link, reducing navigation clutter while maintaining access to documentation.

