### PR TITLE
Wrap repository calls with elevated access in tests

### DIFF
--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/sample/TestDataService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/sample/TestDataService.java
@@ -99,6 +99,7 @@ public class TestDataService {
     public CompletableFuture<EntityDefinition> createCarEntityDefinition(String structureNameSuffix) {
         EntityDefinition structure = new EntityDefinition();
         structure.setName("Car"+(structureNameSuffix != null ? structureNameSuffix : ""));
+        structure.setOrganizationId("kinotic");
         structure.setApplicationId("org.kinotic.sample");
         structure.setProjectId("org.kinotic.sample_default");
         structure.setDescription("Defines a Car");
@@ -184,6 +185,7 @@ public class TestDataService {
     public CompletableFuture<EntityDefinition> createPersonEntityDefinition(String structureNameSuffix) {
         EntityDefinition structure = new EntityDefinition();
         structure.setName("Person"+(structureNameSuffix != null ? structureNameSuffix : ""));
+        structure.setOrganizationId("kinotic");
         structure.setApplicationId("org.kinotic.sample");
         structure.setProjectId("org.kinotic.sample_default");
         structure.setDescription("Defines a Person");

--- a/kinotic-test/build.gradle
+++ b/kinotic-test/build.gradle
@@ -10,6 +10,10 @@ dependencies {
 	implementation project(':kinotic-persistence')
 	implementation project(':kinotic-sql')
 
+	// SecurityContext lives in kinotic-core but its API surface (Vertx) is hidden by `implementation`.
+	// kinotic-test uses Vertx + SecurityContext to wrap test calls in withElevatedAccess.
+	implementation 'io.vertx:vertx-core'
+
 	implementation 'io.jsonwebtoken:jjwt-api'
 	implementation 'io.jsonwebtoken:jjwt-impl'
 	implementation 'io.jsonwebtoken:jjwt-jackson'

--- a/kinotic-test/src/test/java/org/kinotic/test/support/kinotic/KinoticTestBase.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/support/kinotic/KinoticTestBase.java
@@ -1,8 +1,14 @@
 package org.kinotic.test.support.kinotic;
 
+import io.vertx.core.Vertx;
+import org.kinotic.core.api.security.SecurityContext;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 /**
  * Test base for tests that need the full Kinotic stack (Elasticsearch + kinotic-server)
@@ -13,4 +19,37 @@ import org.springframework.test.context.ContextConfiguration;
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public abstract class KinoticTestBase {
+
+    /**
+     * Default organization id used by test fixtures. Scoped CRUD services derive
+     * Elasticsearch routing keys and ID prefixes from this value when running
+     * with elevated access, so all test entities are co-located under one org.
+     */
+    public static final String TEST_ORG_ID = "kinotic";
+
+    @Autowired
+    protected Vertx vertx;
+
+    @Autowired
+    protected SecurityContext securityContext;
+
+    /**
+     * Runs the supplied async operation on a Vert.x context with elevated access
+     * so that {@code AbstractCrudService} skips org-scope enforcement on
+     * {@link org.kinotic.os.api.model.OrganizationScoped} entities. This lets tests
+     * exercise scoped services without authenticating as an ORGANIZATION participant.
+     */
+    protected <T> CompletableFuture<T> elevated(Supplier<CompletableFuture<T>> supplier) {
+        CompletableFuture<T> result = new CompletableFuture<>();
+        vertx.getOrCreateContext().runOnContext(v ->
+                securityContext.withElevatedAccess(supplier)
+                               .whenComplete((value, error) -> {
+                                   if (error != null) {
+                                       result.completeExceptionally(error);
+                                   } else {
+                                       result.complete(value);
+                                   }
+                               }));
+        return result;
+    }
 }

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/ApplicationTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/ApplicationTests.java
@@ -11,8 +11,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import java.util.concurrent.CompletableFuture;
-
 @SpringBootTest
 public class ApplicationTests extends KinoticTestBase {
 
@@ -23,20 +21,19 @@ public class ApplicationTests extends KinoticTestBase {
 	public void createAndDeleteApplication() {
 		Application test = new Application();
 		test.setId("Test");
+		test.setOrganizationId(TEST_ORG_ID);
 		test.setDescription("Testing This Application");
 
-		CompletableFuture<Application> future = applicationService.save(test);
-
-		StepVerifier.create(Mono.fromFuture(future))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> applicationService.save(test))))
 					.expectNextMatches(application -> application.getId().equals("Test") && application.getUpdated() != null)
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(applicationService.deleteById(test.getId())))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> applicationService.deleteById(test.getId()))))
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(applicationService.findById(test.getId())))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> applicationService.findById(test.getId()))))
 					.expectComplete()
 					.verify();
 	}

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/BulkUpdateTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/BulkUpdateTests.java
@@ -77,23 +77,23 @@ public class BulkUpdateTests extends KinoticTestBase {
         Assertions.assertNotNull(holder2);
 
         // Sync Index since bulk updates are not queryable until they are indexed
-        entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1).join();
-        entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2).join();
+        elevated(() -> entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
+        elevated(() -> entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
 
         // TODO: verify all data items as well, not just sizes
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findAll(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findAll(holder1.getEntityDefinition().getId(),
                                                                        Pageable.ofSize(numberOfPeopleToCreate * 2),// make sure page size is larger than number of entities
                                                                        RawJson.class,
-                                                                       context1)))
+                                                                       context1))))
                     .expectNextMatches(rawJsons -> rawJsons.getTotalElements() == numberOfPeopleToCreate
                             && rawJsons.getContent().size() == numberOfPeopleToCreate)
                     .as("Verifying Tenant 1 has "+numberOfPeopleToCreate+" entities")
                     .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
                                                                        Pageable.ofSize(numberOfPeopleToCreate * 2), // make sure page size is larger than number of entities
                                                                        RawJson.class,
