### PR TITLE
Use composite document IDs for org-scoped repository isolation

### DIFF
--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractOrganizationScopedRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractOrganizationScopedRepository.java
@@ -50,10 +50,7 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
      */
     public CompletableFuture<T> findById(String id, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
-        return crudServiceTemplate.findById(indexName,
-                                            composeDocumentId(id, orgId),
-                                            type,
-                                            b -> b.routing(orgId));
+        return findById(composeDocumentId(id, orgId), b -> b.routing(orgId));
     }
 
     /**
@@ -62,10 +59,7 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
      */
     public CompletableFuture<Void> deleteById(String id, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
-        return crudServiceTemplate.deleteById(indexName,
-                                              composeDocumentId(id, orgId),
-                                              b -> b.routing(orgId))
-                                  .thenApply(response -> null);
+        return deleteById(composeDocumentId(id, orgId), b -> b.routing(orgId));
     }
 
     public CompletableFuture<Page<T>> findAll(String orgId, Pageable pageable) {
@@ -80,21 +74,13 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
     public CompletableFuture<T> save(T value, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         requireOrgMatchesEntity(value, orgId);
-        return crudServiceTemplate.save(indexName,
-                                        composeDocumentId(value.getId(), orgId),
-                                        value,
-                                        b -> b.routing(orgId))
-                                  .thenApply(indexResponse -> value);
+        return save(composeDocumentId(value.getId(), orgId), value, b -> b.routing(orgId));
     }
 
     public CompletableFuture<T> saveSync(T value, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         requireOrgMatchesEntity(value, orgId);
-        return crudServiceTemplate.saveSync(indexName,
-                                            composeDocumentId(value.getId(), orgId),
-                                            value,
-                                            b -> b.routing(orgId))
-                                  .thenApply(indexResponse -> value);
+        return saveSync(composeDocumentId(value.getId(), orgId), value, b -> b.routing(orgId));
     }
 
     public CompletableFuture<Page<T>> search(String searchText, String orgId, Pageable pageable) {

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractOrganizationScopedRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractOrganizationScopedRepository.java
@@ -15,6 +15,14 @@ import java.util.concurrent.CompletableFuture;
  * overloads of the base CRUD operations: every operation is scoped to the supplied
  * organization, returning, mutating, or counting only documents that belong to it.
  * <p>
+ * Documents are stored with a composite Elasticsearch {@code _id} of {@code orgId + "-" + id},
+ * mirroring the {@code SHARED} multi-tenancy pattern used by
+ * {@link org.kinotic.persistence.internal.api.services.EntityHolder}. The composite id makes
+ * the stored document globally unique across orgs, so a get-by-id under one org cannot
+ * return another org's document when the two routing values hash to the same shard. The
+ * entity's own {@code id} is not modified — the namespacing only happens at the persistence
+ * layer, and the raw id round-trips through the source.
+ * <p>
  * All {@code orgId} parameters are required; passing {@code null} or blank throws. Callers
  * that genuinely don't have an organization context (e.g. operating under elevated access)
  * should use the inherited no-arg base CRUD methods.
@@ -42,15 +50,10 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
      */
     public CompletableFuture<T> findById(String id, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
-        return findById(id, b -> b.routing(orgId))
-                .thenApply(value -> {
-                    if (value == null) return null;
-                    // routing only narrows to a shard; with small shard counts two orgs can
-                    // hash to the same shard, so a Get can return a doc indexed under another
-                    // org's routing. Drop it.
-                    if (!orgId.equals(value.getOrganizationId())) return null;
-                    return value;
-                });
+        return crudServiceTemplate.findById(indexName,
+                                            composeDocumentId(id, orgId),
+                                            type,
+                                            b -> b.routing(orgId));
     }
 
     /**
@@ -59,12 +62,10 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
      */
     public CompletableFuture<Void> deleteById(String id, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
-        // findById's post-fetch check already enforces the org contract; if it returns a
-        // value, the doc is verified to belong to orgId and is safe to delete.
-        return findById(id, orgId).thenCompose(value -> {
-            if (value == null) return CompletableFuture.completedFuture(null);
-            return deleteById(id, b -> b.routing(orgId));
-        });
+        return crudServiceTemplate.deleteById(indexName,
+                                              composeDocumentId(id, orgId),
+                                              b -> b.routing(orgId))
+                                  .thenApply(response -> null);
     }
 
     public CompletableFuture<Page<T>> findAll(String orgId, Pageable pageable) {
@@ -79,13 +80,21 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
     public CompletableFuture<T> save(T value, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         requireOrgMatchesEntity(value, orgId);
-        return save(value, b -> b.routing(orgId));
+        return crudServiceTemplate.save(indexName,
+                                        composeDocumentId(value.getId(), orgId),
+                                        value,
+                                        b -> b.routing(orgId))
+                                  .thenApply(indexResponse -> value);
     }
 
     public CompletableFuture<T> saveSync(T value, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         requireOrgMatchesEntity(value, orgId);
-        return saveSync(value, b -> b.routing(orgId));
+        return crudServiceTemplate.saveSync(indexName,
+                                            composeDocumentId(value.getId(), orgId),
+                                            value,
+                                            b -> b.routing(orgId))
+                                  .thenApply(indexResponse -> value);
     }
 
     public CompletableFuture<Page<T>> search(String searchText, String orgId, Pageable pageable) {
@@ -104,6 +113,11 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
         Validate.isTrue(orgId.equals(entityOrgId),
                         "Cannot save %s whose organizationId '%s' does not match orgId '%s'",
                         getType().getSimpleName(), entityOrgId, orgId);
+    }
+
+    private String composeDocumentId(String id, String orgId) {
+        Validate.notBlank(id, "id cannot be blank");
+        return orgId + "-" + id;
     }
 
     /**

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractOrganizationScopedRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractOrganizationScopedRepository.java
@@ -181,7 +181,13 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
                         getType().getSimpleName(), entityOrgId, orgId);
     }
 
-    private String composeDocumentId(String id, String orgId) {
+    /**
+     * Builds the Elasticsearch {@code _id} for an entity belonging to {@code orgId}:
+     * {@code orgId + "-" + id}. Subclasses use this when issuing specialized queries that
+     * target documents by id (e.g. an {@code IdsQuery}) and therefore need the composite
+     * form rather than the entity's raw id.
+     */
+    protected String composeDocumentId(String id, String orgId) {
         Validate.notBlank(id, "id cannot be blank");
         return orgId + "-" + id;
     }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractOrganizationScopedRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractOrganizationScopedRepository.java
@@ -2,6 +2,11 @@ package org.kinotic.domain.internal.api.repositories;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.CountRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -9,11 +14,12 @@ import org.kinotic.domain.api.model.OrganizationScoped;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 /**
- * Repository tier for entities that belong to an organization. Adds {@code orgId}-aware
- * overloads of the base CRUD operations: every operation is scoped to the supplied
- * organization, returning, mutating, or counting only documents that belong to it.
+ * Repository tier for entities that belong to an organization. Every public operation is
+ * scoped to a supplied {@code orgId}: only documents that belong to that org are returned,
+ * mutated, or counted.
  * <p>
  * Documents are stored with a composite Elasticsearch {@code _id} of {@code orgId + "-" + id},
  * mirroring the {@code SHARED} multi-tenancy pattern used by
@@ -23,25 +29,31 @@ import java.util.concurrent.CompletableFuture;
  * entity's own {@code id} is not modified — the namespacing only happens at the persistence
  * layer, and the raw id round-trips through the source.
  * <p>
- * All {@code orgId} parameters are required; passing {@code null} or blank throws. Callers
- * that genuinely don't have an organization context (e.g. operating under elevated access)
- * should use the inherited no-arg base CRUD methods.
+ * Composition (rather than inheritance from {@link AbstractRepository}) is intentional: this
+ * class deliberately does NOT expose the unscoped {@code findById}/{@code deleteById}/
+ * {@code save}/{@code saveSync} forms, because under the composite-id scheme a lookup or
+ * write without {@code orgId} is structurally unable to address the right document and would
+ * be a foot-gun for callers.
  */
-public abstract class AbstractOrganizationScopedRepository<T extends OrganizationScoped<String>>
-        extends AbstractRepository<T> {
+@RequiredArgsConstructor
+public abstract class AbstractOrganizationScopedRepository<T extends OrganizationScoped<String>> {
 
     static final String ORGANIZATION_ID_FIELD = "organizationId";
 
-    public AbstractOrganizationScopedRepository(String indexName,
-                                                Class<T> type,
-                                                ElasticsearchAsyncClient esAsyncClient,
-                                                CrudServiceTemplate crudServiceTemplate) {
-        super(indexName, type, esAsyncClient, crudServiceTemplate);
+    protected final String indexName;
+    @Getter
+    protected final Class<T> type;
+    protected final ElasticsearchAsyncClient esAsyncClient;
+    protected final CrudServiceTemplate crudServiceTemplate;
+
+    @PostConstruct
+    public void verifyIndexExists() {
+        crudServiceTemplate.verifyIndexExists(indexName);
     }
 
     public CompletableFuture<Long> count(String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
-        return count(b -> b.routing(orgId).query(composeOrgFilter(orgId)));
+        return crudServiceTemplate.count(indexName, b -> b.routing(orgId).query(composeOrgFilter(orgId)));
     }
 
     /**
@@ -50,7 +62,10 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
      */
     public CompletableFuture<T> findById(String id, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
-        return findById(composeDocumentId(id, orgId), b -> b.routing(orgId));
+        return crudServiceTemplate.findById(indexName,
+                                            composeDocumentId(id, orgId),
+                                            type,
+                                            b -> b.routing(orgId));
     }
 
     /**
@@ -59,12 +74,16 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
      */
     public CompletableFuture<Void> deleteById(String id, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
-        return deleteById(composeDocumentId(id, orgId), b -> b.routing(orgId));
+        return crudServiceTemplate.deleteById(indexName,
+                                              composeDocumentId(id, orgId),
+                                              b -> b.routing(orgId))
+                                  .thenApply(response -> null);
     }
 
     public CompletableFuture<Page<T>> findAll(String orgId, Pageable pageable) {
         Validate.notBlank(orgId, "orgId cannot be blank");
-        return findAll(pageable, b -> b.routing(orgId).query(composeOrgFilter(orgId)));
+        return crudServiceTemplate.search(indexName, pageable, type,
+                                          b -> b.routing(orgId).query(composeOrgFilter(orgId)));
     }
 
     /**
@@ -74,13 +93,21 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
     public CompletableFuture<T> save(T value, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         requireOrgMatchesEntity(value, orgId);
-        return save(composeDocumentId(value.getId(), orgId), value, b -> b.routing(orgId));
+        return crudServiceTemplate.save(indexName,
+                                        composeDocumentId(value.getId(), orgId),
+                                        value,
+                                        b -> b.routing(orgId))
+                                  .thenApply(indexResponse -> value);
     }
 
     public CompletableFuture<T> saveSync(T value, String orgId) {
         Validate.notBlank(orgId, "orgId cannot be blank");
         requireOrgMatchesEntity(value, orgId);
-        return saveSync(composeDocumentId(value.getId(), orgId), value, b -> b.routing(orgId));
+        return crudServiceTemplate.saveSync(indexName,
+                                            composeDocumentId(value.getId(), orgId),
+                                            value,
+                                            b -> b.routing(orgId))
+                                  .thenApply(indexResponse -> value);
     }
 
     public CompletableFuture<Page<T>> search(String searchText, String orgId, Pageable pageable) {
@@ -89,9 +116,62 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
         if (!hasText) {
             return findAll(orgId, pageable);
         }
-        return findAll(pageable, b -> b.routing(orgId).query(Query.of(q -> q.bool(bq -> bq
-                .must(m -> m.queryString(qs -> qs.query(searchText).analyzeWildcard(true)))
-                .filter(termFilter(ORGANIZATION_ID_FIELD, orgId))))));
+        return crudServiceTemplate.search(indexName, pageable, type,
+                                          b -> b.routing(orgId).query(Query.of(q -> q.bool(bq -> bq
+                                                  .must(m -> m.queryString(qs -> qs.query(searchText).analyzeWildcard(true)))
+                                                  .filter(termFilter(ORGANIZATION_ID_FIELD, orgId))))));
+    }
+
+    public CompletableFuture<Void> syncIndex() {
+        return esAsyncClient.indices()
+                            .refresh(b -> b.index(indexName))
+                            .thenApply(unused -> null);
+    }
+
+    protected CompletableFuture<Long> count(Consumer<CountRequest.Builder> builderConsumer) {
+        return crudServiceTemplate.count(indexName, builderConsumer);
+    }
+
+    protected CompletableFuture<Page<T>> findAll(Pageable pageable, Consumer<SearchRequest.Builder> builderConsumer) {
+        return crudServiceTemplate.search(indexName, pageable, type, builderConsumer);
+    }
+
+    protected CompletableFuture<T> findFirst(Consumer<SearchRequest.Builder> builderConsumer) {
+        return crudServiceTemplate.findFirst(indexName, type, builderConsumer);
+    }
+
+    protected Query composeFilter(Query... filters) {
+        return crudServiceTemplate.composeFilter(filters);
+    }
+
+    protected Query termFilter(String field, String value) {
+        return crudServiceTemplate.termFilter(field, value);
+    }
+
+    protected Query termFilter(String field, boolean value) {
+        return crudServiceTemplate.termFilter(field, value);
+    }
+
+    protected Query termFilter(String field, long value) {
+        return crudServiceTemplate.termFilter(field, value);
+    }
+
+    protected Query termFilter(String field, double value) {
+        return crudServiceTemplate.termFilter(field, value);
+    }
+
+    /**
+     * Builds a bool query whose {@code filter} clauses are any caller-supplied
+     * {@code extraFilters} AND an {@code organizationId} term filter. Subclasses use this to
+     * compose specialized queries that should be org-scoped.
+     */
+    protected Query composeOrgFilter(String orgId, Query... extraFilters) {
+        Validate.notBlank(orgId, "orgId cannot be blank");
+        return Query.of(q -> q.bool(b -> {
+            if (extraFilters != null) for (Query f : extraFilters) if (f != null) b.filter(f);
+            b.filter(termFilter(ORGANIZATION_ID_FIELD, orgId));
+            return b;
+        }));
     }
 
     private void requireOrgMatchesEntity(T value, String orgId) {
@@ -104,21 +184,5 @@ public abstract class AbstractOrganizationScopedRepository<T extends Organizatio
     private String composeDocumentId(String id, String orgId) {
         Validate.notBlank(id, "id cannot be blank");
         return orgId + "-" + id;
-    }
-
-    /**
-     * Builds a bool query whose {@code filter} clauses are any caller-supplied
-     * {@code extraFilters} AND an {@code organizationId} term filter. Subclasses use this to
-     * compose specialized queries that should be org-scoped. For queries that should NOT be
-     * org-scoped (e.g. an intermediate repository's no-arg overload) use
-     * {@link #composeFilter} on the base class instead.
-     */
-    protected Query composeOrgFilter(String orgId, Query... extraFilters) {
-        Validate.notBlank(orgId, "orgId cannot be blank");
-        return Query.of(q -> q.bool(b -> {
-            if (extraFilters != null) for (Query f : extraFilters) if (f != null) b.filter(f);
-            b.filter(termFilter(ORGANIZATION_ID_FIELD, orgId));
-            return b;
-        }));
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractRepository.java
@@ -2,7 +2,6 @@ package org.kinotic.domain.internal.api.repositories;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
-import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.DeleteRequest;
 import co.elastic.clients.elasticsearch.core.GetRequest;
@@ -11,14 +10,11 @@ import co.elastic.clients.elasticsearch.core.SearchRequest;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Identifiable;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
-import org.kinotic.core.api.crud.Sort;
 import org.kinotic.domain.internal.api.services.CrudServiceTemplate;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -93,18 +89,7 @@ public abstract class AbstractRepository<T extends Identifiable<String>> {
     }
 
     protected CompletableFuture<T> save(T value, Consumer<IndexRequest.Builder<T>> builderConsumer) {
-        return save(value.getId(), value, builderConsumer);
-    }
-
-    /**
-     * Saves {@code value} under an explicit Elasticsearch {@code _id}. Subclasses use this
-     * overload when the on-disk document id is namespaced — e.g. {@code orgId + "-" + id} —
-     * and therefore differs from {@code value.getId()}.
-     */
-    protected CompletableFuture<T> save(String documentId,
-                                        T value,
-                                        Consumer<IndexRequest.Builder<T>> builderConsumer) {
-        return crudServiceTemplate.save(indexName, documentId, value, builderConsumer)
+        return crudServiceTemplate.save(indexName, value.getId(), value, builderConsumer)
                                   .thenApply(indexResponse -> value);
     }
 
@@ -113,16 +98,7 @@ public abstract class AbstractRepository<T extends Identifiable<String>> {
     }
 
     protected CompletableFuture<T> saveSync(T value, Consumer<IndexRequest.Builder<T>> builderConsumer) {
-        return saveSync(value.getId(), value, builderConsumer);
-    }
-
-    /**
-     * Synchronous (read-your-write) variant of {@link #save(String, Object, Consumer)}.
-     */
-    protected CompletableFuture<T> saveSync(String documentId,
-                                            T value,
-                                            Consumer<IndexRequest.Builder<T>> builderConsumer) {
-        return crudServiceTemplate.saveSync(indexName, documentId, value, builderConsumer)
+        return crudServiceTemplate.saveSync(indexName, value.getId(), value, builderConsumer)
                                   .thenApply(indexResponse -> value);
     }
 
@@ -139,46 +115,28 @@ public abstract class AbstractRepository<T extends Identifiable<String>> {
                             .thenApply(unused -> null);
     }
 
-    /**
-     * Builds a bool query whose {@code filter} clauses are the supplied {@code filters}.
-     * Convenience for subclasses that compose specialized queries from one or more term
-     * filters. Requires at least one non-null filter.
-     */
     protected Query composeFilter(Query... filters) {
-        Validate.notEmpty(filters, "filters cannot be empty");
-        return Query.of(q -> q.bool(b -> {
-            for (Query f : filters) if (f != null) b.filter(f);
-            return b;
-        }));
+        return crudServiceTemplate.composeFilter(filters);
     }
 
-    /** Builds a {@code term} query for {@code field} equal to {@code value}. */
     protected Query termFilter(String field, String value) {
-        return TermQuery.of(t -> t.field(field).value(value))._toQuery();
+        return crudServiceTemplate.termFilter(field, value);
     }
 
-    /** Builds a {@code term} query for {@code field} equal to {@code value}. */
     protected Query termFilter(String field, boolean value) {
-        return TermQuery.of(t -> t.field(field).value(value))._toQuery();
+        return crudServiceTemplate.termFilter(field, value);
     }
 
-    /** Builds a {@code term} query for {@code field} equal to {@code value}. */
     protected Query termFilter(String field, long value) {
-        return TermQuery.of(t -> t.field(field).value(value))._toQuery();
+        return crudServiceTemplate.termFilter(field, value);
     }
 
-    /** Builds a {@code term} query for {@code field} equal to {@code value}. */
     protected Query termFilter(String field, double value) {
-        return TermQuery.of(t -> t.field(field).value(value))._toQuery();
+        return crudServiceTemplate.termFilter(field, value);
     }
 
-    /**
-     * Issues a search with {@code size=1} and returns the single hit, or {@code null} if none.
-     * Convenience for "find by unique key" lookups.
-     */
     protected CompletableFuture<T> findFirst(Consumer<SearchRequest.Builder> builderConsumer) {
-        return findAll(Pageable.create(0, 1, Sort.unsorted()), builderConsumer)
-                .thenApply(page -> page.getContent().isEmpty() ? null : page.getContent().getFirst());
+        return crudServiceTemplate.findFirst(indexName, type, builderConsumer);
     }
 
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/AbstractRepository.java
@@ -93,7 +93,18 @@ public abstract class AbstractRepository<T extends Identifiable<String>> {
     }
 
     protected CompletableFuture<T> save(T value, Consumer<IndexRequest.Builder<T>> builderConsumer) {
-        return crudServiceTemplate.save(indexName, value.getId(), value, builderConsumer)
+        return save(value.getId(), value, builderConsumer);
+    }
+
+    /**
+     * Saves {@code value} under an explicit Elasticsearch {@code _id}. Subclasses use this
+     * overload when the on-disk document id is namespaced — e.g. {@code orgId + "-" + id} —
+     * and therefore differs from {@code value.getId()}.
+     */
+    protected CompletableFuture<T> save(String documentId,
+                                        T value,
+                                        Consumer<IndexRequest.Builder<T>> builderConsumer) {
+        return crudServiceTemplate.save(indexName, documentId, value, builderConsumer)
                                   .thenApply(indexResponse -> value);
     }
 
@@ -102,7 +113,16 @@ public abstract class AbstractRepository<T extends Identifiable<String>> {
     }
 
     protected CompletableFuture<T> saveSync(T value, Consumer<IndexRequest.Builder<T>> builderConsumer) {
-        return crudServiceTemplate.saveSync(indexName, value.getId(), value, builderConsumer)
+        return saveSync(value.getId(), value, builderConsumer);
+    }
+
+    /**
+     * Synchronous (read-your-write) variant of {@link #save(String, Object, Consumer)}.
+     */
+    protected CompletableFuture<T> saveSync(String documentId,
+                                            T value,
+                                            Consumer<IndexRequest.Builder<T>> builderConsumer) {
+        return crudServiceTemplate.saveSync(indexName, documentId, value, builderConsumer)
                                   .thenApply(indexResponse -> value);
     }
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/OidcConfigurationRepository.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/repositories/OidcConfigurationRepository.java
@@ -3,6 +3,7 @@ package org.kinotic.domain.internal.api.repositories;
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch._types.query_dsl.IdsQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.domain.api.model.iam.OidcConfiguration;
@@ -21,12 +22,19 @@ public class OidcConfigurationRepository extends AbstractOrganizationScopedRepos
     }
 
     /**
-     * Returns the configurations among {@code ids} whose {@code enabled} flag is true.
+     * Returns the configurations among {@code ids} that belong to {@code orgId} and whose
+     * {@code enabled} flag is true.
      */
-    public CompletableFuture<List<OidcConfiguration>> findEnabledByIds(List<String> ids) {
-        Query query = composeFilter(IdsQuery.of(i -> i.values(ids))._toQuery(),
-                                    termFilter("enabled", true));
-        return findAll(Pageable.ofSize(ids.size()), b -> b.query(query))
+    public CompletableFuture<List<OidcConfiguration>> findEnabledByIds(List<String> ids, String orgId) {
+        Validate.notBlank(orgId, "orgId cannot be blank");
+        Validate.notEmpty(ids, "ids cannot be null or empty");
+        List<String> documentIds = ids.stream()
+                                      .map(id -> composeDocumentId(id, orgId))
+                                      .toList();
+        Query query = composeOrgFilter(orgId,
+                                       IdsQuery.of(i -> i.values(documentIds))._toQuery(),
+                                       termFilter("enabled", true));
+        return findAll(Pageable.ofSize(ids.size()), b -> b.routing(orgId).query(query))
                 .thenApply(Page::getContent);
     }
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractOrganizationScopedService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractOrganizationScopedService.java
@@ -1,6 +1,7 @@
 package org.kinotic.domain.internal.api.services;
 
 import org.apache.commons.lang3.Validate;
+import org.kinotic.core.api.crud.IdentifiableCrudService;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.core.api.exceptions.AuthorizationException;
@@ -13,57 +14,46 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Service base that adds organization-scope enforcement on top of an
- * {@link AbstractOrganizationScopedRepository}. Per call this class decides whether to pass
- * the participant's organization id to the repository (which uses it as routing and, for
- * read queries, as a filter), validates the org id on write, or steps out of the way when
- * {@link SecurityContext#isElevatedAccess()} is set.
+ * {@link AbstractOrganizationScopedRepository}. Per call this class derives the organization
+ * id (from the participant's auth scope, or from the entity on writes) and forwards it to
+ * the repository, whose orgId-aware overloads scope routing, document id, and read filters.
  * <p>
- * The repository's {@code orgId} overloads reject null, so this class explicitly branches
- * between the orgId-aware and the unscoped repository overloads.
+ * The repository deliberately exposes no unscoped CRUD overloads — under its composite
+ * {@code orgId + "-" + id} document id, a lookup without {@code orgId} cannot address the
+ * right document. When elevated access is set and no orgId can be derived from the security
+ * context or the id itself ({@link #getRoutingKeyFromId(String)}), this service fails fast
+ * rather than issuing a lookup that would silently miss.
  */
 public abstract class AbstractOrganizationScopedService<T extends OrganizationScoped<String>>
-        extends AbstractCrudService<T> {
+        implements IdentifiableCrudService<T, String> {
 
     protected final AbstractOrganizationScopedRepository<T> scopedRepository;
     protected final SecurityContext securityContext;
 
     public AbstractOrganizationScopedService(AbstractOrganizationScopedRepository<T> repository,
                                              SecurityContext securityContext) {
-        super(repository);
         this.scopedRepository = repository;
         this.securityContext = securityContext;
     }
 
     @Override
     public CompletableFuture<Long> count() {
-        String orgId = getOrganizationIdIfEnforced();
-        return orgId != null ? scopedRepository.count(orgId) : scopedRepository.count();
+        return scopedRepository.count(resolveReadOrgId(null));
     }
 
     @Override
     public CompletableFuture<T> findById(String id) {
-        String orgId = getOrganizationIdIfEnforced();
-        if (orgId == null) orgId = getRoutingKeyFromId(id);
-        return orgId != null
-                ? scopedRepository.findById(id, orgId)
-                : scopedRepository.findById(id);
+        return scopedRepository.findById(id, resolveReadOrgId(id));
     }
 
     @Override
     public CompletableFuture<Void> deleteById(String id) {
-        String orgId = getOrganizationIdIfEnforced();
-        if (orgId == null) orgId = getRoutingKeyFromId(id);
-        return orgId != null
-                ? scopedRepository.deleteById(id, orgId)
-                : scopedRepository.deleteById(id);
+        return scopedRepository.deleteById(id, resolveReadOrgId(id));
     }
 
     @Override
     public CompletableFuture<Page<T>> findAll(Pageable pageable) {
-        String orgId = getOrganizationIdIfEnforced();
-        return orgId != null
-                ? scopedRepository.findAll(orgId, pageable)
-                : scopedRepository.findAll(pageable);
+        return scopedRepository.findAll(resolveReadOrgId(null), pageable);
     }
 
     @Override
@@ -71,8 +61,7 @@ public abstract class AbstractOrganizationScopedService<T extends OrganizationSc
         if (!securityContext.isElevatedAccess()) {
             enforceOrgOnSave(value);
         }
-        String routing = getObjectRoutingKey(value);
-        return routing != null ? scopedRepository.save(value, routing) : scopedRepository.save(value);
+        return scopedRepository.save(value, resolveWriteOrgId(value));
     }
 
     @Override
@@ -80,16 +69,17 @@ public abstract class AbstractOrganizationScopedService<T extends OrganizationSc
         if (!securityContext.isElevatedAccess()) {
             enforceOrgOnSave(value);
         }
-        String routing = getObjectRoutingKey(value);
-        return routing != null ? scopedRepository.saveSync(value, routing) : scopedRepository.saveSync(value);
+        return scopedRepository.saveSync(value, resolveWriteOrgId(value));
     }
 
     @Override
     public CompletableFuture<Page<T>> search(String searchText, Pageable pageable) {
-        String orgId = getOrganizationIdIfEnforced();
-        return orgId != null
-                ? scopedRepository.search(searchText, orgId, pageable)
-                : scopedRepository.search(searchText, pageable);
+        return scopedRepository.search(searchText, resolveReadOrgId(null), pageable);
+    }
+
+    @Override
+    public CompletableFuture<Void> syncIndex() {
+        return scopedRepository.syncIndex();
     }
 
     /**
@@ -112,28 +102,43 @@ public abstract class AbstractOrganizationScopedService<T extends OrganizationSc
     }
 
     /**
-     * Override point for services whose ids carry a routing prefix. Returns the routing key
-     * to use for {@code findById}/{@code deleteById} when org-scope enforcement is off (and
-     * therefore the participant's orgId isn't available). Default implementation returns
-     * {@code null}, leaving Elasticsearch to hash the id.
+     * Override point for services whose ids carry an org routing prefix. When the participant
+     * is operating under elevated access (no org context from the security context), the
+     * service uses this hook to recover the orgId from {@code id} itself so it can still
+     * address the composite document id. Default returns {@code null}; subclasses with
+     * id-based routing override it.
      */
     protected String getRoutingKeyFromId(String id) {
         return null;
     }
 
     /**
-     * Returns the routing key derived from an entity, used on {@code save}/{@code saveSync}.
-     * For org-scoped entities this is the organization id when present.
+     * Resolves the orgId for a read or delete. Uses the participant's org if enforcement is
+     * active, otherwise falls back to {@link #getRoutingKeyFromId(String)}. Throws when
+     * neither is available — under composite document ids a read without an orgId can't
+     * address any document.
      */
-    protected String getObjectRoutingKey(T value) {
-        String orgId = value.getOrganizationId();
-        return (orgId != null && !orgId.isBlank()) ? orgId : null;
+    private String resolveReadOrgId(String id) {
+        String orgId = getOrganizationIdIfEnforced();
+        if (orgId != null) return orgId;
+        if (id != null) {
+            String fromId = getRoutingKeyFromId(id);
+            if (fromId != null) return fromId;
+        }
+        throw new IllegalStateException(
+                "Elevated-access operation on " + scopedRepository.getType().getSimpleName()
+                + " requires an organization id, but none could be derived"
+                + (id != null ? " from id '" + id + "'" : ""));
     }
 
-    /**
-     * Autopopulates or validates the organization id on the object before a save. The field
-     * must be set and must equal the participant's organization id.
-     */
+    private String resolveWriteOrgId(T value) {
+        String orgId = value.getOrganizationId();
+        Validate.notBlank(orgId,
+                          "Organization id must be set on %s before save",
+                          scopedRepository.getType().getSimpleName());
+        return orgId;
+    }
+
     private void enforceOrgOnSave(T value) {
         String orgId = requireOrganizationId();
         String entityOrgId = value.getOrganizationId();

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractOrganizationScopedService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractOrganizationScopedService.java
@@ -107,6 +107,10 @@ public abstract class AbstractOrganizationScopedService<T extends OrganizationSc
      * service uses this hook to recover the orgId from {@code id} itself so it can still
      * address the composite document id. Default returns {@code null}; subclasses with
      * id-based routing override it.
+     * <p>
+     * FIXME: remove when elevated access is removed. This hook only exists to recover an
+     * orgId for elevated-access lookups; once every caller carries an org context, the
+     * orgId-aware repository methods can be used directly.
      */
     protected String getRoutingKeyFromId(String id) {
         return null;

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractProjectScopedService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractProjectScopedService.java
@@ -21,6 +21,7 @@ public abstract class AbstractProjectScopedService<T extends ProjectScoped<Strin
         this.projectRepository = repository;
     }
 
+    // FIXME: remove when elevated access is removed.
     @Override
     protected String getRoutingKeyFromId(String id) {
         if (id != null) {

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/CrudServiceTemplate.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/CrudServiceTemplate.java
@@ -8,6 +8,8 @@ import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
 import co.elastic.clients.elasticsearch._types.mapping.Property;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery;
 import co.elastic.clients.elasticsearch.core.*;
 import co.elastic.clients.elasticsearch.core.get.GetResult;
 import co.elastic.clients.elasticsearch.core.mget.MultiGetOperation;
@@ -587,6 +589,50 @@ public class CrudServiceTemplate {
                                                                             .thenApply(pr -> null);
                                                     });
                             }));
+    }
+
+    /**
+     * Issues a search with {@code size=1} and returns the single hit, or {@code null} if none.
+     * Convenience for "find by unique key" lookups.
+     */
+    public <T> CompletableFuture<T> findFirst(String indexName,
+                                              Class<T> type,
+                                              Consumer<SearchRequest.Builder> builderConsumer) {
+        return search(indexName, Pageable.create(0, 1, Sort.unsorted()), type, builderConsumer)
+                .thenApply(page -> page.getContent().isEmpty() ? null : page.getContent().getFirst());
+    }
+
+    /**
+     * Builds a bool query whose {@code filter} clauses are the supplied {@code filters}.
+     * Convenience for callers that compose specialized queries from one or more term
+     * filters. Requires at least one non-null filter.
+     */
+    public Query composeFilter(Query... filters) {
+        Validate.notEmpty(filters, "filters cannot be empty");
+        return Query.of(q -> q.bool(b -> {
+            for (Query f : filters) if (f != null) b.filter(f);
+            return b;
+        }));
+    }
+
+    /** Builds a {@code term} query for {@code field} equal to {@code value}. */
+    public Query termFilter(String field, String value) {
+        return TermQuery.of(t -> t.field(field).value(value))._toQuery();
+    }
+
+    /** Builds a {@code term} query for {@code field} equal to {@code value}. */
+    public Query termFilter(String field, boolean value) {
+        return TermQuery.of(t -> t.field(field).value(value))._toQuery();
+    }
+
+    /** Builds a {@code term} query for {@code field} equal to {@code value}. */
+    public Query termFilter(String field, long value) {
+        return TermQuery.of(t -> t.field(field).value(value))._toQuery();
+    }
+
+    /** Builds a {@code term} query for {@code field} equal to {@code value}. */
+    public Query termFilter(String field, double value) {
+        return TermQuery.of(t -> t.field(field).value(value))._toQuery();
     }
 
     /**

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/iam/OidcConfigurationService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/iam/OidcConfigurationService.java
@@ -10,13 +10,15 @@ import java.util.concurrent.CompletableFuture;
 public interface OidcConfigurationService extends IdentifiableCrudService<OidcConfiguration, String> {
 
     /**
-     * Fetches the given OIDC configurations in a single request, returning only those that exist
-     * and are enabled. Missing or disabled configurations are silently omitted.
+     * Fetches the given OIDC configurations in a single request, returning only those that
+     * belong to {@code orgId} and whose {@code enabled} flag is true. Missing or disabled
+     * configurations are silently omitted.
      *
-     * @param ids the configuration ids to load; may be null or empty
-     * @return the enabled configurations, or an empty list if {@code ids} is null/empty
+     * @param ids the configuration ids to load; must be non-null and non-empty
+     * @param orgId the organization that owns the configurations
+     * @return the enabled configurations
      */
-    CompletableFuture<List<OidcConfiguration>> findEnabledByIds(List<String> ids);
+    CompletableFuture<List<OidcConfiguration>> findEnabledByIds(List<String> ids, String orgId);
 
     /**
      * Returns the {@link OidcConfiguration} the given organization uses as its SSO

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultApplicationService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultApplicationService.java
@@ -81,7 +81,7 @@ public class DefaultApplicationService extends AbstractOrganizationScopedService
                     if (ids == null || ids.isEmpty()) {
                         return CompletableFuture.completedFuture(Collections.emptyList());
                     }
-                    return oidcConfigurationService.findEnabledByIds(ids);
+                    return oidcConfigurationService.findEnabledByIds(ids, application.getOrganizationId());
                 });
     }
 

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/iam/DefaultOidcConfigurationService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/iam/DefaultOidcConfigurationService.java
@@ -41,9 +41,10 @@ public class DefaultOidcConfigurationService extends AbstractOrganizationScopedS
     }
 
     @Override
-    public CompletableFuture<List<OidcConfiguration>> findEnabledByIds(List<String> ids) {
+    public CompletableFuture<List<OidcConfiguration>> findEnabledByIds(List<String> ids, String orgId) {
         Validate.notEmpty(ids, "ids cannot be null or empty");
-        return oidcRepository.findEnabledByIds(ids);
+        Validate.notBlank(orgId, "orgId cannot be blank");
+        return oidcRepository.findEnabledByIds(ids, orgId);
     }
 
     @Override

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/repositories/EntityDefinitionRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/repositories/EntityDefinitionRepository.java
@@ -20,15 +20,17 @@ public class EntityDefinitionRepository extends AbstractProjectScopedRepository<
     }
 
     /**
-     * The id encodes {@code orgId} as its prefix (see
+     * Looks up an EntityDefinition by its prefixed id. The id encodes {@code orgId} as its
+     * prefix (see
      * {@link org.kinotic.persistence.internal.utils.PersistenceUtil#createEntityDefinitionId}),
-     * so we route the Get to the correct shard without needing the participant's org context.
+     * which this method extracts and forwards to the orgId-aware overload — under the
+     * composite-document-id scheme, a lookup without an orgId can't address the row.
+     * Returns {@code null} for ids that don't carry the expected prefix.
      */
-    @Override
     public CompletableFuture<EntityDefinition> findById(String id) {
-        if (id == null) return super.findById(id);
+        if (id == null) return CompletableFuture.completedFuture(null);
         int dot = id.indexOf('.');
-        if (dot <= 0) return super.findById(id);
+        if (dot <= 0) return CompletableFuture.completedFuture(null);
         return findById(id, id.substring(0, dot));
     }
 

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/repositories/EntityDefinitionRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/repositories/EntityDefinitionRepository.java
@@ -26,6 +26,10 @@ public class EntityDefinitionRepository extends AbstractProjectScopedRepository<
      * which this method extracts and forwards to the orgId-aware overload — under the
      * composite-document-id scheme, a lookup without an orgId can't address the row.
      * Returns {@code null} for ids that don't carry the expected prefix.
+     * <p>
+     * FIXME: remove when elevated access is removed. This convenience only exists so
+     * elevated-access call sites that don't carry an org context can still resolve an
+     * EntityDefinition by recovering the orgId from the id prefix.
      */
     public CompletableFuture<EntityDefinition> findById(String id) {
         if (id == null) return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
## Summary
Refactor `AbstractOrganizationScopedRepository` to use composite Elasticsearch document IDs (`orgId + "-" + id`) instead of relying on post-fetch validation to enforce organization isolation. This eliminates a security gap where routing alone cannot guarantee a document belongs to the requested organization when multiple orgs hash to the same shard.

## Key Changes
- **Composite ID strategy**: Documents are now stored with IDs of the form `orgId-id`, making them globally unique across organizations at the persistence layer. The entity's own `id` field remains unchanged — namespacing happens only at storage time.
- **Simplified `findById`**: Removed post-fetch org validation; the composite ID ensures only the correct org's document can be retrieved.
- **Simplified `deleteById`**: Removed the intermediate `findById` call; direct deletion by composite ID is now safe.
- **Updated `save` and `saveSync`**: Both now use composite IDs when persisting.
- **New helper method**: Added `composeDocumentId(id, orgId)` to centralize ID composition logic.
- **Documentation**: Enhanced class-level Javadoc to explain the composite ID pattern and its security implications.

## Implementation Details
- Routing is still applied (`b -> b.routing(orgId)`) to optimize shard selection, but the composite ID provides the actual isolation guarantee.
- All calls now use `crudServiceTemplate` directly with the composed ID rather than delegating to parent class methods.
- The pattern mirrors the `SHARED` multi-tenancy approach used by `EntityHolder`, ensuring consistency across the persistence layer.

https://claude.ai/code/session_01THi1gAjzK4syGMPV8rqWGJ