### PR TITLE
Remove baseUrl from TypeScript app configuration

### DIFF
--- a/kinotic-frontend/tsconfig.app.json
+++ b/kinotic-frontend/tsconfig.app.json
@@ -2,7 +2,6 @@
   "extends": "@vue/tsconfig/tsconfig.dom.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "baseUrl": ".",
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
## Summary
Removed the `baseUrl` compiler option from the TypeScript application configuration file.

## Changes
- Removed `"baseUrl": "."` from `tsconfig.app.json`

## Details
The `baseUrl` option in TypeScript's compiler options was set to the current directory (`.`), which allows for non-relative module imports. Removing this configuration simplifies the TypeScript setup and may encourage more explicit relative imports or path aliases for better code clarity and maintainability.

https://claude.ai/code/session_01KCxvXp7VUvQSDBmcH3AkzP