-                                                                       context2)))
+                                                                       context2))))
                     .expectNextMatches(rawJsons -> rawJsons.getTotalElements() == numberOfPeopleToCreate
                             && rawJsons.getContent().size() == numberOfPeopleToCreate)
                     .as("Verifying Tenant 2 has "+numberOfPeopleToCreate+" entities")
@@ -103,7 +103,7 @@ public class BulkUpdateTests extends KinoticTestBase {
     @Test
     public void bulkSaveObjectWithMultipleIds() throws Exception{
         EntityContext entityContext = new DefaultEntityContext(new DummyParticipant());
-        CompletableFuture<Pair<EntityDefinition, Boolean>> createStructure = testDataService.createCarEntityDefinitionIfNotExists("_bulkSaveMultipleIds");
+        CompletableFuture<Pair<EntityDefinition, Boolean>> createStructure = elevated(() -> testDataService.createCarEntityDefinitionIfNotExists("_bulkSaveMultipleIds"));
 
         StepVerifier.create(Mono.fromFuture(createStructure))
                     .expectNextMatches(pair -> pair.getLeft() != null && pair.getRight())
@@ -130,9 +130,9 @@ public class BulkUpdateTests extends KinoticTestBase {
         testHelper.bulkSaveCarsAsRawJson(cars, entityDefinition, entityContext).join();
 
         // Sync Index since bulk updates are not queryable until they are indexed
-        entitiesRepository.syncIndex(entityDefinition.getId(), entityContext).join();
+        elevated(() -> entitiesRepository.syncIndex(entityDefinition.getId(), entityContext)).join();
 
-        Page<RawJson> page = entitiesRepository.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext).join();
+        Page<RawJson> page = elevated(() -> entitiesRepository.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).join();
 
         Assertions.assertEquals(50, page.getTotalElements(), "Wrong number of entities");
     }
@@ -140,7 +140,7 @@ public class BulkUpdateTests extends KinoticTestBase {
     @Test
     public void bulkUpdateObjectWithMultipleIds() throws Exception{
         EntityContext entityContext = new DefaultEntityContext(new DummyParticipant());
-        CompletableFuture<Pair<EntityDefinition, Boolean>> createStructure = testDataService.createCarEntityDefinitionIfNotExists("_bulkUpdateMultipleIds");
+        CompletableFuture<Pair<EntityDefinition, Boolean>> createStructure = elevated(() -> testDataService.createCarEntityDefinitionIfNotExists("_bulkUpdateMultipleIds"));
 
         StepVerifier.create(Mono.fromFuture(createStructure))
                     .expectNextMatches(pair -> pair.getLeft() != null && pair.getRight())
@@ -167,9 +167,9 @@ public class BulkUpdateTests extends KinoticTestBase {
         testHelper.bulkUpdateCarsAsRawJson(cars, entityDefinition, entityContext).join();
 
         // Sync Index since bulk updates are not queryable until they are indexed
-        entitiesRepository.syncIndex(entityDefinition.getId(), entityContext).join();
+        elevated(() -> entitiesRepository.syncIndex(entityDefinition.getId(), entityContext)).join();
 
-        Page<RawJson> page = entitiesRepository.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext).join();
+        Page<RawJson> page = elevated(() -> entitiesRepository.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).join();
 
         Assertions.assertEquals(50, page.getTotalElements(), "Wrong number of entities");
     }

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/EntityCrudTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/EntityCrudTests.java
@@ -58,9 +58,9 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder);
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.deleteById(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.deleteById(holder.getEntityDefinition().getId(),
                                                                           holder.getFirstPerson().getId(),
-                                                                          new DefaultEntityContext(new DummyParticipant()))))
+                                                                          new DefaultEntityContext(new DummyParticipant())))))
                     .verifyComplete();
     }
 
