### PR TITLE
Replace DataTable loading template with CSS-based loading indicator

### DIFF
--- a/kinotic-frontend/components.d.ts
+++ b/kinotic-frontend/components.d.ts
@@ -42,7 +42,6 @@ declare module 'vue' {
     Paginator: typeof import('primevue/paginator')['default']
     Password: typeof import('primevue/password')['default']
     Popover: typeof import('primevue/popover')['default']
-    ProgressBar: typeof import('primevue/progressbar')['default']
     ProjectList: typeof import('./src/components/ProjectList.vue')['default']
     ProjectStructuresTable: typeof import('./src/components/ProjectStructuresTable.vue')['default']
     PropertyType: typeof import('./src/components/structures/flow-components/PropertyType.vue')['default']

--- a/kinotic-frontend/components.d.ts
+++ b/kinotic-frontend/components.d.ts
@@ -42,6 +42,7 @@ declare module 'vue' {
     Paginator: typeof import('primevue/paginator')['default']
     Password: typeof import('primevue/password')['default']
     Popover: typeof import('primevue/popover')['default']
+    ProgressBar: typeof import('primevue/progressbar')['default']
     ProjectList: typeof import('./src/components/ProjectList.vue')['default']
     ProjectStructuresTable: typeof import('./src/components/ProjectStructuresTable.vue')['default']
     PropertyType: typeof import('./src/components/structures/flow-components/PropertyType.vue')['default']

--- a/kinotic-frontend/src/components/CrudTable.vue
+++ b/kinotic-frontend/src/components/CrudTable.vue
@@ -17,6 +17,7 @@ import ConfirmDialog from "primevue/confirmdialog";
 import Card from "primevue/card";
 import Paginator, { type PageState } from "primevue/paginator";
 import SelectButton from "primevue/selectbutton";
+import ProgressBar from "primevue/progressbar";
 import { useToast } from "primevue/usetoast";
 
 import {
@@ -47,6 +48,7 @@ const debug = createDebug('crud-table');
     Card,
     Paginator,
     SelectButton,
+    ProgressBar,
   },
 })
 class CrudTable extends Vue {
@@ -443,15 +445,19 @@ export default toNative(CrudTable);
       <div v-if="isBurgerView" class="flex flex-1 flex-col">
         <div
           :class="[
-            'crud-table__table-shell flex flex-1 flex-col rounded-[14px] border px-4 py-2 transition-colors',
+            'crud-table__table-shell relative flex flex-1 flex-col overflow-hidden rounded-[14px] border px-4 py-2 transition-colors',
             isDark ? 'border-surface-700 bg-transparent text-surface-0 shadow-[0_0_0_1px_rgba(58,58,64,0.15)]' : 'border-surface-200 bg-transparent text-surface-950'
           ]"
         >
+          <ProgressBar
+            v-if="loading"
+            class="crud-table__loading-bar"
+            mode="indeterminate"
+          />
           <DataTable
             class="crud-table__datatable"
             :pt="dataTablePt"
             :value="items"
-            :loading="loading"
             dataKey="id"
             @row-click="onRowClick"
             sortMode="multiple"
@@ -491,13 +497,6 @@ export default toNative(CrudTable);
                 </div>
               </template>
             </Column>
-            <template #loading>
-              <div
-                :class="['flex h-full w-full items-center justify-center py-20', isDark ? 'bg-transparent text-surface-400' : 'bg-transparent text-surface-500']"
-              >
-                <i class="pi pi-spin pi-spinner text-2xl text-primary" />
-              </div>
-            </template>
           </DataTable>
 
           <!-- Filler between the rows and the bottom border: absorbs leftover shell height
@@ -526,6 +525,17 @@ export default toNative(CrudTable);
 </template>
 
 <style>
