### PR TITLE
Update package name from kinotic-website to Kinotic

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kinotic-website",
+  "name": "Kinotic",
   "scripts": {
     "dev": "nuxt dev",
     "build": "nuxt build",


### PR DESCRIPTION
## Summary
Updated the package name in package.json to reflect a more concise and branded naming convention.

## Changes
- Changed package name from `kinotic-website` to `Kinotic` in package.json

## Details
This change simplifies the package identifier to use the primary brand name rather than a descriptive slug. This is a cosmetic update that may be useful for package registry visibility or internal branding consistency.

https://claude.ai/code/session_01DifTVjvpf52KAqiupFuE8v