### PR TITLE
claude/refactor-secret-storage-enum-KBNRi

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/api/config/SecretStorageBackendType.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/config/SecretStorageBackendType.java
@@ -1,0 +1,16 @@
+package org.kinotic.core.api.config;
+
+/**
+ * Supported backend types for secret storage.
+ */
+public enum SecretStorageBackendType {
+    /**
+     * Chronicle Map (OpenHFT) backed secret storage that persists secrets to a memory-mapped file.
+     * Intended for local development.
+     */
+    HFT,
+    /**
+     * Azure Key Vault backed secret storage.
+     */
+    AZURE
+}

--- a/kinotic-core/src/main/java/org/kinotic/core/api/config/SecretStorageSettings.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/config/SecretStorageSettings.java
@@ -12,19 +12,19 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class SecretStorageSettings {
     /**
-     * Backend type: "azure" or "chronicle-map". If null, in-memory storage is used.
+     * Backend type. If null, in-memory storage is used.
      */
-    private String backend;
+    private SecretStorageBackendType backend;
     /**
      * Base64-encoded 32-byte HKDF master key for deriving opaque secret names.
      */
     private String masterKey;
     /**
-     * Azure Key Vault settings. Required when {@code backend} is {@code "azure"}.
+     * Azure Key Vault settings. Required when {@code backend} is {@link SecretStorageBackendType#AZURE}.
      */
     private AzureSettings azure;
     /**
-     * Chronicle Map settings. Required when {@code backend} is {@code "chronicle-map"}.
+     * Chronicle Map settings. Required when {@code backend} is {@link SecretStorageBackendType#HFT}.
      */
     private ChronicleMapSettings chronicleMap;
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/config/SecretStorageConfiguration.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/config/SecretStorageConfiguration.java
@@ -21,9 +21,8 @@ public class SecretStorageConfiguration {
             return new InMemoryBackend();
         }
         return switch (settings.getBackend()) {
-            case "chronicle-map" -> createChronicleMapBackend(settings);
-            case "azure" -> createAzureBackend(settings);
-            default -> throw new IllegalArgumentException("Unknown secret storage backend: " + settings.getBackend());
+            case HFT -> createChronicleMapBackend(settings);
+            case AZURE -> createAzureBackend(settings);
         };
     }
 

--- a/kinotic-server/src/main/resources/application-development.yml
+++ b/kinotic-server/src/main/resources/application-development.yml
@@ -4,6 +4,9 @@ kinotic:
   maxNumberOfCoresToUse: 4
   ignite:
     discoveryType: SHAREDFS
+  secretStorage:
+    backend: hft
+    masterKey: a2lub3RpYy1kZXZlbG9wbWVudC1tYXN0ZXIta2V5LSE=
   persistence:
     corsAllowedOriginPattern: "https:\\/\\/studio.apollographql.com|http:\\/\\/localhost:\\d+|http:\\/\\/121.0.0.1:\\d+"
     corsAllowedHeaders:


### PR DESCRIPTION
Replace the stringly-typed SecretStorageSettings.backend field with a
new SecretStorageBackendType enum (HFT, AZURE) so invalid backend names
fail at binding time rather than at bean creation. Configure the
development profile to use the HFT (Chronicle Map) backend with a dev
master key.