@@ -72,21 +72,21 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder);
 
-        entitiesRepository.syncIndex(holder.getEntityDefinition().getId(), context).join();
+        elevated(() -> entitiesRepository.syncIndex(holder.getEntityDefinition().getId(), context)).join();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.count(holder.getEntityDefinition().getId(), context)))
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.count(holder.getEntityDefinition().getId(), context))))
                 .expectNext(20L)
                 .as("Verifying Tenant 1 has 20 entities")
                 .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.deleteByQuery(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.deleteByQuery(holder.getEntityDefinition().getId(),
                                                                              "lastName: A*",
-                                                                             context)))
+                                                                             context))))
                 .verifyComplete();
 
-        entitiesRepository.syncIndex(holder.getEntityDefinition().getId(), context).join();
+        elevated(() -> entitiesRepository.syncIndex(holder.getEntityDefinition().getId(), context)).join();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.count(holder.getEntityDefinition().getId(), context)))
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.count(holder.getEntityDefinition().getId(), context))))
                 .expectNext(18L)
                 .as("Verifying Tenant 1 has 18 entities after delete by query")
                 .verifyComplete();
@@ -100,10 +100,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder);
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findById(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findById(holder.getEntityDefinition().getId(),
                                                                         holder.getFirstPerson().getId(),
                                                                         RawJson.class,
-                                                                        new DefaultEntityContext(new DummyParticipant()))))
+                                                                        new DefaultEntityContext(new DummyParticipant())))))
                     .expectNextMatches(found -> {
                         boolean ret;
                         try {
@@ -140,10 +140,10 @@ public class EntityCrudTests extends KinoticTestBase {
             }
         }
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findByIds(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findByIds(holder.getEntityDefinition().getId(),
                                                                          ids,
                                                                          RawJson.class,
-                                                                         context)))
+                                                                         context))))
                 .expectNextMatches(responseList -> {
                     boolean ret = false;
                     try {
@@ -182,10 +182,10 @@ public class EntityCrudTests extends KinoticTestBase {
             }
         }
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findByIds(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findByIds(holder.getEntityDefinition().getId(),
                                                                          ids,
                                                                          RawJson.class,
-                                                                         context)))
+                                                                         context))))
                 .expectNextMatches(List::isEmpty)
                 .as("Verifying Tenant ids query to be empty as none of ids matches")
                 .verifyComplete();
@@ -205,15 +205,15 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder2);
 
-        entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1).join();
-        entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2).join();
+        elevated(() -> entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
+        elevated(() -> entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.count(holder1.getEntityDefinition().getId(), context1)))
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.count(holder1.getEntityDefinition().getId(), context1))))
                     .expectNext(10L)
                     .as("Verifying Tenant 1 has 10 entities")
                     .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.count(holder2.getEntityDefinition().getId(), context2)))
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.count(holder2.getEntityDefinition().getId(), context2))))
                     .expectNext(20L)
                     .as("Verifying Tenant 2 has 20 entities")
                     .verifyComplete();
@@ -233,20 +233,20 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder2);
 
-        entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1).join();
-        entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2).join();
+        elevated(() -> entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
+        elevated(() -> entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.countByQuery(holder1.getEntityDefinition().getId(), "lastName: Z*", context1)))
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.countByQuery(holder1.getEntityDefinition().getId(), "lastName: Z*", context1))))
                 .expectNext(2L)
                 .as("Verifying Tenant 1 has 2 entities by search")
                 .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.countByQuery(holder2.getEntityDefinition().getId(), "lastName: A*", context2)))
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.countByQuery(holder2.getEntityDefinition().getId(), "lastName: A*", context2))))
                 .expectNext(2L)
                 .as("Verifying Tenant 2 has 2 entities by search")
                 .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.countByQuery(holder2.getEntityDefinition().getId(), "lastName: a*", context2)))
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.countByQuery(holder2.getEntityDefinition().getId(), "lastName: a*", context2))))
                 .expectNext(0L)
                 .as("Verifying Tenant 0 has 2 entities by search")
                 .verifyComplete();
@@ -268,23 +268,23 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder2);
 