+/* Pinned to the shell's top edge; the shell's overflow-hidden clips it to the rounded corners. */
+.crud-table__loading-bar.p-progressbar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  border-radius: 0;
+  background: transparent;
+}
+
 .p-datatable-paginator-bottom {
   border: none !important;
   box-shadow: none !important;

--- a/kinotic-frontend/src/components/CrudTable.vue
+++ b/kinotic-frontend/src/components/CrudTable.vue
@@ -17,7 +17,6 @@ import ConfirmDialog from "primevue/confirmdialog";
 import Card from "primevue/card";
 import Paginator, { type PageState } from "primevue/paginator";
 import SelectButton from "primevue/selectbutton";
-import ProgressBar from "primevue/progressbar";
 import { useToast } from "primevue/usetoast";
 
 import {
@@ -48,7 +47,6 @@ const debug = createDebug('crud-table');
     Card,
     Paginator,
     SelectButton,
-    ProgressBar,
   },
 })
 class CrudTable extends Vue {
@@ -445,17 +443,12 @@ export default toNative(CrudTable);
       <div v-if="isBurgerView" class="flex flex-1 flex-col">
         <div
           :class="[
-            'crud-table__table-shell relative flex flex-1 flex-col overflow-hidden rounded-[14px] border px-4 py-2 transition-colors',
+            'crud-table__table-shell flex flex-1 flex-col rounded-[14px] border px-4 py-2 transition-colors',
             isDark ? 'border-surface-700 bg-transparent text-surface-0 shadow-[0_0_0_1px_rgba(58,58,64,0.15)]' : 'border-surface-200 bg-transparent text-surface-950'
           ]"
         >
-          <ProgressBar
-            v-if="loading"
-            class="crud-table__loading-bar"
-            mode="indeterminate"
-          />
           <DataTable
-            class="crud-table__datatable"
+            :class="['crud-table__datatable', { 'crud-table__datatable--loading': loading }]"
             :pt="dataTablePt"
             :value="items"
             dataKey="id"
@@ -525,15 +518,31 @@ export default toNative(CrudTable);
 </template>
 
 <style>
-/* Pinned to the shell's top edge; the shell's overflow-hidden clips it to the rounded corners. */
-.crud-table__loading-bar.p-progressbar {
+/* While loading, an indeterminate line overlays the header row's bottom divider. */
+.crud-table__datatable--loading .p-datatable-thead {
+  position: relative;
+}
+
+.crud-table__datatable--loading .p-datatable-thead::after {
+  content: "";
   position: absolute;
-  top: 0;
   left: 0;
   right: 0;
+  bottom: 0;
   height: 3px;
-  border-radius: 0;
-  background: transparent;
+  background: linear-gradient(90deg, transparent, var(--p-primary-500), transparent);
+  background-size: 40% 100%;
+  background-repeat: no-repeat;
+  animation: crud-table-loading-slide 1.2s ease-in-out infinite;
+}
+
+@keyframes crud-table-loading-slide {
+  0% {
+    background-position: -100% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
 }
 
 .p-datatable-paginator-bottom {


### PR DESCRIPTION
## Summary
Replaces the DataTable's loading template (spinner overlay) with a CSS-based indeterminate progress line that animates across the table header's bottom border. This provides a more subtle loading state indicator while maintaining visual feedback.

## Changes
- Removed the `#loading` template from DataTable that displayed a centered spinner overlay
- Removed the `:loading` prop binding from DataTable
- Added conditional CSS class `crud-table__datatable--loading` to DataTable based on loading state
- Implemented CSS-based loading indicator:
  - Pseudo-element (`::after`) on the table header that displays an animated gradient line
  - Gradient slides horizontally across the header's bottom border using `crud-table-loading-slide` keyframe animation
  - Animation runs continuously (1.2s cycle) while loading is active
  - Uses primary color (`--p-primary-500`) for visual consistency

## Implementation Details
The new approach uses a `::after` pseudo-element positioned absolutely on the table header with a linear gradient background that animates via `background-position`. This creates a smooth, non-intrusive loading indicator that doesn't obscure table content, unlike the previous centered spinner overlay.

https://claude.ai/code/session_01CfL3VwvdG233KbebvcBwRe