### PR TITLE
Fix Paketo health check path for kinotic-server container

### DIFF
--- a/deployment/docker-compose/compose.kinotic-server.yml
+++ b/deployment/docker-compose/compose.kinotic-server.yml
@@ -47,6 +47,7 @@ services:
       SPRING_AI_OPENAI_BASE_URL: "https://api.x.ai"
       SPRING_AI_OPENAI_CHAT_OPTIONS_MODEL: "grok-4"
       THC_PORT: 58503 # Paketo health-check probe — health endpoint is mounted on the api-gateway router (stomp port)
+      THC_PATH: /health # THC defaults to "/", which 404s; the api-gateway only mounts /health
     stdin_open: true # docker run -i
     tty: true        # docker run -t
     deploy:


### PR DESCRIPTION
## Summary
Configure the Paketo health check (THC) to use the correct health endpoint path for the kinotic-server container in the Docker Compose configuration.

## Changes
- Added `THC_PATH: /health` environment variable to the kinotic-server service
- This ensures the Paketo health-check probe queries the correct `/health` endpoint instead of the default `/` path, which was returning 404s
- The `/health` endpoint is the only health path mounted on the api-gateway router (STOMP port)

## Details
The Paketo health check probe was previously using its default path of `/`, which doesn't exist on the api-gateway router. By explicitly setting `THC_PATH` to `/health`, the health check will now properly probe the correct endpoint that is actually mounted and available on the container.

https://claude.ai/code/session_01XzHDHY8LGjZVzDqUdjBro6