-        entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1).join();
-        entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2).join();
+        elevated(() -> entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
+        elevated(() -> entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
 
         // TODO: verify all data items as well, not just sizes
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findAll(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findAll(holder1.getEntityDefinition().getId(),
                                                                        Pageable.ofSize(20), // make sure page size is larger than number of entities
                                                                        RawJson.class,
-                                                                       context1)))
+                                                                       context1))))
                     .expectNextMatches(rawJsons -> rawJsons.getTotalElements() == 10
                             && rawJsons.getContent().size() == 10)
                     .as("Verifying Tenant 1 has 10 entities")
                     .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
                                                                        Pageable.ofSize(20), // make sure page size is larger than number of entities
                                                                        RawJson.class,
-                                                                       context2)))
+                                                                       context2))))
                     .expectNextMatches(rawJsons -> rawJsons.getTotalElements() == 20
                             && rawJsons.getContent().size() == 20)
                     .as("Verifying Tenant 2 has 20 entities")
@@ -306,8 +306,8 @@ public class EntityCrudTests extends KinoticTestBase {
         Assertions.assertNotNull(holder2);
 
         // Make sure all data is indexed
-        entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1).join();
-        entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2).join();
+        elevated(() -> entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
+        elevated(() -> entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
 
         Thread.sleep(10000); // TODO: why does this still fail without a sleep? Sync index should be ensuring data is indexed.
 
@@ -315,12 +315,12 @@ public class EntityCrudTests extends KinoticTestBase {
         Sort sort = Sort.by("firstName");
         AtomicReference<String> cursorRef = new AtomicReference<>();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findAll(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findAll(holder1.getEntityDefinition().getId(),
                                                                        Pageable.create("",
                                                                                     20,
                                                                                     Sort.by("firstName")),
                                                                        RawJson.class,
-                                                                       context1)))
+                                                                       context1))))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         if(page instanceof CursorPage){
@@ -336,10 +336,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(cursorRef.get(), "Cursor is null");
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findAll(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findAll(holder1.getEntityDefinition().getId(),
                                                                        Pageable.create(cursorRef.get(), 20, sort),
                                                                        RawJson.class,
-                                                                       context1)))
+                                                                       context1))))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         cursorRef.set(null);
@@ -356,10 +356,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(cursorRef.get(), "Cursor is null");
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findAll(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findAll(holder1.getEntityDefinition().getId(),
                                                                        Pageable.create(cursorRef.get(), 20, sort),
                                                                        RawJson.class,
-                                                                       context1)))
+                                                                       context1))))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         cursorRef.set(null);
@@ -378,10 +378,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNull(cursorRef.get(), "Cursor is not null");
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
                                                                        Pageable.create("", 10, sort),
                                                                        RawJson.class,
-                                                                       context2)))
+                                                                       context2))))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         if(page instanceof CursorPage){
@@ -397,10 +397,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(cursorRef.get(), "Cursor is null");
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
                                                                        Pageable.create(cursorRef.get(), 10, sort),
                                                                        RawJson.class,
-                                                                       context2)))
+                                                                       context2))))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         cursorRef.set(null);
@@ -417,10 +417,10 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(cursorRef.get(), "Cursor is null");
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
                                                                        Pageable.create(cursorRef.get(), 10, sort),
                                                                        RawJson.class,
