### PR TITLE
Delegate WebSocket factory to core's authenticated factory

### DIFF
--- a/kinotic-js/kinotic-cli/package.json
+++ b/kinotic-js/kinotic-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kinotic-ai/kinotic-cli",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "description": "Kinotic CLI provides the ability to build, deploy, and manage Kinotic applications that run on the Kinotic OS.",
     "author": "Kinotic Developers",
     "bin": {
@@ -18,7 +18,7 @@
     ],
     "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@kinotic-ai/core": "^1.7.0",
+        "@kinotic-ai/core": "^1.8.0",
         "@kinotic-ai/idl": "^1.0.9",
         "@kinotic-ai/os-api": "^1.11.0",
         "@kinotic-ai/persistence": "^1.4.0",

--- a/kinotic-js/kinotic-cli/src/internal/CliAuthenticator.ts
+++ b/kinotic-js/kinotic-cli/src/internal/CliAuthenticator.ts
@@ -1,8 +1,7 @@
-import {ConnectionInfo, IWebSocket, Kinotic} from '@kinotic-ai/core'
+import {BearerTokenAuthProvider, ConnectionInfo, createAuthenticatedWebSocketFactory, Kinotic} from '@kinotic-ai/core'
 import {confirm} from '@inquirer/prompts'
 import open from 'open'
 import pTimeout from 'p-timeout'
-import {WebSocket} from 'ws'
 import {createStateManager} from './state/IStateManager'
 import {Logger} from './Logger'
 
@@ -19,7 +18,6 @@ interface ServerTarget {
     port: number
     useSSL: boolean
     restBaseUrl: string
-    wsUrl: string
 }
 
 /** State key the rotating refresh token is persisted under, keyed by server url. */
@@ -90,14 +88,13 @@ export class CliAuthenticator {
             connectionInfo.host = target.host
             connectionInfo.port = target.port
             connectionInfo.useSSL = target.useSSL
-            // The CLI is a Node client: it attaches the access token as a WebSocket upgrade
-            // header. The factory is async so the token is refreshed before each (re)connect.
-            connectionInfo.webSocketFactory = async () => {
-                const token = await this.freshAccessToken(target.restBaseUrl)
-                return new WebSocket(target.wsUrl, {
-                    headers: {Authorization: 'Bearer ' + token}
-                }) as unknown as IWebSocket
-            }
+            // The CLI is a Node client: core builds the broker URL and attaches the bearer
+            // token as a WebSocket upgrade header. The supplier refreshes the access token
+            // before each (re)connect, since core consults the provider on every connect.
+            connectionInfo.webSocketFactory = createAuthenticatedWebSocketFactory(
+                {host: target.host, port: target.port, useSSL: target.useSSL},
+                new BearerTokenAuthProvider(() => this.freshAccessToken(target.restBaseUrl)),
+            )
 
             await pTimeout(Kinotic.connect(connectionInfo), {
                 milliseconds: 60000,
@@ -158,8 +155,7 @@ export class CliAuthenticator {
             host: url.hostname,
             port,
             useSSL,
-            restBaseUrl: (useSSL ? 'https' : 'http') + '://' + url.hostname + ':' + port,
-            wsUrl: (useSSL ? 'wss' : 'ws') + '://' + url.hostname + ':' + port + '/v1'
+            restBaseUrl: (useSSL ? 'https' : 'http') + '://' + url.hostname + ':' + port
         }
     }
 


### PR DESCRIPTION
Replace the CLI's manual WebSocket construction with core's `createAuthenticatedWebSocketFactory`, which handles broker URL building and bearer token attachment. This eliminates duplicate URL construction logic and leverages core's token refresh provider pattern.

**Changes:**

- Import `BearerTokenAuthProvider` and `createAuthenticatedWebSocketFactory` from `@kinotic-ai/core`
- Remove manual `WebSocket` import and construction from `CliAuthenticator.ts`
- Replace inline WebSocket factory with `createAuthenticatedWebSocketFactory()`, passing connection details and a `BearerTokenAuthProvider` that supplies fresh tokens on each connect
- Remove `wsUrl` field from `ServerTarget` interface; broker URL is now built by core
- Update `@kinotic-ai/core` dependency from `^1.7.0` to `^1.8.0`
- Bump package version to `2.4.1`

The token refresh supplier is now invoked by core on every (re)connect, eliminating the need for the CLI to manage WebSocket URL construction or token injection headers directly.

https://claude.ai/code/session_01Ea6CnoS2UtnXn1TBLXzC9u