### PR TITLE
Add organization ID to entity definitions and repositories

### DIFF
--- a/kinotic-frontend/.config/kinotic.config.ts
+++ b/kinotic-frontend/.config/kinotic.config.ts
@@ -1,9 +1,7 @@
+import type { KinoticProjectConfig } from '@kinotic-ai/os-api'
 
-
-import type { TypescriptProjectConfig } from '@kinotic-ai/persistence'
-
-const config: TypescriptProjectConfig = {
-  mdl: "ts",
+const config: KinoticProjectConfig = {
+  organization: "kinotic",
   application: "structures__system",
   entitiesPaths: [
     "src/domain"

--- a/kinotic-frontend/src/pages/NewStructure.vue
+++ b/kinotic-frontend/src/pages/NewStructure.vue
@@ -9,6 +9,7 @@ import Button from "primevue/button"
 import InputText from "primevue/inputtext"
 import StructureNode from "@/components/structures/flow-components/StructureNode.vue"
 import { useStructureStore } from "@/stores/editor"
+import { USER_STATE } from "@/states/IUserState"
 import "@vue-flow/core/dist/style.css"
 import "@vue-flow/core/dist/theme-default.css"
 import "@vue-flow/minimap/dist/style.css"
@@ -59,7 +60,7 @@ export default class NewStructure extends Vue {
 
   beforeMount(): void {
     // Initialize structure once when modal opens
-    this.structureStore.initNewStructure("app-123", "proj-456")
+    this.structureStore.initNewStructure(USER_STATE.getOrganizationId(), "app-123", "proj-456")
   }
 
   handleMouseEnter() {

--- a/kinotic-frontend/src/services/generated/BaseDashboardEntityRepository.ts
+++ b/kinotic-frontend/src/services/generated/BaseDashboardEntityRepository.ts
@@ -11,7 +11,7 @@ export class BaseDashboardEntityRepository extends EntityRepository<Dashboard> {
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('structures__system', 'Dashboard', entitiesRepository)
+    super('kinotic', 'structures__system', 'Dashboard', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-frontend/src/services/generated/BaseDashboardWidgetEntityRepository.ts
+++ b/kinotic-frontend/src/services/generated/BaseDashboardWidgetEntityRepository.ts
@@ -11,7 +11,7 @@ export class BaseDashboardWidgetEntityRepository extends EntityRepository<Dashbo
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('structures__system', 'DashboardWidget', entitiesRepository)
+    super('kinotic', 'structures__system', 'DashboardWidget', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-frontend/src/services/generated/BaseDataInsightsWidgetEntityRepository.ts
+++ b/kinotic-frontend/src/services/generated/BaseDataInsightsWidgetEntityRepository.ts
@@ -11,7 +11,7 @@ export class BaseDataInsightsWidgetEntityRepository extends EntityRepository<Dat
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('structures__system', 'DataInsightsWidget', entitiesRepository)
+    super('kinotic', 'structures__system', 'DataInsightsWidget', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-frontend/src/stores/editor.ts
+++ b/kinotic-frontend/src/stores/editor.ts
@@ -28,7 +28,7 @@ export interface IStructureStore {
     nodes: Node[];
     edges: Edge[]
 
-    initNewStructure(applicationId: string, projectId: string): void
+    initNewStructure(organizationId: string, applicationId: string, projectId: string): void
     addProperty(parentId: string, propertyName: string, typeCode: string, decorators?: C3Decorator[]): void
     renameProperty(parentId: string, oldName: string, newName: string): void
     updatePropertyType(parentId: string, propertyName: string, typeCode: string): void
@@ -73,14 +73,14 @@ class StructureStore implements IStructureStore {
         this.edgesRef.value = value
     }
 
-    initNewStructure(applicationId: string, projectId: string) {
+    initNewStructure(organizationId: string, applicationId: string, projectId: string) {
         const rootType = new ObjectC3Type('NewStructure123', 'default.namespace')
         rootType.addDecorator({
             type: 'Entity',
             multiTenancyType: 'NONE',
             entityType: 'TABLE'
         } as C3Decorator)
-        this.structure = new EntityDefinition(applicationId, projectId, rootType.name, rootType)
+        this.structure = new EntityDefinition(organizationId, applicationId, projectId, rootType.name, rootType)
 
         this.generateGraph()
     }


### PR DESCRIPTION
## Summary
This PR updates the codebase to include organization ID as a required parameter throughout the entity management layer. This change reflects a shift from application-level to organization-level scoping for entities.

## Key Changes
- **Config Update**: Migrated `kinotic.config.ts` from `TypescriptProjectConfig` to `KinoticProjectConfig`, replacing `mdl: "ts"` with `organization: "kinotic"`
- **Structure Store**: Updated `initNewStructure()` method signature to accept `organizationId` as the first parameter, and pass it to `EntityDefinition` constructor
- **NewStructure Component**: Modified to retrieve organization ID from `USER_STATE` and pass it when initializing new structures
- **Entity Repositories**: Updated all generated repository constructors (`BaseDashboardEntityRepository`, `BaseDashboardWidgetEntityRepository`, `BaseDataInsightsWidgetEntityRepository`) to pass organization ID (`'kinotic'`) as the first argument to parent `EntityRepository` constructor

## Implementation Details
- Organization ID is now a required first parameter in the entity definition hierarchy
- The organization ID is sourced from user state in the UI layer, ensuring consistency with the current user's organization context
- All repository classes follow the same pattern of passing organization ID before application/entity identifiers

https://claude.ai/code/session_01M5H9DRay9rpuey3uJ7gAQ1