-                                                                       context2)))
+                                                                       context2))))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         cursorRef.set(null);
@@ -438,10 +438,10 @@ public class EntityCrudTests extends KinoticTestBase {
         Assertions.assertNotNull(cursorRef.get(), "Cursor is null");
 
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findAll(holder2.getEntityDefinition().getId(),
                                                                        Pageable.create(cursorRef.get(), 10, sort),
                                                                        RawJson.class,
-                                                                       context2)))
+                                                                       context2))))
                     .expectNextMatches(page -> {
                         String cursor = null;
                         cursorRef.set(null);
@@ -470,15 +470,15 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder2);
 
-        entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1).join();
-        entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2).join();
+        elevated(() -> entitiesRepository.syncIndex(holder1.getEntityDefinition().getId(), context1)).join();
+        elevated(() -> entitiesRepository.syncIndex(holder2.getEntityDefinition().getId(), context2)).join();
 
         // TODO: verify all data items as well, not just sizes
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.search(holder1.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.search(holder1.getEntityDefinition().getId(),
                                                                       "lastName: Z*",
                                                                       Pageable.ofSize(20), // make sure page size is larger than number of entities
                                                                       RawJson.class,
-                                                                      context1)))
+                                                                      context1))))
                     .expectNextMatches(rawJsons -> {
                         boolean b = rawJsons.getTotalElements() == 2
                                 && rawJsons.getContent().size() == 2;
@@ -490,11 +490,11 @@ public class EntityCrudTests extends KinoticTestBase {
                     .as("Verifying search for Tenant 1 has 2 entities")
                     .verifyComplete();
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.search(holder2.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.search(holder2.getEntityDefinition().getId(),
                                                                       "lastName: Z*",
                                                                       Pageable.ofSize(20), // make sure page size is larger than number of entities
                                                                       RawJson.class,
-                                                                      context2)))
+                                                                      context2))))
                     .expectNextMatches(rawJsons -> {
                         boolean b = rawJsons.getTotalElements() == 2
                                 && rawJsons.getContent().size() == 2;
@@ -522,13 +522,13 @@ public class EntityCrudTests extends KinoticTestBase {
 
         contextMap.forEach((context, holder) -> {
 
-            entitiesRepository.syncIndex(holder.getEntityDefinition().getId(), context).join();
+            elevated(() -> entitiesRepository.syncIndex(holder.getEntityDefinition().getId(), context)).join();
 
-            StepVerifier.create(Mono.fromFuture(entitiesRepository.search(holder.getEntityDefinition().getId(),
+            StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.search(holder.getEntityDefinition().getId(),
                                                                           "lastName: *",
                                                                           Pageable.ofSize(20), // make sure page size is larger than number of entities
                                                                           RawJson.class,
-                                                                          context)))
+                                                                          context))))
                     .expectNextMatches(rawJsons -> {
                         long expectedCount = holder.getPersons().size();
                         long queriedCount = rawJsons.getTotalElements();
@@ -549,17 +549,17 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertNotNull(holder);
 
-        StepVerifier.create(Mono.fromFuture(entitiesRepository.findById(holder.getEntityDefinition().getId(),
+        StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.findById(holder.getEntityDefinition().getId(),
                                                                         "missing",
                                                                         RawJson.class,
-                                                                        new DefaultEntityContext(new DummyParticipant()))))
+                                                                        new DefaultEntityContext(new DummyParticipant())))))
                     .verifyComplete();
     }
 
     @Test
     public void testPartialUpdate() throws Exception {
         EntityContext entityContext = new DefaultEntityContext(new DummyParticipant());
-        CompletableFuture<Pair<EntityDefinition, Boolean>> createStructure = testDataService.createCarEntityDefinitionIfNotExists("_partialUpdate");
+        CompletableFuture<Pair<EntityDefinition, Boolean>> createStructure = elevated(() -> testDataService.createCarEntityDefinitionIfNotExists("_partialUpdate"));
 
         StepVerifier.create(Mono.fromFuture(createStructure))
                     .expectNextMatches(pair -> {
@@ -583,9 +583,9 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertEquals(car.getId(), result.getId(), "Car id does not match");
 
-        entitiesRepository.syncIndex(entityDefinition.getId(), entityContext).join();
+        elevated(() -> entitiesRepository.syncIndex(entityDefinition.getId(), entityContext)).join();
 
-        Page<RawJson> page = entitiesRepository.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext).join();
+        Page<RawJson> page = elevated(() -> entitiesRepository.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).join();
 
         Assertions.assertEquals(1, page.getTotalElements(), "Wrong number of entities");
 
@@ -605,9 +605,9 @@ public class EntityCrudTests extends KinoticTestBase {
 
         Assertions.assertEquals(car.getId(), result2.getId(), "Car id does not match after partial update");
 
-        entitiesRepository.syncIndex(entityDefinition.getId(), entityContext).join();
+        elevated(() -> entitiesRepository.syncIndex(entityDefinition.getId(), entityContext)).join();
 
-        Page<RawJson> page2 = entitiesRepository.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext).join();
+        Page<RawJson> page2 = elevated(() -> entitiesRepository.findAll(entityDefinition.getId(), Pageable.ofSize(10), RawJson.class, entityContext)).join();
 
         Assertions.assertEquals(1, page2.getTotalElements(), "Wrong number of entities after partial update");
 

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/EntityDefinitionCrudTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/entity/EntityDefinitionCrudTests.java
@@ -37,12 +37,13 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 
 		EntityDefinition entityDefinition = new EntityDefinition();
 		entityDefinition.setName("PersonWat")
+						.setOrganizationId(TEST_ORG_ID)
 						.setApplicationId("org.kinotic.sample")
 						.setProjectId("org.kinotic.sample_default")
 						.setDescription("Defines a Person")
 						.setSchema(testDataService.createPersonSchema(MultiTenancyType.NONE, false));
 
-		CompletableFuture<EntityDefinition> future = entityDefinitionService.create(entityDefinition);
+		CompletableFuture<EntityDefinition> future = elevated(() -> entityDefinitionService.create(entityDefinition));
 
 		StepVerifier.create(Mono.fromFuture(future))
 					.expectNextMatches(savedStructure -> {
@@ -57,21 +58,15 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 					.expectComplete()
 					.verify();
 
-		CompletableFuture<Void> pubFuture = entityDefinitionService.publish(future.get().getId());
-
-		StepVerifier.create(Mono.fromFuture(pubFuture))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> entityDefinitionService.publish(future.join().getId()))))
 					.expectComplete()
 					.verify();
 
-		CompletableFuture<Void> unPubFuture = entityDefinitionService.unPublish(future.get().getId());
-
-		StepVerifier.create(Mono.fromFuture(unPubFuture))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> entityDefinitionService.unPublish(future.join().getId()))))
 					.expectComplete()
 					.verify();
 
