### PR TITLE
Add primary field to kinotic_iam_user seed data

### DIFF
--- a/kinotic-migration/src/main/resources/migrations/V3__kinotic_test_users.sql
+++ b/kinotic-migration/src/main/resources/migrations/V3__kinotic_test_users.sql
@@ -3,7 +3,7 @@
 INSERT INTO kinotic_system (id) VALUES ('kinotic-system') WITH REFRESH;
 
 -- Seed the default system administrator (password: kinotic)
-INSERT INTO kinotic_iam_user (id, email, displayName, authType, authScopeType, authScopeId, enabled) VALUES ('00000000-0000-0000-0000-000000000001', 'admin@kinotic.local', 'System Admin', 'LOCAL', 'SYSTEM', 'kinotic', true) WITH REFRESH;
+INSERT INTO kinotic_iam_user (id, email, displayName, authType, authScopeType, authScopeId, enabled, primary) VALUES ('00000000-0000-0000-0000-000000000001', 'admin@kinotic.local', 'System Admin', 'LOCAL', 'SYSTEM', 'kinotic', true, true) WITH REFRESH;
 INSERT INTO kinotic_iam_credential (id, passwordHash) VALUES ('00000000-0000-0000-0000-000000000001', '$2b$12$ztUtxd/6nRYTACObjRNnMOisx3QlNuP2GmabcBdrv4Vcd6Vs46GaG') WITH REFRESH;
 
 
@@ -11,5 +11,5 @@ INSERT INTO kinotic_iam_credential (id, passwordHash) VALUES ('00000000-0000-000
 INSERT INTO kinotic_organization (id, name, description) VALUES ('kinotic-test', 'kinotic-test', 'Organization used by kinotic end-to-end and core package tests') WITH REFRESH;
 
 -- Seed the kinotic-test organization user (password: kinotic)
-INSERT INTO kinotic_iam_user (id, email, displayName, authType, authScopeType, authScopeId, enabled) VALUES ('00000000-0000-0000-0000-000000000002', 'kinotic@kinotic.local', 'Kinotic Test', 'LOCAL', 'ORGANIZATION', 'kinotic-test', true) WITH REFRESH;
+INSERT INTO kinotic_iam_user (id, email, displayName, authType, authScopeType, authScopeId, enabled, primary) VALUES ('00000000-0000-0000-0000-000000000002', 'kinotic@kinotic.local', 'Kinotic Test', 'LOCAL', 'ORGANIZATION', 'kinotic-test', true, true) WITH REFRESH;
 INSERT INTO kinotic_iam_credential (id, passwordHash) VALUES ('00000000-0000-0000-0000-000000000002', '$2b$12$ztUtxd/6nRYTACObjRNnMOisx3QlNuP2GmabcBdrv4Vcd6Vs46GaG') WITH REFRESH;


### PR DESCRIPTION
## Summary
Updated the test user seed migration to include the `primary` field for IAM users, marking both the system administrator and test organization users as primary users.

## Changes
- Added `primary` column to the `kinotic_iam_user` INSERT statements in the migration script
- Set `primary` to `true` for both seeded users:
  - System administrator user (admin@kinotic.local)
  - Kinotic test organization user (kinotic@kinotic.local)

## Details
This change reflects a schema update to the `kinotic_iam_user` table that now includes a `primary` field to designate primary user accounts. Both seed users are marked as primary to ensure they function as the main user accounts for their respective scopes (SYSTEM and ORGANIZATION).

https://claude.ai/code/session_016qdjmR2PjjVPwVtPVeRhRe