### PR TITLE
Simplify secret storage by removing key rotation support

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/api/config/SecretStorageProperties.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/config/SecretStorageProperties.java
@@ -6,15 +6,16 @@ import lombok.experimental.Accessors;
 
 /**
  * Configuration settings for secret storage.
- * <p>
- * The master key set used for name derivation is no longer configured here — it is loaded
- * from the platform secrets mount (see {@link PlatformSecretsProperties}) so it can
- * rotate transparently without restarts.
  */
 @Getter
 @Setter
 @Accessors(chain = true)
 public class SecretStorageProperties {
+    /**
+     * Base64-encoded master key used by {@code SecretNameDeriver} to derive opaque,
+     * deterministic storage names from {@code (secretScope, key)} pairs.
+     */
+    private String masterKey;
     /**
      * Backend type. If null, in-memory storage is used.
      */

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/secret/DefaultSecretStorageService.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/secret/DefaultSecretStorageService.java
@@ -4,22 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.kinotic.core.api.secret.SecretStorageService;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
-/**
- * Rotation-aware secret storage service.
- * <p>
- * Writes use the currently active master key via {@link SecretNameDeriver#deriveActive}.
- * Reads query all candidate derivations ({@link SecretNameDeriver#deriveAll}) so entries
- * written under a prior master key remain readable during a rotation window. Deletes remove
- * every candidate name to avoid orphans after rotation.
- */
 @Component
 @RequiredArgsConstructor
 public class DefaultSecretStorageService implements SecretStorageService {
@@ -29,72 +18,53 @@ public class DefaultSecretStorageService implements SecretStorageService {
 
     @Override
     public CompletableFuture<Void> setSecret(String secretScope, String key, String value) {
-        return secretStorageBackend.setSecret(secretNameDeriver.deriveActive(secretScope, key), value);
+        String derivedName = secretNameDeriver.derive(secretScope, key);
+        return secretStorageBackend.setSecret(derivedName, value);
     }
 
     @Override
     public CompletableFuture<String> getSecret(String secretScope, String key) {
-        return tryReadCandidates(secretNameDeriver.deriveAll(secretScope, key), 0);
+        String derivedName = secretNameDeriver.derive(secretScope, key);
+        return secretStorageBackend.getSecret(derivedName);
     }
 
     @Override
     public CompletableFuture<Void> deleteSecret(String secretScope, String key) {
-        return secretStorageBackend.deleteSecrets(secretNameDeriver.deriveAll(secretScope, key));
+        String derivedName = secretNameDeriver.derive(secretScope, key);
+        return secretStorageBackend.deleteSecret(derivedName);
     }
 
     @Override
     public CompletableFuture<Void> setSecrets(String secretScope, Map<String, String> secrets) {
-        Map<String, String> derived = new HashMap<>(secrets.size());
-        for (Map.Entry<String, String> e : secrets.entrySet()) {
-            derived.put(secretNameDeriver.deriveActive(secretScope, e.getKey()), e.getValue());
-        }
+        Map<String, String> derived = secrets.entrySet()
+                                             .stream()
+                                             .collect(Collectors.toMap(
+                                                     e -> secretNameDeriver.derive(secretScope, e.getKey()),
+                                                     Map.Entry::getValue));
         return secretStorageBackend.setSecrets(derived);
     }
 
     @Override
     public CompletableFuture<Map<String, String>> getSecrets(String secretScope, List<String> keys) {
-        Map<String, List<String>> logicalToCandidates = new HashMap<>(keys.size());
-        Set<String> allCandidates = new HashSet<>();
-        for (String k : keys) {
-            List<String> cands = secretNameDeriver.deriveAll(secretScope, k);
-            logicalToCandidates.put(k, cands);
-            allCandidates.addAll(cands);
-        }
-        return secretStorageBackend.getSecrets(List.copyOf(allCandidates))
-                                   .thenApply(backendResults -> {
-            Map<String, String> out = new HashMap<>(keys.size());
-            for (Map.Entry<String, List<String>> e : logicalToCandidates.entrySet()) {
-                for (String candidate : e.getValue()) {
-                    String value = backendResults.get(candidate);
-                    if (value != null) {
-                        out.put(e.getKey(), value);
-                        break;
-                    }
-                }
-            }
-            return out;
-        });
+        Map<String, String> derivedToOriginal = keys.stream()
+                                                    .collect(Collectors.toMap(
+                                                            k -> secretNameDeriver.derive(secretScope, k),
+                                                            k -> k));
+
+        return secretStorageBackend.getSecrets(List.copyOf(derivedToOriginal.keySet()))
+                                   .thenApply(derivedResults ->
+                                           derivedResults.entrySet()
+                                                         .stream()
+                                                         .collect(Collectors.toMap(
+                                                                 e -> derivedToOriginal.get(e.getKey()),
+                                                                 Map.Entry::getValue)));
     }
 
     @Override
     public CompletableFuture<Void> deleteSecrets(String secretScope, List<String> keys) {
-        List<String> derivedNames = new ArrayList<>();
-        for (String k : keys) {
-            derivedNames.addAll(secretNameDeriver.deriveAll(secretScope, k));
-        }
+        List<String> derivedNames = keys.stream()
+                                        .map(k -> secretNameDeriver.derive(secretScope, k))
+                                        .toList();
         return secretStorageBackend.deleteSecrets(derivedNames);
-    }
-
-    private CompletableFuture<String> tryReadCandidates(List<String> candidates, int idx) {
-        if (idx >= candidates.size()) {
-            return CompletableFuture.completedFuture(null);
-        }
-        return secretStorageBackend.getSecret(candidates.get(idx))
-                                   .handle((value, ex) -> {
-            if (ex == null && value != null) {
-                return CompletableFuture.completedFuture(value);
-            }
-            return tryReadCandidates(candidates, idx + 1);
-        }).thenCompose(f -> f);
     }
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/secret/SecretNameDeriver.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/secret/SecretNameDeriver.java
@@ -1,18 +1,15 @@
 package org.kinotic.core.internal.api.secret;
 
 import lombok.extern.slf4j.Slf4j;
-import org.kinotic.core.api.config.VersionedKeySet;
-import org.kinotic.core.internal.platform.PlatformSecretsService;
+import org.kinotic.core.api.config.KinoticProperties;
+import org.kinotic.core.api.config.SecretStorageProperties;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
-import java.util.ArrayList;
 import java.util.Base64;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Derives opaque, deterministic secret names using a two-level HKDF chain (HMAC-SHA256).
@@ -20,9 +17,6 @@ import java.util.concurrent.atomic.AtomicReference;
  * Level 1: scopeKey = HMAC(masterKey, secretScope)
  * Level 2: derivedName = HMAC(scopeKey, key)  → base64url (43 chars, no padding)
  * <p>
- * Master keys are sourced from {@link PlatformSecretsService} (platform secrets mount) and
- * swap atomically on rotation. {@link #deriveActive} uses the current active key;
- * {@link #deriveAll} returns one name per key so rotation-aware reads can try each in turn.
  */
 @Slf4j
 @Component
@@ -30,58 +24,31 @@ public class SecretNameDeriver {
 
     private static final String HMAC_ALGORITHM = "HmacSHA256";
 
-    private final AtomicReference<VersionedKeySet> masterKeys = new AtomicReference<>();
+    private final byte[] masterKey;
 
-    public SecretNameDeriver(PlatformSecretsService platformSecretsService) {
-        VersionedKeySet initial = platformSecretsService.getSecretStorageMasterKeys();
-        if (initial == null) {
-            throw new IllegalStateException(
-                    "Secret-storage master keys are not mounted. Configure " +
-                    "kinotic.platformSecrets.secretStorageMasterKeysPath to point at a " +
-                    "VersionedKeySet JSON file.");
+    public SecretNameDeriver(KinoticProperties properties) {
+        SecretStorageProperties settings = properties.getSecretStorage();
+        if (settings != null && settings.getMasterKey() != null) {
+            this.masterKey = Base64.getDecoder().decode(settings.getMasterKey());
+        } else {
+            throw new IllegalStateException("No secret storage master key configured");
         }
-        masterKeys.set(initial);
-        platformSecretsService.addSecretStorageMasterKeysListener(updated -> {
-            log.info("Rotating secret-storage master keys; active={}", updated.getActiveKeyId());
-            masterKeys.set(updated);
-        });
-        log.info("Secret name deriver initialized with master keys (activeKeyId={})",
-                 initial.getActiveKeyId());
     }
 
     /**
-     * Derives the opaque storage name for the given scope and key using the currently active
-     * master key. Used for writes.
+     * Derives an opaque, deterministic 43-character base64url name for the given scope and key.
+     * <p>
+     * The derivation is a two-level HMAC chain:
+     * <ol>
+     *   <li>scopeKey = HMAC-SHA256(masterKey, secretScope)</li>
+     *   <li>derivedName = base64url(HMAC-SHA256(scopeKey, key))</li>
+     * </ol>
+     *
+     * @param secretScope the isolation scope (e.g. tenant ID)
+     * @param key         the logical secret key within the scope
+     * @return a 43-character base64url string (no padding) suitable as a storage key
      */
-    public String deriveActive(String secretScope, String key) {
-        VersionedKeySet set = masterKeys.get();
-        return deriveWith(decode(set.getActive().getKey()), secretScope, key);
-    }
-
-    /**
-     * Derives all valid storage names for the given scope and key, ordered with the active
-     * master key's derivation first and older keys after. Callers doing reads should try
-     * each in order so secrets written under prior master keys remain reachable during a
-     * rotation window.
-     */
-    public List<String> deriveAll(String secretScope, String key) {
-        VersionedKeySet set = masterKeys.get();
-        List<String> result = new ArrayList<>(set.getKeys().size());
-        String activeId = set.getActiveKeyId();
-        result.add(deriveWith(decode(set.findById(activeId).getKey()), secretScope, key));
-        for (VersionedKeySet.KeyEntry entry : set.getKeys()) {
-            if (!entry.getId().equals(activeId)) {
-                result.add(deriveWith(decode(entry.getKey()), secretScope, key));
-            }
-        }
-        return result;
-    }
-
-    private static byte[] decode(String base64) {
-        return Base64.getDecoder().decode(base64);
-    }
-
-    private static String deriveWith(byte[] masterKey, String secretScope, String key) {
+    public String derive(String secretScope, String key) {
         byte[] scopeKey = hmac(masterKey, secretScope.getBytes(StandardCharsets.UTF_8));
         byte[] hash = hmac(scopeKey, key.getBytes(StandardCharsets.UTF_8));
         return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);


### PR DESCRIPTION
## Summary
This PR removes the key rotation mechanism from the secret storage service, simplifying the implementation to use a single static master key configured via properties instead of dynamically loaded and rotated keys from the platform secrets mount.

## Key Changes
- **SecretNameDeriver**: Replaced dynamic key rotation logic with a single static master key
  - Removed `AtomicReference<VersionedKeySet>` and listener-based key rotation
  - Removed `deriveActive()` and `deriveAll()` methods; replaced with single `derive()` method
  - Master key now sourced from `KinoticProperties.secretStorage.masterKey` (base64-encoded)
  - Simplified initialization to decode the configured master key once

- **DefaultSecretStorageService**: Removed rotation-aware read/write/delete logic
  - Removed `tryReadCandidates()` recursive method that tried multiple key candidates
  - Simplified `getSecret()` to directly call backend instead of trying multiple derivations
  - Simplified `deleteSecret()` to delete single derived name instead of all candidates
  - Refactored `setSecrets()`, `getSecrets()`, and `deleteSecrets()` to use streams and single derivations
  - Removed extensive javadoc describing rotation behavior

- **SecretStorageProperties**: Added `masterKey` configuration field
  - New base64-encoded master key property for name derivation
  - Updated javadoc to reflect removal of platform secrets mount dependency

## Implementation Details
- The two-level HMAC-SHA256 derivation chain remains unchanged (scopeKey → derivedName)
- All methods now use a single deterministic name per (scope, key) pair
- Stream-based refactoring improves code readability and reduces mutable state
- Configuration is now simpler: just provide a base64-encoded master key in properties

https://claude.ai/code/session_016J39KAFGApES9tnj1JVWEn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches secret name derivation from rotation-aware key sets to a single configured master key, which can break reads of secrets written under prior keys and changes delete semantics. Also introduces a required `secretStorage.masterKey` property, making misconfiguration a startup/runtime risk.
> 
> **Overview**
> Simplifies secret storage by **removing key-rotation support** and deriving exactly one storage name per `(secretScope, key)`.
> 
> `SecretNameDeriver` now loads a single base64 `secretStorage.masterKey` from `KinoticProperties` and exposes a single `derive()` method, deleting the old rotation/listener logic and multi-key derivation APIs.
> 
> `DefaultSecretStorageService` is updated to use the single derived name for all read/write/delete and batch operations, removing candidate-lookup/cleanup behavior and the recursive fallback read path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a35f96f08af4e968f4b51c89c44f5853b47272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->