-		CompletableFuture<Void> delFuture = entityDefinitionService.deleteById(future.get().getId());
-
-		StepVerifier.create(Mono.fromFuture(delFuture))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> entityDefinitionService.deleteById(future.join().getId()))))
 					.expectComplete()
 					.verify();
 	}
@@ -80,12 +75,13 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 	public void tryOperationsOnPublishedStructure() throws Exception{
 		EntityDefinition entityDefinition = new EntityDefinition();
 		entityDefinition.setName("PersonBum")
+						.setOrganizationId(TEST_ORG_ID)
 						.setApplicationId("org.kinotic.sample")
 						.setProjectId("org.kinotic.sample_default")
 						.setDescription("Defines a Person")
 						.setSchema(testDataService.createPersonSchema(MultiTenancyType.NONE, false));
 
-		CompletableFuture<EntityDefinition> future = entityDefinitionService.create(entityDefinition);
+		CompletableFuture<EntityDefinition> future = elevated(() -> entityDefinitionService.create(entityDefinition));
 
 		StepVerifier.create(Mono.fromFuture(future))
 					.expectNextMatches(savedStructure -> {
@@ -100,15 +96,11 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 					.expectComplete()
 					.verify();
 
-		CompletableFuture<Void> pubFuture = entityDefinitionService.publish(future.get().getId());
-
-		StepVerifier.create(Mono.fromFuture(pubFuture))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> entityDefinitionService.publish(future.join().getId()))))
 					.expectComplete()
 					.verify();
 
-		CompletableFuture<Void> delFuture = entityDefinitionService.deleteById(future.get().getId());
-
-		StepVerifier.create(Mono.fromFuture(delFuture))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> entityDefinitionService.deleteById(future.join().getId()))))
 					.expectError(IllegalStateException.class)
 					.verify();
 
@@ -119,14 +111,13 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 	public void createStructureInvalidField(){
 		EntityDefinition entityDefinition = new EntityDefinition();
 		entityDefinition.setName("PersonStupid")
+						.setOrganizationId(TEST_ORG_ID)
 						.setApplicationId("org.kinotic.sample")
 						.setProjectId("org.kinotic.sample_default")
 						.setDescription("Defines a Person")
 						.setSchema(testDataService.createPersonSchema(MultiTenancyType.NONE, true));
 
-		CompletableFuture<EntityDefinition> future = entityDefinitionService.create(entityDefinition);
-
-		StepVerifier.create(Mono.fromFuture(future))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> entityDefinitionService.create(entityDefinition))))
 					.expectError(IllegalArgumentException.class)
 					.verify();
 	}
@@ -135,12 +126,13 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 	public void createStructureWithSameNameError() throws Exception {
 		EntityDefinition entityDefinition = new EntityDefinition();
 		entityDefinition.setName("PersonHomer")
+						.setOrganizationId(TEST_ORG_ID)
 						.setApplicationId("org.kinotic.sample")
 						.setProjectId("org.kinotic.sample_default")
 						.setDescription("Defines a Person")
 						.setSchema(testDataService.createPersonSchema(MultiTenancyType.NONE, false));
 
-		CompletableFuture<EntityDefinition> future = entityDefinitionService.create(entityDefinition);
+		CompletableFuture<EntityDefinition> future = elevated(() -> entityDefinitionService.create(entityDefinition));
 
 		StepVerifier.create(Mono.fromFuture(future))
 					.expectNextMatches(savedStructure -> {
@@ -155,15 +147,11 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 					.expectComplete()
 					.verify();
 
-		CompletableFuture<EntityDefinition> future2 = entityDefinitionService.create(entityDefinition);
-
-		StepVerifier.create(Mono.fromFuture(future2))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> entityDefinitionService.create(entityDefinition))))
 					.expectError(IllegalArgumentException.class)
 					.verify();
 
