### PR TITLE
Upgrade Kinotic dependencies across packages

### DIFF
--- a/kinotic-js/e2e-tests/package.json
+++ b/kinotic-js/e2e-tests/package.json
@@ -15,10 +15,10 @@
   "devDependencies": {
     "@faker-js/faker": "^10.2.0",
     "@kinotic-ai/kinotic-cli": "^2.2.0",
-    "@kinotic-ai/core": "^1.2.1",
+    "@kinotic-ai/core": "^1.2.2",
     "@kinotic-ai/idl": "^1.0.9",
-    "@kinotic-ai/os-api": "^1.1.0",
-    "@kinotic-ai/persistence": "^1.2.0",
+    "@kinotic-ai/os-api": "^1.4.0",
+    "@kinotic-ai/persistence": "^1.2.1",
     "@types/node": "^25.0.6",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-vue": "^6.0.3",

--- a/kinotic-js/kinotic-cli/package.json
+++ b/kinotic-js/kinotic-cli/package.json
@@ -18,10 +18,10 @@
     ],
     "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@kinotic-ai/core": "^1.1.1",
+        "@kinotic-ai/core": "^1.2.2",
         "@kinotic-ai/idl": "^1.0.9",
-        "@kinotic-ai/os-api": "^1.1.0",
-        "@kinotic-ai/persistence": "^1.2.0",
+        "@kinotic-ai/os-api": "^1.4.0",
+        "@kinotic-ai/persistence": "^1.2.1",
         "@oclif/core": "^4.9.0",
         "c12": "^3.3.3",
         "chalk": "^5.6.2",

--- a/kinotic-js/load-generator/package.json
+++ b/kinotic-js/load-generator/package.json
@@ -29,10 +29,10 @@
   },
   "dependencies": {
     "@faker-js/faker": "^10.4.0",
-    "@kinotic-ai/core": "^1.2.1",
+    "@kinotic-ai/core": "^1.2.2",
     "@kinotic-ai/idl": "^1.0.9",
     "@kinotic-ai/kinotic-cli": "^2.2.0",
-    "@kinotic-ai/os-api": "^1.2.0",
+    "@kinotic-ai/os-api": "^1.4.0",
     "@kinotic-ai/persistence": "^1.2.1",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.214.0",


### PR DESCRIPTION
## Summary
This PR updates Kinotic package dependencies to their latest versions across the e2e-tests, kinotic-cli, and load-generator packages.

## Changes
- Updated `@kinotic-ai/core` from `^1.1.1` / `^1.2.1` to `^1.2.2`
- Updated `@kinotic-ai/os-api` from `^1.1.0` / `^1.2.0` to `^1.4.0`
- Updated `@kinotic-ai/persistence` from `^1.2.0` to `^1.2.1`

## Details
These dependency updates ensure all packages are using compatible and up-to-date versions of core Kinotic libraries. The `os-api` package receives a more significant version bump (1.1.0/1.2.0 → 1.4.0), which may include new features or improvements.

https://claude.ai/code/session_012dtGJz2NkRDLKAncchs9qy