### PR TITLE
Use kinotic-test as entity organizationId in load-generator

### DIFF
--- a/kinotic-js/load-generator/.config/kinotic.config.ts
+++ b/kinotic-js/load-generator/.config/kinotic.config.ts
@@ -1,7 +1,7 @@
 import type { KinoticProjectConfig } from '@kinotic-ai/os-api'
 
 const config: KinoticProjectConfig = {
-  organization: "kinotic",
+  organization: "kinotic-test",
   application: "load-testing",
   entitiesPaths: [
     {

--- a/kinotic-js/load-generator/src/repository/ecommerce/generated/BaseCustomerRepository.ts
+++ b/kinotic-js/load-generator/src/repository/ecommerce/generated/BaseCustomerRepository.ts
@@ -11,7 +11,7 @@ export class BaseCustomerRepository extends EntityRepository<Customer> {
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('kinotic', 'ecommerce', 'Customer', entitiesRepository)
+    super('kinotic-test', 'ecommerce', 'Customer', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-js/load-generator/src/repository/ecommerce/generated/BaseProductRepository.ts
+++ b/kinotic-js/load-generator/src/repository/ecommerce/generated/BaseProductRepository.ts
@@ -11,7 +11,7 @@ export class BaseProductRepository extends EntityRepository<Product> {
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('kinotic', 'ecommerce', 'Product', entitiesRepository)
+    super('kinotic-test', 'ecommerce', 'Product', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-js/load-generator/src/repository/ecommerce/generated/BaseProductReviewRepository.ts
+++ b/kinotic-js/load-generator/src/repository/ecommerce/generated/BaseProductReviewRepository.ts
@@ -11,7 +11,7 @@ export class BaseProductReviewRepository extends EntityRepository<ProductReview>
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('kinotic', 'ecommerce', 'ProductReview', entitiesRepository)
+    super('kinotic-test', 'ecommerce', 'ProductReview', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-js/load-generator/src/repository/ecommerce/generated/BasePurchaseRepository.ts
+++ b/kinotic-js/load-generator/src/repository/ecommerce/generated/BasePurchaseRepository.ts
@@ -11,7 +11,7 @@ export class BasePurchaseRepository extends EntityRepository<Purchase> {
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('kinotic', 'ecommerce', 'Purchase', entitiesRepository)
+    super('kinotic-test', 'ecommerce', 'Purchase', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-js/load-generator/src/repository/generated/BasePersonRepository.ts
+++ b/kinotic-js/load-generator/src/repository/generated/BasePersonRepository.ts
@@ -11,7 +11,7 @@ export class BasePersonRepository extends EntityRepository<Person> {
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('kinotic', 'load-testing', 'Person', entitiesRepository)
+    super('kinotic-test', 'load-testing', 'Person', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-js/load-generator/src/repository/health/generated/BaseAppointmentRepository.ts
+++ b/kinotic-js/load-generator/src/repository/health/generated/BaseAppointmentRepository.ts
@@ -11,7 +11,7 @@ export class BaseAppointmentRepository extends EntityRepository<Appointment> {
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('kinotic', 'healthcare', 'Appointment', entitiesRepository)
+    super('kinotic-test', 'healthcare', 'Appointment', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-js/load-generator/src/repository/health/generated/BaseDiagnosisRepository.ts
+++ b/kinotic-js/load-generator/src/repository/health/generated/BaseDiagnosisRepository.ts
@@ -11,7 +11,7 @@ export class BaseDiagnosisRepository extends EntityRepository<Diagnosis> {
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('kinotic', 'healthcare', 'Diagnosis', entitiesRepository)
+    super('kinotic-test', 'healthcare', 'Diagnosis', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-js/load-generator/src/repository/health/generated/BasePatientRepository.ts
+++ b/kinotic-js/load-generator/src/repository/health/generated/BasePatientRepository.ts
@@ -11,7 +11,7 @@ export class BasePatientRepository extends EntityRepository<Patient> {
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('kinotic', 'healthcare', 'Patient', entitiesRepository)
+    super('kinotic-test', 'healthcare', 'Patient', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-js/load-generator/src/repository/health/generated/BaseProviderRepository.ts
+++ b/kinotic-js/load-generator/src/repository/health/generated/BaseProviderRepository.ts
@@ -25,7 +25,7 @@ export class BaseProviderRepository extends EntityRepository<Provider> {
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('kinotic', 'healthcare', 'Provider', entitiesRepository)
+    super('kinotic-test', 'healthcare', 'Provider', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-js/load-generator/src/repository/health/generated/BaseTreatmentRepository.ts
+++ b/kinotic-js/load-generator/src/repository/health/generated/BaseTreatmentRepository.ts
@@ -11,7 +11,7 @@ export class BaseTreatmentRepository extends EntityRepository<Treatment> {
   private readonly shouldValidate: boolean
 
   constructor(shouldValidate: boolean = true, entitiesRepository?: IEntitiesRepository) {
-    super('kinotic', 'healthcare', 'Treatment', entitiesRepository)
+    super('kinotic-test', 'healthcare', 'Treatment', entitiesRepository)
     this.shouldValidate = shouldValidate
   }
 

--- a/kinotic-js/load-generator/src/tasks/schema/EcommerceTaskFactory.ts
+++ b/kinotic-js/load-generator/src/tasks/schema/EcommerceTaskFactory.ts
@@ -15,7 +15,7 @@ import { createKinoticTaskBuilder } from './CreateKinoticTaskBuilder'
 import { initKinoticAppClient } from '../../utils/AuthHelpers'
 
 export class EcommerceTaskFactory {
-    private readonly organizationId = 'kinotic'
+    private readonly organizationId = 'kinotic-test'
     private readonly applicationId = 'ecommerce'
     private projectId = 'ecommerce_main_project'
     private readonly taskBuilder: CreateKinoticTaskBuilder

--- a/kinotic-js/load-generator/src/tasks/schema/HealthTaskFactory.ts
+++ b/kinotic-js/load-generator/src/tasks/schema/HealthTaskFactory.ts
@@ -16,7 +16,7 @@ import { initKinoticAppClient } from '../../utils/AuthHelpers'
 import path from 'path'
 
 export class HealthTaskFactory {
-    private readonly organizationId = 'kinotic'
+    private readonly organizationId = 'kinotic-test'
     private readonly applicationId = 'healthcare'
     private projectId = 'healthcare_main_project'
     private readonly taskBuilder: CreateKinoticTaskBuilder

--- a/kinotic-js/load-generator/src/utils/EntityDefinitionGenerator.ts
+++ b/kinotic-js/load-generator/src/utils/EntityDefinitionGenerator.ts
@@ -20,7 +20,7 @@ export class EntityDefinitionGenerator {
         const definitions = new Map<string, ObjectC3Type>()
 
         const projectConfig = new KinoticProjectConfig()
-        projectConfig.organization = 'kinotic'
+        projectConfig.organization = 'kinotic-test'
         projectConfig.application = this.application
         projectConfig.validate = false
         projectConfig.entitiesPaths = [{

--- a/kinotic-js/load-generator/src/utils/buildEntityDefinitions.ts
+++ b/kinotic-js/load-generator/src/utils/buildEntityDefinitions.ts
@@ -15,7 +15,7 @@ async function buildEntityDefinitions() {
         const codeGenerationService = new EntityCodeGenerationService(namespace, '.js', logger)
 
         const namespaceConfig: KinoticProjectConfig = new KinoticProjectConfig()
-        namespaceConfig.organization = 'kinotic'
+        namespaceConfig.organization = 'kinotic-test'
         namespaceConfig.application = namespace
         namespaceConfig.validate = false
         namespaceConfig.entitiesPaths = [{
@@ -45,7 +45,7 @@ async function buildEntityDefinitions() {
         const codeGenerationService = new EntityCodeGenerationService(namespace, '.js', logger)
 
         const namespaceConfig: KinoticProjectConfig = new KinoticProjectConfig()
-        namespaceConfig.organization = 'kinotic'
+        namespaceConfig.organization = 'kinotic-test'
         namespaceConfig.application = namespace
         namespaceConfig.validate = false
         namespaceConfig.entitiesPaths = [{


### PR DESCRIPTION
## Summary

Tags load-generator entities with `organizationId: "kinotic-test"` so the auth scope matches.

The load generator authenticates as the `kinotic-test` organization (set up in #180), but the org id baked into generated repositories, factories, and the codegen configs was still `'kinotic'`. The backend's org enforcement rejects mismatches:

```
Cannot save EntityDefinition with organizationId 'kinotic' while authenticated as organization 'kinotic-test'
```

This PR was originally a stack of refactors covering renames, package bumps, the two-auth-path pattern, and the org-id; #180 picked up everything except the org id, so this PR is now just the one-liner sweep.

### Changes

- Generated `Base*Repository.ts` `super()` first arg (11 files: Person + 4 ecommerce + 5 health, minus the orphaned Prescription)
- `EcommerceTaskFactory` / `HealthTaskFactory` `organizationId` field
- `.config/kinotic.config.ts` `organization`
- `KinoticProjectConfig.organization` in `src/utils/buildEntityDefinitions.ts` (both ecommerce and health) and `src/utils/EntityDefinitionGenerator.ts`

`'kinotic'` left untouched where it isn't an org id: `passcode: 'kinotic'`, `APP_USER_PASSWORD = 'kinotic'`, and the `tenantId` arg in `LoadTaskGeneratorFactory.createConnectionInfo('kinotic', ...)`.

### Test plan

- [ ] `cd kinotic-js/load-generator && pnpm install && pnpm exec tsc --noEmit --ignoreDeprecations "6.0"` — 0 errors in `src/`
- [ ] Run the `generateComplexEntities` load test against a server with the `kinotic-test` org and `kinotic@kinotic.local` user — every `Create <Name> EntityDefinition` task should succeed without the "organizationId mismatch" error
- [ ] Bulk-save tasks (`Generate and Save Ecommerce Test Data`, `Generate and Save Health Domain Test Data`) should write through the APP-scoped client

https://claude.ai/code/session_01M5H9DRay9rpuey3uJ7gAQ1