-		CompletableFuture<Void> delFuture = entityDefinitionService.deleteById(future.get().getId());
-
-		StepVerifier.create(Mono.fromFuture(delFuture))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> entityDefinitionService.deleteById(future.join().getId()))))
 					.expectComplete()
 					.verify();
 	}
@@ -172,12 +160,13 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 	public void tryOperationOnNotPublishedStructure() throws Exception {
 		EntityDefinition entityDefinition = new EntityDefinition();
 		entityDefinition.setName("PersonStoned")
+						.setOrganizationId(TEST_ORG_ID)
 						.setApplicationId("org.kinotic.sample")
 						.setProjectId("org.kinotic.sample_default")
 						.setDescription("Defines a Person")
 						.setSchema(testDataService.createPersonSchema(MultiTenancyType.NONE, false));
 
-		CompletableFuture<EntityDefinition> future = entityDefinitionService.create(entityDefinition);
+		CompletableFuture<EntityDefinition> future = elevated(() -> entityDefinitionService.create(entityDefinition));
 
 		StepVerifier.create(Mono.fromFuture(future))
 					.expectNextMatches(savedStructure -> {
@@ -192,15 +181,11 @@ public class EntityDefinitionCrudTests extends KinoticTestBase {
 					.expectComplete()
 					.verify();
 
-		CompletableFuture<Long> countFuture = entitiesRepository.count(future.get().getId(), new DefaultEntityContext(new DummyParticipant()));
-
-		StepVerifier.create(Mono.fromFuture(countFuture))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> entitiesRepository.count(future.join().getId(), new DefaultEntityContext(new DummyParticipant())))))
 					.expectError(IllegalArgumentException.class)
 					.verify();
 
-		CompletableFuture<Void> delFuture = entityDefinitionService.deleteById(future.get().getId());
-
-		StepVerifier.create(Mono.fromFuture(delFuture))
+		StepVerifier.create(Mono.fromFuture(elevated(() -> entityDefinitionService.deleteById(future.join().getId()))))
 					.expectComplete()
 					.verify();
 	}

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/support/TestHelper.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/support/TestHelper.java
@@ -1,5 +1,7 @@
 package org.kinotic.test.tests.core.support;
 
+import io.vertx.core.Vertx;
+import org.kinotic.core.api.security.SecurityContext;
 import org.kinotic.persistence.api.model.EntityContext;
 import org.kinotic.persistence.api.model.EntityDefinition;
 import org.kinotic.persistence.api.services.EntitiesRepository;
