### PR TITLE
Enable Gradle build cache and parallel builds

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - develop
       - main
-      - monoRepoRefactoring
-      - 2.x
     paths-ignore:
       - 'helm/**'
       - 'docker-compose/**'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,8 @@
 kinoticVersion=4.2.0-SNAPSHOT
 
+org.gradle.caching=true
+org.gradle.parallel=true
+
 allureVersion=2.33.0
 antlrVersion=4.13.1
 aspectJVersion=1.9.25.1


### PR DESCRIPTION
Turns on org.gradle.caching and org.gradle.parallel in gradle.properties.
The gradle/actions/setup-gradle@v4 action already persists the Gradle
user home across CI runs, so enabling the local build cache is sufficient
to get cross-run caching in GitHub Actions as well.