### PR TITLE
Add organization scoping to user authentication and entities

### DIFF
--- a/kinotic-frontend/src/components/ApplicationSidebar.vue
+++ b/kinotic-frontend/src/components/ApplicationSidebar.vue
@@ -7,6 +7,7 @@ import { useToast } from 'primevue/usetoast'
 import { createDebug } from '@/util/debug'
 import type {Application} from "@kinotic-ai/os-api";
 import {Kinotic} from "@kinotic-ai/core";
+import { USER_STATE } from '@/states/IUserState'
 import { isDark as darkMode } from '@/composables/useTheme'
 
 const debug = createDebug('application-sidebar');
@@ -64,6 +65,7 @@ async function handleSubmit(): Promise<void> {
   try {
     const applicationData: Application = {
       id: sanitizeId(form.name),
+      organizationId: USER_STATE.getOrganizationId(),
       description: form.description,
       updated: null
     }

--- a/kinotic-frontend/src/components/NewProjectSidebar.vue
+++ b/kinotic-frontend/src/components/NewProjectSidebar.vue
@@ -3,6 +3,7 @@ import { Component, Vue, Prop } from 'vue-facing-decorator';
 import { Kinotic } from '@kinotic-ai/core';
 import { Project, ProjectType } from '@kinotic-ai/os-api';
 import { APPLICATION_STATE } from '@/states/IApplicationState';
+import { USER_STATE } from '@/states/IUserState';
 
 import InputText from 'primevue/inputtext';
 import Textarea from 'primevue/textarea';
@@ -54,6 +55,7 @@ export default class NewProjectSidebar extends Vue {
             if (!app) throw new Error('No current application selected');
 
             const project = new Project(null, app.id, this.form.name, this.form.description);
+            project.organizationId = USER_STATE.getOrganizationId();
             project.sourceOfTruth = ProjectType.TYPESCRIPT;
 
             const createdProject = await Kinotic.projects.create(project);

--- a/kinotic-frontend/src/pages/ApplicationSettings.vue
+++ b/kinotic-frontend/src/pages/ApplicationSettings.vue
@@ -147,6 +147,7 @@
 import { ref, defineProps, onMounted, watch, computed } from 'vue'
 import { InputText, Textarea, Button, Tabs, TabList, Tab, TabPanels, TabPanel, Dialog, IconField, InputIcon } from 'primevue'
 import { APPLICATION_STATE } from '@/states/IApplicationState'
+import { USER_STATE } from '@/states/IUserState'
 import { Kinotic } from '@kinotic-ai/core'
 import { useToast } from 'primevue/usetoast'
 import { DataInsightsWidgetEntityRepository } from '@/services/DataInsightsWidgetEntityRepository'
@@ -205,6 +206,7 @@ const saveSettings = async () => {
   try {
     const updatedApplication = {
       ...APPLICATION_STATE.currentApplication,
+      organizationId: USER_STATE.getOrganizationId(),
       description: appDescription.value
     }
 

--- a/kinotic-frontend/src/states/IUserState.ts
+++ b/kinotic-frontend/src/states/IUserState.ts
@@ -7,24 +7,19 @@ import { createConnectionInfo } from '../util/helpers'
 
 export interface IUserState {
     connectedInfo: ConnectedInfo | null
+    authScopeType: string | null
+    authScopeId: string | null
 
     isAccessDenied(): boolean
     isAuthenticated(): boolean
 
     /**
-     * Returns the organization id of the currently authenticated participant.
-     * Throws if no participant is connected or the participant is not authenticated
-     * to an organization scope. Use this to populate `organizationId` on org-scoped
-     * entities before save — the backend rejects entities without it.
+     * Returns the organization id of the currently authenticated participant. For now this
+     * is just the JWT's scopeId — true when the participant logged in at the ORGANIZATION
+     * scope. SYSTEM- and APPLICATION-scoped logins still need a separate resolution path
+     * (TODO).
      */
     getOrganizationId(): string
-
-    /**
-     * Authenticates a local (email/password) user via STOMP CONNECT. The credentials are
-     * sent on the CONNECT frame; no token is minted, no token is stored — the gateway's
-     * SessionManager owns the session for the WebSocket lifetime.
-     */
-    authenticate(login: string, passcode: string): Promise<void>
 
     /**
      * Authenticates with a Kinotic-minted JWT (the short-lived ticket delivered as a URL
@@ -39,33 +34,10 @@ export interface IUserState {
 
 export class UserState implements IUserState {
     public connectedInfo: ConnectedInfo | null = null
+    public authScopeType: string | null = null
+    public authScopeId: string | null = null
     private authenticated: boolean = false
     private accessDenied: boolean = false
-
-    public async authenticate(login: string, passcode: string): Promise<void> {
-        try {
-            await Kinotic.disconnect()
-        } catch (error) {
-            debug('No existing connection to disconnect')
-        }
-
-        const connectionInfo: ConnectionInfo = createConnectionInfo()
-        connectionInfo.connectHeaders = {
-            login,
-            passcode,
-            authScopeType: 'ORGANIZATION', //FIXME: remove hard coded org
-            authScopeId: 'kinotic-test'
-        }
-
-        try {
-            this.connectedInfo = await Kinotic.connect(connectionInfo)
-            this.authenticated = true
-            this.accessDenied = false
-        } catch (reason: any) {
-            this.accessDenied = true
-            throw new Error(reason ? String(reason) : 'Credentials invalid')
-        }
-    }
 
     public async loginWithToken(token: string): Promise<void> {
         try {
@@ -88,6 +60,8 @@ export class UserState implements IUserState {
 
         try {
             this.connectedInfo = await Kinotic.connect(connectionInfo)
+            this.authScopeType = claims.scopeType
+            this.authScopeId = claims.scopeId
             this.authenticated = true
             this.accessDenied = false
         } catch (reason: any) {
@@ -105,6 +79,8 @@ export class UserState implements IUserState {
             }
         }
         this.connectedInfo = null
+        this.authScopeType = null
+        this.authScopeId = null
         this.authenticated = false
         this.accessDenied = false
     }
@@ -118,11 +94,10 @@ export class UserState implements IUserState {
     }
 
     public getOrganizationId(): string {
-        const orgId = this.connectedInfo?.participant?.authScopeId
-        if (!orgId) {
-            throw new Error('No organization id available — user is not authenticated to an organization scope')
+        if (!this.authScopeId) {
+            throw new Error('No organization id available — user is not authenticated')
         }
-        return orgId
+        return this.authScopeId
     }
 }
 

--- a/kinotic-frontend/src/states/IUserState.ts
+++ b/kinotic-frontend/src/states/IUserState.ts
@@ -14,10 +14,9 @@ export interface IUserState {
     isAuthenticated(): boolean
 
     /**
-     * Returns the organization id of the currently authenticated participant. For now this
-     * is just the JWT's scopeId — true when the participant logged in at the ORGANIZATION
-     * scope. SYSTEM- and APPLICATION-scoped logins still need a separate resolution path
-     * (TODO).
+     * Returns the organization id of the currently authenticated participant. Only valid for
+     * ORGANIZATION-scoped logins, where the JWT's scopeId IS the org id; throws for SYSTEM-
+     * or APPLICATION-scoped participants (those need a separate resolution path — TODO).
      */
     getOrganizationId(): string
 
@@ -96,6 +95,9 @@ export class UserState implements IUserState {
     public getOrganizationId(): string {
         if (!this.authScopeId) {
             throw new Error('No organization id available — user is not authenticated')
+        }
+        if (this.authScopeType !== 'ORGANIZATION') {
+            throw new Error(`Cannot resolve organization id: participant is ${this.authScopeType}-scoped, expected ORGANIZATION`)
         }
         return this.authScopeId
     }

--- a/kinotic-frontend/src/states/IUserState.ts
+++ b/kinotic-frontend/src/states/IUserState.ts
@@ -12,6 +12,14 @@ export interface IUserState {
     isAuthenticated(): boolean
 
     /**
+     * Returns the organization id of the currently authenticated participant.
+     * Throws if no participant is connected or the participant is not authenticated
+     * to an organization scope. Use this to populate `organizationId` on org-scoped
+     * entities before save — the backend rejects entities without it.
+     */
+    getOrganizationId(): string
+
+    /**
      * Authenticates a local (email/password) user via STOMP CONNECT. The credentials are
      * sent on the CONNECT frame; no token is minted, no token is stored — the gateway's
      * SessionManager owns the session for the WebSocket lifetime.
@@ -107,6 +115,14 @@ export class UserState implements IUserState {
 
     public isAuthenticated(): boolean {
         return this.authenticated && this.connectedInfo !== null
+    }
+
+    public getOrganizationId(): string {
+        const orgId = this.connectedInfo?.participant?.authScopeId
+        if (!orgId) {
+            throw new Error('No organization id available — user is not authenticated to an organization scope')
+        }
+        return orgId
     }
 }
 

--- a/kinotic-js/workspace/packages/os-api/src/api/model/Application.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/model/Application.ts
@@ -2,6 +2,14 @@ import type { Identifiable } from '@kinotic-ai/core'
 
 export class Application implements Identifiable<string> {
     public id: string
+
+    /**
+     * The id of the organization that owns this application.
+     * Must be set by the caller before save — backend org enforcement rejects entities
+     * with a missing or mismatched organizationId.
+     */
+    public organizationId!: string
+
     public description: string
     public updated: number | null = null
 

--- a/kinotic-js/workspace/packages/os-api/src/api/model/Project.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/model/Project.ts
@@ -9,6 +9,13 @@ export class Project implements Identifiable<string> {
     public id: string | null = null
 
     /**
+     * The id of the organization that owns this project.
+     * Must be set by the caller before save — backend org enforcement rejects entities
+     * with a missing or mismatched organizationId.
+     */
+    public organizationId!: string
+
+    /**
      * The id of the application that this project belongs to.
      * All application ids are unique throughout the entire system.
      */


### PR DESCRIPTION
## Summary
This PR refactors user authentication to track organization scope information and ensures all organization-owned entities (Applications and Projects) are properly scoped to their owning organization before persistence.

## Key Changes

- **User State Enhancement**: 
  - Removed the `authenticate(login, passcode)` method that used hardcoded organization credentials
  - Added `authScopeType` and `authScopeId` properties to track the authenticated user's scope
  - Introduced `getOrganizationId()` method to safely retrieve the organization ID for ORGANIZATION-scoped users, with validation and error handling for other scope types
  - Updated `loginWithToken()` to extract and store scope information from JWT claims
  - Updated `logout()` to clear scope information

- **Entity Model Updates**:
  - Added `organizationId` field to `Application` model with documentation requiring callers to set it before save
  - Added `organizationId` field to `Project` model with the same requirement

- **Component Updates**:
  - `ApplicationSidebar.vue`: Now sets `organizationId` when creating new applications using `USER_STATE.getOrganizationId()`
  - `NewProjectSidebar.vue`: Now sets `organizationId` when creating new projects using `USER_STATE.getOrganizationId()`
  - `ApplicationSettings.vue`: Now includes `organizationId` when updating application settings using `USER_STATE.getOrganizationId()`

## Implementation Details

The `getOrganizationId()` method includes validation to ensure:
1. The user is authenticated (authScopeId is set)
2. The user's scope type is ORGANIZATION (not SYSTEM or APPLICATION)
3. Throws descriptive errors for invalid states, with TODOs noting that SYSTEM and APPLICATION-scoped participants need separate resolution paths

All entity creation and updates now consistently enforce organization ownership through the organization ID field.

https://claude.ai/code/session_01Pq6TFx4tW8ihQBob3GDbmu