### PR TITLE
Remove secret-storage master key management from platform secrets

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/api/config/PlatformSecretsProperties.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/config/PlatformSecretsProperties.java
@@ -23,10 +23,4 @@ public class PlatformSecretsProperties {
      * Consumed by the Kinotic JWT issuer for signing STOMP-CONNECT tickets.
      */
     private Path jwtSigningKeysPath;
-
-    /**
-     * Path to the secret-storage master key set file (one {@link VersionedKeySet} JSON document).
-     * Consumed by the secret name deriver for HKDF-based opaque naming.
-     */
-    private Path secretStorageMasterKeysPath;
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/platform/PlatformSecretsService.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/platform/PlatformSecretsService.java
@@ -23,9 +23,8 @@ import java.util.function.Consumer;
 
 /**
  * Loads platform-level {@link VersionedKeySet} JSON files from disk and periodically polls
- * them for changes. Used by the JWT issuer (signing keys) and the secret name deriver
- * (masterKeys). File updates surface as atomic reference swaps; consumers register
- * listeners to react to rotations.
+ * them for changes. Used by the JWT issuer (signing keys). File updates surface as atomic
+ * reference swaps; consumers register listeners to react to rotations.
  * <p>
  * Polling (rather than {@code WatchService}) avoids the symlink/atomic-replace quirks of
  * Kubernetes Secret volumes and Azure Key Vault CSI mounts. The poll interval is well below
@@ -42,10 +41,8 @@ public class PlatformSecretsService {
     private final Optional<PlatformSecretsBootstrap> bootstrap;
 
     private final AtomicReference<Loaded> jwtSigningKeys = new AtomicReference<>();
-    private final AtomicReference<Loaded> secretStorageMasterKeys = new AtomicReference<>();
 
     private final List<Consumer<VersionedKeySet>> jwtListeners = new CopyOnWriteArrayList<>();
-    private final List<Consumer<VersionedKeySet>> masterKeyListeners = new CopyOnWriteArrayList<>();
 
     private ScheduledExecutorService scheduler;
 
@@ -63,9 +60,6 @@ public class PlatformSecretsService {
 
         if (properties.getJwtSigningKeysPath() != null) {
             jwtSigningKeys.set(loadFile(properties.getJwtSigningKeysPath()));
-        }
-        if (properties.getSecretStorageMasterKeysPath() != null) {
-            secretStorageMasterKeys.set(loadFile(properties.getSecretStorageMasterKeysPath()));
         }
 
         scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
@@ -91,23 +85,13 @@ public class PlatformSecretsService {
         return loaded == null ? null : loaded.content();
     }
 
-    public VersionedKeySet getSecretStorageMasterKeys() {
-        Loaded loaded = secretStorageMasterKeys.get();
-        return loaded == null ? null : loaded.content();
-    }
-
     public void addJwtSigningKeysListener(Consumer<VersionedKeySet> listener) {
         jwtListeners.add(listener);
-    }
-
-    public void addSecretStorageMasterKeysListener(Consumer<VersionedKeySet> listener) {
-        masterKeyListeners.add(listener);
     }
 
     private void poll() {
         try {
             reloadIfChanged(jwtSigningKeys, jwtListeners);
-            reloadIfChanged(secretStorageMasterKeys, masterKeyListeners);
         } catch (Exception e) {
             log.error("Platform secrets poll failed", e);
         }

--- a/kinotic-server/src/main/java/org/kinotic/server/config/DevPlatformSecretsGenerator.java
+++ b/kinotic-server/src/main/java/org/kinotic/server/config/DevPlatformSecretsGenerator.java
@@ -43,7 +43,6 @@ public class DevPlatformSecretsGenerator implements PlatformSecretsBootstrap {
     public void ensureFilesExist() {
         PlatformSecretsProperties props = kinoticProperties.getPlatformSecrets();
         ensureFile(props.getJwtSigningKeysPath(), "JWT signing keys");
-        ensureFile(props.getSecretStorageMasterKeysPath(), "secret-storage master keys");
     }
 
     private void ensureFile(Path path, String label) {

--- a/kinotic-server/src/main/resources/application-development.yml
+++ b/kinotic-server/src/main/resources/application-development.yml
@@ -26,13 +26,15 @@ kinotic:
     # which the IDE has but the Paketo bootBuildImage's JRE base does not. Compose layers
     # on the `compose` profile to flip this back to in-memory; see application-compose.yml.
     backend: ~
+    # Base64-encoded 32-byte key used by SecretNameDeriver to derive opaque, deterministic
+    # storage names. Dev-only value — production supplies this via Azure Key Vault.
+    masterKey: 0qWH2oHEp27LLD7iBHEiABqJFf1q5GRYK6OdMc5Wdv4=
   platformSecrets:
     # Auto-seeded on first boot by DevPlatformSecretsGenerator (dev profile only). Each
     # developer machine ends up with its own random keys; none of this is committed.
     # Production uses Azure Key Vault via the Secrets Store CSI driver — same file layout,
     # different origin.
     jwtSigningKeysPath: ${user.home}/.kinotic/dev-platform-secrets/jwt-signing-keys
-    secretStorageMasterKeysPath: ${user.home}/.kinotic/dev-platform-secrets/secret-storage-master-keys
   # OIDC client secrets resolve via SecretReferenceResolver — Azure Key Vault when
   # kinotic.secretStorage.azure.vaultUrl is set, otherwise from KINOTIC_AKV_<name> env vars
   # (uppercased, non-alphanumerics → "_"). For local dev, export the env var matching the


### PR DESCRIPTION
## Summary
Removes the secret-storage master key loading and rotation infrastructure from `PlatformSecretsService`. The master key is now supplied directly via configuration (`kinotic.secretStorage.masterKey`) rather than being managed as a rotatable platform secret.

## Key Changes
- **PlatformSecretsService**: Removed `secretStorageMasterKeys` atomic reference, `masterKeyListeners` list, and related methods (`getSecretStorageMasterKeys()`, `addSecretStorageMasterKeysListener()`)
- **PlatformSecretsService**: Removed master key file polling logic from the `poll()` method
- **PlatformSecretsService**: Updated class-level documentation to remove references to master key usage
- **PlatformSecretsProperties**: Removed `secretStorageMasterKeysPath` configuration property and its documentation
- **application-development.yml**: 
  - Added `kinotic.secretStorage.masterKey` configuration with a base64-encoded 32-byte key
  - Removed `platformSecrets.secretStorageMasterKeysPath` configuration
  - Added clarifying comments about master key sourcing (dev vs. production)
- **DevPlatformSecretsGenerator**: Removed the file existence check for secret-storage master keys

## Implementation Details
The master key is now a static configuration value rather than a rotatable secret file. In development, it's provided directly in `application-development.yml`. In production, it's supplied via Azure Key Vault through the existing secret resolution mechanism (`SecretReferenceResolver`), not through the platform secrets polling system.

https://claude.ai/code/session_01KCxvXp7VUvQSDBmcH3AkzP