### PR TITLE
Add environment-specific migration selection

### DIFF
--- a/kinotic-migration/src/main/java/org/kinotic/migration/MigrationInitializer.java
+++ b/kinotic-migration/src/main/java/org/kinotic/migration/MigrationInitializer.java
@@ -7,9 +7,11 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.Set;
 
 /**
  * Starts the migration process when the application is ready.
@@ -22,10 +24,13 @@ public class MigrationInitializer {
     private final MigrationExecutor migrationExecutor;
     private final MigrationParser migrationParser;
     private final ApplicationContext applicationContext;
+    private final Environment springEnvironment;
 
     @EventListener
     public void onApplicationReadyEvent(ApplicationReadyEvent event) throws IOException {
-        SystemMigrator systemMigrator = new SystemMigrator(migrationExecutor, migrationParser);
+        SystemMigrator systemMigrator = new SystemMigrator(migrationExecutor,
+                                                           migrationParser,
+                                                           Set.of(springEnvironment.getActiveProfiles()));
         systemMigrator.execute();
 
         ((ConfigurableApplicationContext) applicationContext).close();

--- a/kinotic-migration/src/main/java/org/kinotic/migration/SystemMigrator.java
+++ b/kinotic-migration/src/main/java/org/kinotic/migration/SystemMigrator.java
@@ -9,7 +9,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Loads system migrations from the filesystem and applies them after the Elasticsearch client is configured
@@ -21,10 +25,17 @@ public class SystemMigrator {
 
     private final MigrationExecutor migrationExecutor;
     private final MigrationParser migrationParser;
+    private final Set<String> activeEnvironments;
 
-    public SystemMigrator(MigrationExecutor migrationExecutor, MigrationParser migrationParser) {
+    public SystemMigrator(MigrationExecutor migrationExecutor,
+                          MigrationParser migrationParser,
+                          Collection<String> activeEnvironments) {
         this.migrationExecutor = migrationExecutor;
         this.migrationParser = migrationParser;
+        this.activeEnvironments = activeEnvironments.stream()
+                                                    .filter(e -> e != null && !e.isBlank())
+                                                    .map(e -> e.trim().toLowerCase(Locale.ROOT))
+                                                    .collect(Collectors.toUnmodifiableSet());
     }
 
     public void execute() {
@@ -43,26 +54,22 @@ public class SystemMigrator {
 
             log.info("Found {} system migration files", resources.length);
 
-            // Get the last applied migration version for the system project
-            Integer lastAppliedVersion = migrationExecutor.getLastAppliedMigrationVersion(MigrationExecutor.SYSTEM_PROJECT).get();
-
-            // Load only migrations that need to be applied
+            // Select migrations applicable to the active environments; the executor's per-version check handles idempotency.
             List<Migration> migrationsToApply = new java.util.ArrayList<>();
             for (Resource resource : resources) {
                 Migration migration = new ResourceMigration(resource, migrationParser);
-                if (lastAppliedVersion == null || migration.getVersion() > lastAppliedVersion) {
+                if (appliesToActiveEnvironments(migration)) {
                     migrationsToApply.add(migration);
                 }
             }
 
             if (migrationsToApply.isEmpty()) {
-                log.info("All system migrations are already applied (last applied version: {})", lastAppliedVersion);
+                log.info("No system migrations apply to the active environments {}", activeEnvironments);
                 return;
             }
 
-            log.info("Applying {} new system migrations (starting from version {})",
-                     migrationsToApply.size(),
-                     lastAppliedVersion != null ? lastAppliedVersion + 1 : "1");
+            log.info("Applying {} candidate system migrations for active environments {}",
+                     migrationsToApply.size(), activeEnvironments);
 
             migrationExecutor.executeSystemMigrations(migrationsToApply).get();
             log.info("System migrations processing complete");
@@ -71,5 +78,13 @@ public class SystemMigrator {
             throw new IllegalStateException("Failed to initialize system migrations", e);
         }
     }
-    
+
+    boolean appliesToActiveEnvironments(Migration migration) {
+        Set<String> environments = migration.getEnvironments();
+        if (environments.isEmpty()) {
+            return true;
+        }
+        return environments.stream().anyMatch(activeEnvironments::contains);
+    }
+
 }

--- a/kinotic-migration/src/test/java/org/kinotic/migration/SystemMigratorTest.java
+++ b/kinotic-migration/src/test/java/org/kinotic/migration/SystemMigratorTest.java
@@ -1,0 +1,71 @@
+package org.kinotic.migration;
+
+import org.junit.jupiter.api.Test;
+import org.kinotic.sql.domain.Migration;
+import org.kinotic.sql.domain.MigrationContent;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies environment-based migration selection in {@link SystemMigrator}.
+ */
+class SystemMigratorTest {
+
+    private static SystemMigrator migrator(String... activeProfiles) {
+        return new SystemMigrator(null, null, List.of(activeProfiles));
+    }
+
+    private static Migration withEnvironments(Set<String> environments) {
+        return new Migration() {
+            @Override
+            public Integer getVersion() {
+                return 1;
+            }
+
+            @Override
+            public String getName() {
+                return "test";
+            }
+
+            @Override
+            public MigrationContent getContent() {
+                return new MigrationContent(List.of());
+            }
+
+            @Override
+            public Set<String> getEnvironments() {
+                return environments;
+            }
+        };
+    }
+
+    @Test
+    void commonMigrationAlwaysApplies() {
+        assertTrue(migrator("production").appliesToActiveEnvironments(withEnvironments(Set.of())));
+        assertTrue(migrator().appliesToActiveEnvironments(withEnvironments(Set.of())));
+    }
+
+    @Test
+    void matchingProfileApplies() {
+        assertTrue(migrator("test").appliesToActiveEnvironments(withEnvironments(Set.of("dev", "test"))));
+    }
+
+    @Test
+    void nonMatchingProfileDoesNotApply() {
+        assertFalse(migrator("production").appliesToActiveEnvironments(withEnvironments(Set.of("dev", "test"))));
+    }
+
+    @Test
+    void environmentTaggedMigrationSkippedWhenNoActiveProfiles() {
+        assertFalse(migrator().appliesToActiveEnvironments(withEnvironments(Set.of("dev"))));
+    }
+
+    @Test
+    void profileMatchingIsCaseInsensitive() {
+        assertTrue(migrator("TEST").appliesToActiveEnvironments(withEnvironments(Set.of("test"))));
+    }
+}