@@ -20,6 +22,7 @@ import tools.jackson.databind.util.TokenBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 @Component
 public class TestHelper {
@@ -32,6 +35,30 @@ public class TestHelper {
 
     @Autowired
     private EntitiesRepository entitiesRepository;
+
+    @Autowired
+    private Vertx vertx;
+
+    @Autowired
+    private SecurityContext securityContext;
+
+    /**
+     * Runs the supplier on a Vert.x context with elevated access set so that
+     * org-scope enforcement on {@code OrganizationScoped} entities is skipped.
+     */
+    public <T> CompletableFuture<T> elevated(Supplier<CompletableFuture<T>> supplier) {
+        CompletableFuture<T> result = new CompletableFuture<>();
+        vertx.getOrCreateContext().runOnContext(v ->
+                securityContext.withElevatedAccess(supplier)
+                               .whenComplete((value, error) -> {
+                                   if (error != null) {
+                                       result.completeExceptionally(error);
+                                   } else {
+                                       result.complete(value);
+                                   }
+                               }));
+        return result;
+    }
 
 
     public StructureAndPersonHolder createAndVerify(){
@@ -72,7 +99,7 @@ public class TestHelper {
         } catch (JacksonException e) {
             return CompletableFuture.failedFuture(e);
         }
-        return entitiesRepository.bulkUpdate(entityDefinition.getId(), tokenBuffer, entityContext);
+        return elevated(() -> entitiesRepository.bulkUpdate(entityDefinition.getId(), tokenBuffer, entityContext));
     }
 
     public CompletableFuture<Void> bulkSaveCarsAsRawJson(List<Car> cars, EntityDefinition entityDefinition, EntityContext entityContext){
@@ -82,7 +109,7 @@ public class TestHelper {
         } catch (JacksonException e) {
             return CompletableFuture.failedFuture(e);
         }
-        return entitiesRepository.bulkSave(entityDefinition.getId(), tokenBuffer, entityContext);
+        return elevated(() -> entitiesRepository.bulkSave(entityDefinition.getId(), tokenBuffer, entityContext));
     }
 
     public CompletableFuture<Car> saveCarAsRawJson(Car car, EntityDefinition entityDefinition, EntityContext entityContext){
@@ -92,7 +119,7 @@ public class TestHelper {
         } catch (JacksonException e) {
             return CompletableFuture.failedFuture(e);
         }
-        return entitiesRepository.save(entityDefinition.getId(), tokenBuffer, entityContext)
+        return elevated(() -> entitiesRepository.save(entityDefinition.getId(), tokenBuffer, entityContext))
                                  .thenApply(saved -> {
                                   try (JsonParser parser = saved.asParser()) {
                                       return objectMapper.readValue(parser, Car.class);
@@ -111,7 +138,7 @@ public class TestHelper {
             return CompletableFuture.failedFuture(e);
         }
 
-        return entitiesRepository.update(entityDefinition.getId(), tokenBuffer, entityContext)
+        return elevated(() -> entitiesRepository.update(entityDefinition.getId(), tokenBuffer, entityContext))
                                  .thenApply(saved -> {
                                   try (JsonParser parser = saved.asParser()) {
                                       return objectMapper.readValue(parser, Car.class);
@@ -133,7 +160,7 @@ public class TestHelper {
                                                                            boolean randomPeople,
                                                                            EntityContext entityContext,
                                                                            String structureNameSuffix){
-        return Mono.fromFuture(() -> testDataService
+        return Mono.fromFuture(() -> elevated(() -> testDataService
                 .createPersonEntityDefinitionIfNotExists(structureNameSuffix)
                 .thenCompose(pair -> createTestPeopleWithCorrectMethod(numberOfPeopleToCreate, randomPeople)
                                              .thenCompose(people -> {
@@ -167,14 +194,14 @@ public class TestHelper {
                                                                              }
                                                                              return holder;
                                                                          });
-                                             })));
+                                             }))));
     }
 
     public Mono<StructureAndPersonHolder> createPersonStructureAndEntitiesBulk(int numberOfPeopleToCreate,
                                                                                boolean randomPeople,
                                                                                EntityContext entityContext,
                                                                                String structureNameSuffix){
-        return Mono.fromFuture(() -> testDataService
+        return Mono.fromFuture(() -> elevated(() -> testDataService
                 .createPersonEntityDefinitionIfNotExists(structureNameSuffix)
                 .thenCompose(pair -> createTestPeopleWithCorrectMethod(numberOfPeopleToCreate, randomPeople)
                                              .thenCompose(people -> {
@@ -193,7 +220,7 @@ public class TestHelper {
                                                                  .completedFuture(new StructureAndPersonHolder(
                                                                          entityDefinition,
                                                                          people)));
-                                             })));
+                                             }))));
     }
 
 


### PR DESCRIPTION
## Summary
This PR adds security context elevation to test code to ensure that organization-scoped CRUD operations work correctly when tests don't have explicit organization authentication. All repository and service calls in tests are now wrapped with `elevated()` to bypass org-scope enforcement.

## Key Changes

- **Added `elevated()` helper method** to `KinoticTestBase` and `TestHelper` that wraps async operations with `SecurityContext.withElevatedAccess()` on a Vert.x context, allowing tests to bypass organization-scope enforcement on `OrganizationScoped` entities

- **Updated EntityCrudTests** to wrap all `entitiesRepository` method calls with `elevated()`, including:
  - `deleteById()`, `deleteByQuery()`, `syncIndex()`, `count()`, `countByQuery()`
  - `findById()`, `findByIds()`, `findAll()`, `search()`
  - All cursor-based pagination calls

- **Updated EntityDefinitionCrudTests** to:
  - Add `TEST_ORG_ID` to all `EntityDefinition` objects via `setOrganizationId()`
  - Wrap `entityDefinitionService` and `entitiesRepository` calls with `elevated()`
  - Simplify code by inlining `elevated()` calls directly in `StepVerifier.create()` and using `future.join()` instead of intermediate variables

- **Updated BulkUpdateTests** to wrap repository calls with `elevated()`

- **Updated ApplicationTests** to:
  - Add `TEST_ORG_ID` to `Application` objects
  - Wrap `applicationService` calls with `elevated()`

- **Updated TestHelper** to wrap repository calls in helper methods with `elevated()`

- **Added `TEST_ORG_ID` constant** to `KinoticTestBase` for consistent organization scoping across all tests

- **Updated build.gradle** to explicitly depend on `io.vertx:vertx-core` since `SecurityContext` and `Vertx` are needed by test code

## Implementation Details

The `elevated()` method creates a new `CompletableFuture` and executes the supplier on a Vert.x context with elevated access, properly handling both success and error cases. This ensures all scoped CRUD operations execute with the necessary permissions without requiring test authentication.

https://claude.ai/code/session_01HrAFXsbSXpoEM3FbGR6Br9