### PR TITLE
Auto-derive organizationId in createApplicationIfNotExist

### DIFF
--- a/kinotic-domain/src/main/java/org/kinotic/os/api/services/ApplicationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/os/api/services/ApplicationService.java
@@ -12,7 +12,8 @@ import java.util.concurrent.CompletableFuture;
 public interface ApplicationService extends IdentifiableCrudService<Application, String> {
 
     /**
-     * Creates a new application if it does not already exist.
+     * Creates a new application if it does not already exist. The organization id is derived
+     * from the authenticated participant.
      * @param id the id of the application to create
      * @param description the description of the application to create
      * @return {@link CompletableFuture} emitting the created application

--- a/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/AbstractCrudService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/AbstractCrudService.java
@@ -174,7 +174,7 @@ public abstract class AbstractCrudService<T extends Identifiable<String>> implem
      * @throws IllegalStateException if no {@link Participant} is bound to the current Vert.x context
      * @throws AuthorizationException if the participant's auth scope type is not {@link AuthScopeType#ORGANIZATION}
      */
-    private String requireOrganizationId() {
+    protected String requireOrganizationId() {
         Participant participant = securityContext.currentParticipant();
         if (participant == null) {
             throw new IllegalStateException(

--- a/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/DefaultApplicationService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/os/internal/api/services/DefaultApplicationService.java
@@ -39,12 +39,15 @@ public class DefaultApplicationService extends AbstractCrudService<Application> 
     @Override
     public CompletableFuture<Application> createApplicationIfNotExist(String id, String description) {
         DomainUtil.validateApplicationId(id);
+        String organizationId = requireOrganizationId();
         return findById(id)
                 .thenCompose(application -> {
                     if(application != null){
                         return CompletableFuture.completedFuture(application);
                     }else{
-                        return save(new Application(id, description));
+                        Application newApplication = new Application(id, description);
+                        newApplication.setOrganizationId(organizationId);
+                        return save(newApplication);
                     }
                 });
     }

--- a/kinotic-js/e2e-tests/test/TestHelpers.ts
+++ b/kinotic-js/e2e-tests/test/TestHelpers.ts
@@ -220,6 +220,7 @@ export async function createAlertEntityDefinition(organizationId: string, applic
     await Kinotic.applications.createApplicationIfNotExist(applicationId, 'Application')
 
     let project: Project = new Project(null, applicationId, projectName, 'Project')
+    project.organizationId = organizationId
     project = await Kinotic.projects.createProjectIfNotExist(project)
 
     const {entityDefinitionSchema} = await createAlertSchema(organizationId, applicationId, project.id as string)
@@ -283,6 +284,7 @@ export async function createPersonEntityDefinition(organizationId: string, appli
     await Kinotic.applications.createApplicationIfNotExist(applicationId, 'Application')
 
     let project: Project = new Project(null, applicationId, projectName, 'Project')
+    project.organizationId = organizationId
     project = await Kinotic.projects.createProjectIfNotExist(project)
 
     const {entityDefinitionSchema} = await createPersonSchema(organizationId, applicationId, project.id as string, withTenant)
@@ -318,6 +320,7 @@ export async function createVehicleEntityDefinition(organizationId: string, appl
     await Kinotic.applications.createApplicationIfNotExist(applicationId, 'Application')
     console.log('Created application', applicationId);
     let project: Project = new Project(null, applicationId, projectName, 'Project')
+    project.organizationId = organizationId
     project = await Kinotic.projects.createProjectIfNotExist(project)
     console.log('Created project', project.id);
     const {entityDefinitionSchema} = await createVehicleSchema(organizationId, applicationId, project.id as string)

--- a/kinotic-js/e2e-tests/test/native/MigrationService.testx.ts
+++ b/kinotic-js/e2e-tests/test/native/MigrationService.testx.ts
@@ -41,6 +41,7 @@ describe('Migration Service End To End Tests', () => {
         await Kinotic.applications.createApplicationIfNotExist(context.applicationId, 'Test Application')
         
         const project = new Project(null, context.applicationId, generateRandomString(5), 'Test Project')
+        project.organizationId = 'kinotic-test'
         context.project = await Kinotic.projects.createProjectIfNotExist(project)
         expect(context.project).toBeDefined()
         expect(context.project.id).toBeDefined()

--- a/kinotic-js/kinotic-cli/src/commands/synchronize.ts
+++ b/kinotic-js/kinotic-cli/src/commands/synchronize.ts
@@ -69,6 +69,7 @@ export class Synchronize extends Command {
                                               kinoticProjectConfig.application,
                                               kinoticProjectConfig.name as string,
                                               kinoticProjectConfig.description)
+                        project.organizationId = kinoticProjectConfig.organization
                         project.sourceOfTruth = ProjectType.TYPESCRIPT
                         project = await Kinotic.projects.createProjectIfNotExist(project)
                     }

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IApplicationService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IApplicationService.ts
@@ -6,7 +6,8 @@ import { Application } from '@/api/model/Application'
 export interface IApplicationService extends ICrudServiceProxy<Application> {
 
     /**
-     * Creates a new application if it does not already exist.
+     * Creates a new application if it does not already exist. The organization id is derived
+     * from the authenticated participant on the server.
      * @param id the id of the application to create
      * @param description the description of the application to create
      * @return {@link Promise} emitting the created application


### PR DESCRIPTION
## Summary

Resolves the `Organization id must be set on Application` runtime error from inside the impl, so the public RPC signature stays the same and no os-api republish or coordinated server/client redeploy is needed.

`Application` is constructed inside `ApplicationService.createApplicationIfNotExist(id, description)`, leaving the existing 2-arg call sites no way to set `organizationId`. The org-id auto-populate path was removed from `AbstractCrudService`, so the validator now hard-rejects a blank `organizationId`. Rather than expand the wire contract, this PR pulls the organization id off the authenticated participant — the same pattern `enforceOrgOnSave` and `findAll` already use — and stamps it on the new `Application` before save.

### Changes

- `AbstractCrudService.requireOrganizationId()` bumped from `private` to `protected` so subclasses can reuse the participant-scope check.
- `DefaultApplicationService.createApplicationIfNotExist`: derives `organizationId` via `requireOrganizationId()` and calls `setOrganizationId(...)` on the new `Application` before `save`. Public method signature is unchanged.
- `ApplicationService.java` and `IApplicationService.ts` doc comments updated to note the org id is derived from the participant.
- `kinotic-js/e2e-tests/test/TestHelpers.ts`, `MigrationService.testx.ts`, and `kinotic-cli/src/commands/synchronize.ts`: still set `project.organizationId = ...` before `createProjectIfNotExist`, since `Project` is constructed by the caller and the validator continues to reject a blank org id on save. (No equivalent server-side fix here — `createProjectIfNotExist` takes the full `Project`, so callers already had a place to set it.)

### Heads-up

`createProjectIfNotExist` is structurally different — it accepts a caller-constructed `Project`, so the same auto-derive trick would mean inspecting the passed object and filling a blank field rather than supplying the value from scratch. If you want the same QoL there I can do it as a follow-up; it'd let those `project.organizationId = ...` lines disappear too.

### Test plan

- [ ] `./gradlew :kinotic-domain:check` — Java compile and unit tests
- [ ] `./gradlew :kinotic-persistence:check` — covers updated `TestDataService` (no signature change needed there now)
- [ ] After deploying a kinotic-server image built from this branch, run the e2e suite and the load-generator's `generateComplexEntities` path — `Create Ecommerce Namespace` and `Create Health Namespace` should succeed without the `Organization id must be set on Application` error
- [ ] No `@kinotic-ai/os-api` republish required — TS interface signature is unchanged

https://claude.ai/code/session_01M5H9DRay9rpuey3uJ7gAQ1