--- a/kinotic-sql/src/main/java/org/kinotic/sql/domain/Migration.java
+++ b/kinotic-sql/src/main/java/org/kinotic/sql/domain/Migration.java
@@ -1,5 +1,8 @@
 package org.kinotic.sql.domain;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * Represents a migration file abstraction for the migration system.
  * <p>
@@ -26,4 +29,14 @@ public interface Migration {
      * @return the parsed MigrationContent object for this migration. May be lazily loaded or parsed.
      */
     MigrationContent getContent();
+
+    /**
+     * The set of environments this migration applies to. An empty set means the migration is common
+     * and applies to every environment.
+     *
+     * @return the environments this migration applies to, or an empty set if it applies to all environments
+     */
+    default Set<String> getEnvironments() {
+        return Collections.emptySet();
+    }
 } 

--- a/kinotic-sql/src/main/java/org/kinotic/sql/domain/ResourceMigration.java
+++ b/kinotic-sql/src/main/java/org/kinotic/sql/domain/ResourceMigration.java
@@ -3,6 +3,11 @@ package org.kinotic.sql.domain;
 import org.kinotic.sql.parsers.MigrationParser;
 import org.springframework.core.io.Resource;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
 /**
  * Migration implementation backed by a Spring Resource.
  * <p>
@@ -14,6 +19,7 @@ public class ResourceMigration implements Migration {
     private final MigrationParser parser;
     private final int version;
     private final String name;
+    private final Set<String> environments;
     private MigrationContent content;
 
     public ResourceMigration(Resource resource, MigrationParser parser) {
@@ -21,6 +27,7 @@ public class ResourceMigration implements Migration {
         this.parser = parser;
         this.name = resource.getFilename();
         this.version = extractVersionFromFilename(name);
+        this.environments = extractEnvironmentsFromFilename(name);
     }
 
     @Override
@@ -31,6 +38,11 @@ public class ResourceMigration implements Migration {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public Set<String> getEnvironments() {
+        return environments;
     }
 
     @Override
@@ -57,5 +69,25 @@ public class ResourceMigration implements Migration {
             }
         }
         throw new IllegalArgumentException("Invalid migration filename format: " + filename);
+    }
+
+    private Set<String> extractEnvironmentsFromFilename(String filename) {
+        if (filename == null) throw new IllegalArgumentException("Migration filename is null");
+        if (!filename.toLowerCase(Locale.ROOT).endsWith(".sql")) {
+            throw new IllegalArgumentException("Invalid migration filename format: " + filename);
+        }
+        int idx = filename.indexOf("__");
+        // The portion after the description segment ("V<n>__<description>") holds the optional, dot-delimited environment tokens.
+        String afterDescription = filename.substring(idx + 2, filename.length() - ".sql".length());
+        String[] tokens = afterDescription.split("\\.");
+        Set<String> result = new LinkedHashSet<>();
+        // The first token is the description; everything after it is an environment. Blank tokens (e.g. a double dot) are ignored.
+        for (int i = 1; i < tokens.length; i++) {
+            String env = tokens[i].trim().toLowerCase(Locale.ROOT);
+            if (!env.isEmpty()) {
+                result.add(env);
+            }
+        }
+        return Collections.unmodifiableSet(result);
     }
 } 

--- a/kinotic-sql/src/test/java/org/kinotic/sql/domain/MigrationTest.java
+++ b/kinotic-sql/src/test/java/org/kinotic/sql/domain/MigrationTest.java
@@ -1,0 +1,32 @@
+package org.kinotic.sql.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the default contract of the {@link Migration} interface.
+ */
+class MigrationTest {
+
+    @Test
+    void getEnvironmentsDefaultsToEmpty() {
+        Migration migration = new Migration() {
+            @Override
+            public Integer getVersion() {
+                return 1;
+            }
+
+            @Override
+            public String getName() {
+                return "V1__init.sql";
+            }
+
+            @Override
+            public MigrationContent getContent() {
+                return new MigrationContent(java.util.List.of());
+            }
+        };
+        assertTrue(migration.getEnvironments().isEmpty());
+    }
+}

