### PR TITLE
claude/refactor-iam-credential-store-5i529

### DIFF
--- a/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/AbstractCrudService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/AbstractCrudService.java
@@ -1,7 +1,6 @@
 package org.kinotic.os.internal.api.services;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
-import co.elastic.clients.elasticsearch._types.Refresh;
 
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -51,11 +50,8 @@ public abstract class AbstractCrudService<T extends Identifiable<String>> implem
 
     @Override
     public CompletableFuture<T> save(T entity) {
-        return esAsyncClient.index(i -> i
-                .index(indexName)
-                .id(entity.getId())
-                .document(entity))
-                .thenCompose(indexResponse -> findById(indexResponse.id()));
+        return crudServiceTemplate.save(indexName, entity.getId(), entity, null)
+                                  .thenCompose(indexResponse -> findById(indexResponse.id()));
     }
 
     @Override
@@ -72,12 +68,8 @@ public abstract class AbstractCrudService<T extends Identifiable<String>> implem
 
     @Override
     public CompletableFuture<T> saveSync(T entity) {
-        return esAsyncClient.index(i -> i
-                .index(indexName)
-                .id(entity.getId())
-                .document(entity)
-                .refresh(Refresh.WaitFor))
-                .thenCompose(indexResponse -> findById(indexResponse.id()));
+        return crudServiceTemplate.saveSync(indexName, entity.getId(), entity, null)
+                                  .thenCompose(indexResponse -> findById(indexResponse.id()));
     }
 
 }

--- a/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/CrudServiceTemplate.java
+++ b/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/CrudServiceTemplate.java
@@ -449,6 +449,28 @@ public class CrudServiceTemplate {
                 });
     }
 
+    /**
+     * Indexes a document. Also allows for customization of the {@link IndexRequest}.
+     *
+     * @param indexName       name of the index
+     * @param id              of the document to index
+     * @param document        to index
+     * @param builderConsumer to customize the {@link IndexRequest}, or null if no customization is needed
+     * @return a {@link CompletableFuture} that will complete with the {@link IndexResponse}
+     */
+    public <T> CompletableFuture<IndexResponse> save(String indexName,
+                                                     String id,
+                                                     T document,
+                                                     Consumer<IndexRequest.Builder<T>> builderConsumer) {
+        return esAsyncClient.index((IndexRequest.Builder<T> builder) -> {
+            builder.index(indexName).id(id).document(document);
+            if (builderConsumer != null) {
+                builderConsumer.accept(builder);
+            }
+            return builder;
+        });
+    }
+
     public CompletableFuture<Void> updateIndexMapping(String indexName,
                                                       Map<String, Property> mappings) {
         return esAsyncClient.indices().exists(builder -> builder.index(indexName))

--- a/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/CrudServiceTemplate.java
+++ b/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/CrudServiceTemplate.java
@@ -4,6 +4,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch._types.ErrorResponse;
 import co.elastic.clients.elasticsearch._types.FieldSort;
 import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
 import co.elastic.clients.elasticsearch._types.mapping.Property;
@@ -468,6 +469,28 @@ public class CrudServiceTemplate {
                 builderConsumer.accept(builder);
             }
             return builder;
+        });
+    }
+
+    /**
+     * Indexes a document using {@link Refresh#WaitFor}, guaranteeing read-your-write
+     * semantics for subsequent queries. Also allows for customization of the {@link IndexRequest}.
+     *
+     * @param indexName       name of the index
+     * @param id              of the document to index
+     * @param document        to index
+     * @param builderConsumer to customize the {@link IndexRequest}, or null if no customization is needed
+     * @return a {@link CompletableFuture} that will complete with the {@link IndexResponse}
+     */
+    public <T> CompletableFuture<IndexResponse> saveSync(String indexName,
+                                                         String id,
+                                                         T document,
+                                                         Consumer<IndexRequest.Builder<T>> builderConsumer) {
+        return save(indexName, id, document, builder -> {
+            if (builderConsumer != null) {
+                builderConsumer.accept(builder);
+            }
+            builder.refresh(Refresh.WaitFor);
         });
     }
 

--- a/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/iam/IamCredentialStore.java
+++ b/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/iam/IamCredentialStore.java
@@ -1,6 +1,5 @@
 package org.kinotic.os.internal.api.services.iam;
 
-import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +17,6 @@ public class IamCredentialStore {
 
     private static final String INDEX_NAME = "kinotic_iam_credential";
 
-    private final ElasticsearchAsyncClient esAsyncClient;
     private final CrudServiceTemplate crudServiceTemplate;
 
     @PostConstruct
@@ -27,27 +25,20 @@ public class IamCredentialStore {
     }
 
     public CompletableFuture<IamCredential> findById(String userId) {
-        return esAsyncClient.get(g -> g.index(INDEX_NAME).id(userId), IamCredential.class)
-                            .thenApply(response -> {
-                                if (response.found()) {
-                                    return response.source();
-                                }
-                                return null;
-                            });
+        return crudServiceTemplate.findById(INDEX_NAME, userId, IamCredential.class, null);
     }
 
     public CompletableFuture<IamCredential> save(IamCredential credential) {
-        return esAsyncClient.index(i -> i
-                .index(INDEX_NAME)
-                .id(credential.getId())
-                .document(credential)
-                .refresh(Refresh.WaitFor))
-                .thenApply(response -> credential);
+        return crudServiceTemplate.save(INDEX_NAME,
+                                        credential.getId(),
+                                        credential,
+                                        b -> b.refresh(Refresh.WaitFor))
+                                  .thenApply(response -> credential);
     }
 
     public CompletableFuture<Void> deleteById(String userId) {
-        return esAsyncClient.delete(d -> d.index(INDEX_NAME).id(userId))
-                            .thenApply(response -> null);
+        return crudServiceTemplate.deleteById(INDEX_NAME, userId, null)
+                                  .thenApply(response -> null);
     }
 
 }

--- a/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/iam/IamCredentialStore.java
+++ b/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/iam/IamCredentialStore.java
@@ -1,6 +1,5 @@
 package org.kinotic.os.internal.api.services.iam;
 
-import co.elastic.clients.elasticsearch._types.Refresh;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,10 +28,10 @@ public class IamCredentialStore {
     }
 
     public CompletableFuture<IamCredential> save(IamCredential credential) {
-        return crudServiceTemplate.save(INDEX_NAME,
-                                        credential.getId(),
-                                        credential,
-                                        b -> b.refresh(Refresh.WaitFor))
+        return crudServiceTemplate.saveSync(INDEX_NAME,
+                                            credential.getId(),
+                                            credential,
+                                            null)
                                   .thenApply(response -> credential);
     }
 


### PR DESCRIPTION
Replace direct ElasticsearchAsyncClient calls in IamCredentialStore with
CrudServiceTemplate for findById, save, and deleteById. Adds a save
method to CrudServiceTemplate that mirrors the builder-consumer pattern
of the other methods.

https://claude.ai/code/session_01HpJF1Hw9jyAPBXYXn4KeBb