### PR TITLE
Clarify migration SQL grammar documentation for schema-agnostic systems

### DIFF
--- a/website/content/1.apps/5.persistence/7.migrations.md
+++ b/website/content/1.apps/5.persistence/7.migrations.md
@@ -85,7 +85,7 @@ INSERT INTO users (name, age, active) VALUES ('Jane', 28, TRUE) WITH REFRESH;
 ```
 
 ::callout{type="warning"}
-If your table has a logical `id` field, always include the `id` column in the INSERT. The value is promoted to the Elasticsearch `_id`, which is how find-by-id lookups resolve the document. An INSERT that omits `id` stores the row with a random `_id` and it can only be located via search — not via a direct id lookup. See the [Migration SQL Grammar reference](/reference/migration-sql-grammar#the-id-column) for details.
+If your table has a logical `id` field, always include the `id` column in the INSERT. The value becomes the document's storage identifier, which is how find-by-id lookups resolve the document. An INSERT that omits `id` stores the row with a random identifier and it can only be located via search — not via a direct id lookup. See the [Migration SQL Grammar reference](/reference/migration-sql-grammar#the-id-column) for details.
 ::
 
 ### UPDATE ... SET ... WHERE

--- a/website/content/3.reference/2.migration-sql-grammar.md
+++ b/website/content/3.reference/2.migration-sql-grammar.md
@@ -7,7 +7,7 @@ navigation:
 
 ## Overview
 
-This grammar reference applies to migration scripts used for schema and data migrations in Kinotic. Migration scripts use a SQL dialect designed for Elasticsearch index management and data operations.
+This grammar reference applies to migration scripts used for schema and data migrations in Kinotic. Migration scripts use a SQL dialect designed for schema and data management.
 
 All statements must end with a semicolon (`;`). Identifiers must start with a letter or underscore and can contain letters, numbers, and underscores. Strings are enclosed in single quotes (`'...'`).
 
@@ -113,7 +113,7 @@ REINDEX <source_index> INTO <dest_index> [WITH (<option> [, <option>]*)] ;
 |--------|---------------|-------------|
 | `CONFLICTS` | `ABORT`, `PROCEED` | How to handle version conflicts: abort or proceed |
 | `MAX_DOCS` | Integer (e.g., 1000) | Maximum number of documents to reindex |
-| `SLICES` | `AUTO`, Integer (e.g., 2) | Number of slices (parallelism); AUTO lets Elasticsearch decide |
+| `SLICES` | `AUTO`, Integer (e.g., 2) | Number of slices for parallel processing; AUTO selects automatically based on shard count |
 | `SIZE` | Integer (e.g., 500) | Batch size for reindexing |
 | `SOURCE_FIELDS` | Comma-separated list (e.g., `'field1,field2'`) | Restrict source fields to copy |
 | `QUERY` | String (Lucene query syntax) | Query to filter source documents |
@@ -156,7 +156,7 @@ INSERT INTO products (name, sku, price)
 
 ### The `id` column
 
-When the column list includes `id`, its value is used as the Elasticsearch `_id` of the inserted document. If the column list omits `id`, Elasticsearch auto-generates a random `_id`.
+When the column list includes `id`, its value is used as the document's unique storage identifier. If the column list omits `id`, a random storage identifier is auto-generated.
 
 This matters because every find-by-id lookup resolves the document by its `_id`. A row inserted without an `id` column cannot be retrieved by its logical identifier later — it will only be discoverable via search.
 
@@ -249,34 +249,66 @@ WHERE (category == 'electronics' OR category == 'appliances') AND price > 100
 
 ## Supported Types
 
-| Type | Elasticsearch Mapping |
-|------|----------------------|
-| `TEXT` | text |
-| `KEYWORD` | keyword |
-| `KEYWORD NOT INDEXED` | keyword (not indexed, no doc_values) |
-| `INTEGER` | integer |
-| `INTEGER NOT INDEXED` | integer (not indexed, no doc_values) |
-| `LONG` | long |
-| `LONG NOT INDEXED` | long (not indexed, no doc_values) |
-| `FLOAT` | float |
-| `FLOAT NOT INDEXED` | float (not indexed, no doc_values) |
-| `DOUBLE` | double |
-| `DOUBLE NOT INDEXED` | double (not indexed, no doc_values) |
-| `BOOLEAN` | boolean |
-| `BOOLEAN NOT INDEXED` | boolean (not indexed, no doc_values) |
-| `DATE` | date |
-| `DATE NOT INDEXED` | date (not indexed, no doc_values) |
-| `JSON` | object (flattened) |
-| `JSON NOT INDEXED` | object (not indexed) |
-| `BINARY` | binary |
-| `GEO_POINT` | geo_point |
-| `GEO_SHAPE` | geo_shape |
-| `UUID` | keyword |
-| `UUID NOT INDEXED` | keyword (not indexed, no doc_values) |
-| `DECIMAL` | double |
-| `DECIMAL NOT INDEXED` | double (not indexed, no doc_values) |
+| Type | Description |
+|------|-------------|
+| `TEXT` | Full-text searchable string; analyzed and tokenized |
+| `KEYWORD` | Exact-match string; not tokenized |
+| `KEYWORD NOT INDEXED` | Exact-match string; stored but not searchable |
+| `INTEGER` | 32-bit signed integer |
+| `INTEGER NOT INDEXED` | 32-bit signed integer; stored but not searchable |
+| `LONG` | 64-bit signed integer |
+| `LONG NOT INDEXED` | 64-bit signed integer; stored but not searchable |
+| `FLOAT` | 32-bit floating-point number |
+| `FLOAT NOT INDEXED` | 32-bit floating-point number; stored but not searchable |
+| `DOUBLE` | 64-bit floating-point number |
+| `DOUBLE NOT INDEXED` | 64-bit floating-point number; stored but not searchable |
+| `BOOLEAN` | `true` / `false` value |
+| `BOOLEAN NOT INDEXED` | `true` / `false` value; stored but not searchable |
+| `DATE` | ISO 8601 date/datetime string |
+| `DATE NOT INDEXED` | ISO 8601 date/datetime string; stored but not searchable |
+| `JSON` | Arbitrary JSON object; leaf values indexed as searchable strings (see [JSON type](#json-type)) |
+| `JSON NOT INDEXED` | Arbitrary JSON object; stored as-is without indexing any sub-fields |
+| `BINARY` | Base64-encoded binary data; stored but not searchable |
+| `GEO_POINT` | Geographic point (`lat`, `lon`) |
+| `GEO_SHAPE` | Geographic shape (polygon, line, etc.) |
+| `UUID` | UUID stored as an exact-match string |
+| `UUID NOT INDEXED` | UUID stored as an exact-match string; not searchable |
+| `DECIMAL` | Decimal number stored as a 64-bit float |
+| `DECIMAL NOT INDEXED` | Decimal number stored as a 64-bit float; not searchable |
 
-The `NOT INDEXED` variant of each type stores the value but excludes it from the inverted index and doc_values. This reduces storage and indexing overhead for fields that only need to be returned in results, not queried.
+The `NOT INDEXED` variant of each type stores the value but excludes it from the search index. This reduces storage and indexing overhead for fields that only need to be returned in results, not queried.
+
+---
+
+## JSON Type
+
+The `JSON` type stores an entire JSON object as a single field. All leaf values within the object — regardless of nesting depth — are indexed and queryable as strings. This approach avoids requiring a fixed schema for nested data, making it well-suited for semi-structured or dynamic payloads.
+
+**Key behaviors:**
+
+- **Sub-fields are queryable by dot-path.** A field defined as `metadata JSON` can be filtered with `metadata.version == '2'` or `metadata.source.region == 'us-east'`.
+- **All comparisons are string-based.** Even numeric or date values stored inside a JSON field are compared as strings. Use `TEXT`, `INTEGER`, `DOUBLE`, etc. for fields that require numeric or range queries.
+- **Dynamic nesting is supported.** The sub-field structure does not need to be declared in the schema — any JSON shape can be stored and its leaf values will be indexed automatically.
+
+**Example:**
+
+```sql
+CREATE TABLE events (
+    id      UUID,
+    ts      DATE,
+    payload JSON
+) ;
+```
+
+A record with `payload = {"source": {"region": "us-east"}, "retries": 3}` can then be filtered as:
+
+```sql
+WHERE payload.source.region == 'us-east'
+```
+
+Note that `retries` would be compared as the string `'3'`, not the number `3`.
+
+For `JSON NOT INDEXED`, the object is stored and returned in query results but none of its sub-fields can be queried.
 
 ---
 


### PR DESCRIPTION
## Summary
Updated migration SQL grammar documentation to remove Elasticsearch-specific terminology and implementation details, making the documentation more accurate for schema-agnostic storage systems. Improved clarity and completeness of type definitions and JSON field behavior.

## Key Changes

- **Removed Elasticsearch-specific language** throughout the documentation:
  - Changed "Elasticsearch index management" to "schema and data management"
  - Replaced references to Elasticsearch `_id` with generic "storage identifier" or "document's unique storage identifier"
  - Updated `SLICES` option description to use generic "parallel processing" terminology instead of Elasticsearch-specific behavior

- **Enhanced type documentation** with clearer, more descriptive definitions:
  - Converted type table from "Elasticsearch Mapping" column to "Description" column
  - Added detailed descriptions for each type (e.g., "Full-text searchable string; analyzed and tokenized" for TEXT)
  - Clarified `NOT INDEXED` behavior as "stored but not searchable" rather than technical Elasticsearch details (doc_values, inverted index)
  - Improved descriptions for complex types like JSON, BINARY, GEO_POINT, and GEO_SHAPE

- **Added comprehensive JSON type documentation** with new dedicated section:
  - Explained JSON field behavior including dot-path queryability
  - Clarified that all comparisons within JSON fields are string-based
  - Documented dynamic nesting support without requiring schema declaration
  - Provided concrete example showing JSON field usage and querying
  - Noted behavior difference for `JSON NOT INDEXED` variant

- **Updated related documentation** in migrations guide to use consistent, non-Elasticsearch terminology

## Notable Details
The changes maintain backward compatibility with the SQL grammar itself while improving documentation accuracy and usability for users working with the Kinotic platform's storage abstraction layer.

https://claude.ai/code/session_01PxcDBBkoXDMuPLE3LpiJVt