--- a/kinotic-sql/src/test/java/org/kinotic/sql/domain/ResourceMigrationTest.java
+++ b/kinotic-sql/src/test/java/org/kinotic/sql/domain/ResourceMigrationTest.java
@@ -1,0 +1,69 @@
+package org.kinotic.sql.domain;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies version and environment extraction from migration filenames.
+ */
+class ResourceMigrationTest {
+
+    private static Resource named(String filename) {
+        return new ByteArrayResource(new byte[0]) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        };
+    }
+
+    private static ResourceMigration migration(String filename) {
+        return new ResourceMigration(named(filename), null);
+    }
+
+    @Test
+    void commonMigrationHasNoEnvironments() {
+        ResourceMigration migration = migration("V1__init.sql");
+        assertEquals(1, migration.getVersion());
+        assertTrue(migration.getEnvironments().isEmpty());
+    }
+
+    @Test
+    void multipleEnvironmentsParsed() {
+        ResourceMigration migration = migration("V3__kinotic_test_users.dev.test.sql");
+        assertEquals(3, migration.getVersion());
+        assertEquals(Set.of("dev", "test"), migration.getEnvironments());
+    }
+
+    @Test
+    void environmentTokensNormalizedToLowercase() {
+        assertEquals(Set.of("prod"), migration("V10__x.PROD.sql").getEnvironments());
+    }
+
+    @Test
+    void underscoresInDescriptionAreNotEnvironments() {
+        assertTrue(migration("V5__a_b_c.sql").getEnvironments().isEmpty());
+    }
+
+    @Test
+    void blankEnvironmentTokensAreIgnored() {
+        assertEquals(Set.of("dev"), migration("V3__x..dev.sql").getEnvironments());
+    }
+
+    @Test
+    void versionUnaffectedByEnvironmentTokens() {
+        assertEquals(3, migration("V3__x.dev.test.sql").getVersion());
+    }
+
+    @Test
+    void missingSqlSuffixThrows() {
+        assertThrows(IllegalArgumentException.class, () -> migration("V1__init.txt"));
+    }
+}


### PR DESCRIPTION
Migration files can declare the environments they apply to via dot-delimited
tokens in the filename: V<version>__<description>[.<env>...].sql. A file with
no env tokens is common and runs in every environment; a file with tokens runs
only when one of those tokens matches an active Spring profile.

- Migration interface gains a default getEnvironments() returning an empty set
  (empty = applies to all environments), keeping existing implementors source
  compatible.
- ResourceMigration parses the environment tokens from the filename, normalizing
  to lowercase and ignoring blank tokens. Version parsing is unchanged.
- SystemMigrator takes the active environments and keeps a migration when it is
  common or intersects the active set. The version high-water-mark gate is
  removed; the executor's per-version idempotency check is the source of truth,
  which is required once environment filtering can change which versions are
  present across runs.
- MigrationInitializer sources the active environments from the active Spring
  profiles (Environment.getActiveProfiles()).

Adds unit tests for filename parsing, the interface default, and the selection
predicate.