### PR TITLE
Reduce table row height and simplify published status cell layout

### DIFF
--- a/kinotic-frontend/src/components/CrudTable.vue
+++ b/kinotic-frontend/src/components/CrudTable.vue
@@ -158,7 +158,7 @@ class CrudTable extends Vue {
       },
       bodyCell: {
         class: [
-          'bg-transparent px-[14px] py-4 text-sm align-middle',
+          'bg-transparent px-[14px] py-2 text-sm align-middle',
           this.isDark ? 'border-surface-700 text-surface-200' : 'border-surface-200 text-surface-950'
         ]
       },
@@ -468,14 +468,14 @@ export default toNative(CrudTable);
               <template #body="slotProps">
                 <div
                   v-if="col.centered"
-                  class="flex items-center justify-center w-full min-h-[64px]"
+                  class="flex items-center justify-center w-full min-h-[48px]"
                 >
                   <slot :name="`item.${col.field}`" :item="slotProps.data">
                     {{ slotProps.data[col.field] }}
                   </slot>
                 </div>
                 <template v-else>
-                  <div class="flex min-h-[64px] items-center">
+                  <div class="flex min-h-[48px] items-center">
                     <slot :name="`item.${col.field}`" :item="slotProps.data">
                       {{ slotProps.data[col.field] }}
                     </slot>
@@ -486,7 +486,7 @@ export default toNative(CrudTable);
 
             <Column v-if="editable || $slots['additional-actions']" header="">
               <template #body="slotProps">
-                <div class="flex min-h-[64px] w-full items-center justify-center">
+                <div class="flex min-h-[48px] w-full items-center justify-center">
                   <slot name="additional-actions" :item="slotProps.data" />
                 </div>
               </template>

--- a/kinotic-frontend/src/components/EntityListOld.vue
+++ b/kinotic-frontend/src/components/EntityListOld.vue
@@ -231,7 +231,7 @@ export default EntityList
   </div>
 </template>
 <style>
-.p-datatable .p-button {
+.entity-list-old .p-datatable .p-button {
   margin-top: 1rem;
 }
 .p-toolbar-start {

--- a/kinotic-frontend/src/components/ProjectStructuresTable.vue
+++ b/kinotic-frontend/src/components/ProjectStructuresTable.vue
@@ -343,14 +343,12 @@ export default class ProjectStructuresTable extends Vue {
         </span>
       </template>
       <template #item.published="{ item }">
-        <div class="w-full h-full min-h-[64px] flex items-center justify-center text-center">
-          <Tag
-            :value="item.published ? 'Published' : 'Unpublished'"
-            :severity="item.published ? 'success' : 'secondary'"
-            class="px-2 py-1 text-sm"
-            rounded
-          />
-        </div>
+        <Tag
+          :value="item.published ? 'Published' : 'Unpublished'"
+          :severity="item.published ? 'success' : 'secondary'"
+          class="px-2 py-1 text-sm"
+          rounded
+        />
       </template>
       <template #item.description="{ item }">
         <span>{{ item.description }}</span>

--- a/kinotic-frontend/src/components/StructuresList.vue
+++ b/kinotic-frontend/src/components/StructuresList.vue
@@ -291,14 +291,12 @@ export default defineComponent({
       </template>
 
       <template #item.published="{ item }">
-        <div class="w-full h-full min-h-[64px] flex items-center justify-center text-center">
-          <Tag
-            :value="item.published ? 'Published' : 'Unpublished'"
-            :severity="item.published ? 'success' : 'secondary'"
-            class="px-2 py-1 text-sm"
-            rounded
-          />
-        </div>
+        <Tag
+          :value="item.published ? 'Published' : 'Unpublished'"
+          :severity="item.published ? 'success' : 'secondary'"
+          class="px-2 py-1 text-sm"
+          rounded
+        />
       </template>
       <template #additional-actions="{ item }">
         <div class="flex items-center justify-center">


### PR DESCRIPTION
## Summary
Reduces vertical padding in table cells and simplifies the markup for the published status column across multiple table components. These changes improve visual density and remove unnecessary wrapper divs.

## Key Changes
- **CrudTable.vue**: Reduced `bodyCell` vertical padding from `py-4` to `py-2` and decreased minimum row heights from `64px` to `48px` for both centered and non-centered columns, plus the additional-actions column
- **ProjectStructuresTable.vue**: Removed wrapper div with centering classes from the published status cell template, keeping only the Tag component
- **StructuresList.vue**: Removed wrapper div with centering classes from the published status cell template, keeping only the Tag component
- **EntityListOld.vue**: Scoped the `.p-datatable .p-button` CSS rule to `.entity-list-old` to prevent unintended style leakage

## Implementation Details
The published status cells previously used a full-height wrapper div (`min-h-[64px]`) with flexbox centering. Since the Tag component and table cell styling now handle alignment naturally with the reduced padding, the wrapper is redundant. The CSS scoping change in EntityListOld.vue prevents the button margin rule from affecting other datatable instances on the page.

https://claude.ai/code/session_01FLJHDSLj4AMXCDr1fvAiN2