### PR TITLE
Split Allure report publishing into separate job with gh-pages serialization

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -140,17 +140,19 @@ jobs:
         with:
           allure_results: allure-results
           gh_pages: gh-pages
-          subfolder: allure
+          subfolder: test-results
           allure_report: allure-report
           allure_history: allure-history
 
-      # Stable, crawler-safe entry point. /allure/ redirects to the newest run and is marked
+      # Stable, crawler-safe entry point. /test-results/ redirects to the newest run and is marked
       # noindex, so it is linkable from the site and README without exposing report pages to search
-      # engines — unlike a root redirect, a redirect this deep carries no homepage SEO cost.
+      # engines — unlike a root redirect, a redirect this deep carries no homepage SEO cost. The
+      # folder is named for the artifact (test-results), not the tool, so the public URL survives a
+      # future switch away from Allure.
       - name: Write latest-report redirect
         run: |
-          mkdir -p allure-history/allure
-          cat > allure-history/allure/index.html <<EOF
+          mkdir -p allure-history/test-results
+          cat > allure-history/test-results/index.html <<EOF
           <!doctype html>
           <html lang="en">
           <head>
@@ -179,4 +181,4 @@ jobs:
           description: 'Report published'
           state: 'success'
           sha: ${{ github.sha }}
-          target_url: https://kinotic.ai/allure/${{ github.run_number }}
+          target_url: https://kinotic.ai/test-results/${{ github.run_number }}

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -74,67 +74,109 @@ jobs:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
-#      - name: Run E2E Tests
-#        id: run_e2e_tests
-#        continue-on-error: true
-#        run: |
-#          cd structures-js/structures-e2e
-#          gradle pnpmInstall
-#          gradle pnpmTest
-#
-#      - name: Merge Test Results
-#        run: |
-#          mkdir -p allure-results
-#          cp -r */build/allure-results/* allure-results/ || true
-#          cp -r structures-js/*/allure-results/* allure-results/ || true
-#
-#      - name: Get Allure history
-#        uses: actions/checkout@v4
-#        continue-on-error: true
-#        with:
-#          ref: gh-pages
-#          path: gh-pages
-#
-#      - name: Generate Allure report
-#        uses: simple-elf/allure-report-action@v1.13
-#        id: allure-report
-#        with:
-#          allure_results: allure-results
-#          gh_pages: gh-pages
-#          subfolder: allure
-#          allure_report: allure-report
-#          allure_history: allure-history
-#
-#      - name: Deploy report to Github Pages
-#        uses: peaceiris/actions-gh-pages@v4
-#        with:
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          publish_dir: allure-history
-#          publish_branch: gh-pages
-#          keep_files: true
-#
-#      - name: Add status to Commit
-#        uses: guibranco/github-status-action-v2@v1.1.13
-#        with:
-#          authToken: ${{ secrets.GITHUB_TOKEN }}
-#          context: 'Test Report'
-#          description: 'Passed'
-#          state: 'success'
-#          sha: ${{ github.sha }}
-#          target_url: https://kinotic-ai.github.io/kinotic/allure/${{ github.run_number }}
-#
-#      - name: Check If Failure
-#        if: ${{ steps.gradle_build.outcome == 'failure' || steps.run_e2e_tests.outcome == 'failure' }}
-#        run: |
-#          if [ "${{ steps.gradle_build.outcome }}" == "failure" ]; then
-#            echo "Gradle Build failed."
-#          fi
-#
-#          if [ "${{ steps.run_e2e_tests.outcome }}" == "failure" ]; then
-#            echo "E2E Tests failed."
-#          fi
-#
-#          # Optionally mark the job as failed
-#          exit 1
-#
-#          https://kinoitc-ai.github.io/kinotic/webdocs/guide/overview.html
+      - name: Run E2E Tests
+        id: run_e2e_tests
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: |
+          cd kinotic-js/e2e-tests
+          gradle pnpmInstall
+          gradle pnpmTest
+
+      # Aggregate Allure results from every module into one directory: the Java suites (allure-junit5)
+      # and the JS e2e suite (allure-vitest) each write their own allure-results. Find them wherever
+      # they land, skipping node_modules and the aggregate directory itself.
+      - name: Merge Test Results
+        if: ${{ !cancelled() }}
+        run: |
+          mkdir -p allure-results
+          find . -type d -name allure-results \
+               -not -path './allure-results' \
+               -not -path '*/node_modules/*' -print0 \
+          | while IFS= read -r -d '' dir; do
+              cp -a "$dir/." allure-results/ 2>/dev/null || true
+            done
+
+      # Hand the merged results to the publish_test_report job, which runs on a separate runner.
+      - name: Upload Allure results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-results
+          path: allure-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Publishing the Allure report is split into its own job so the gh-pages serialization
+  # (concurrency below) covers only the gh-pages push, not the heavy build/publish job above —
+  # which keeps its cancel-previous-run behavior. The shared group string couples this job with
+  # the website deploy in website-deploy.yml so the two never push to gh-pages concurrently.
+  publish_test_report:
+    name: Publish Allure Report
+    needs: gradle_build_and_publish
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Download Allure results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: allure-results
+          path: allure-results
+
+      - name: Get Allure history
+        uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Generate Allure report
+        uses: simple-elf/allure-report-action@v1.13
+        id: allure-report
+        with:
+          allure_results: allure-results
+          gh_pages: gh-pages
+          subfolder: allure
+          allure_report: allure-report
+          allure_history: allure-history
+
+      # Stable, crawler-safe entry point. /allure/ redirects to the newest run and is marked
+      # noindex, so it is linkable from the site and README without exposing report pages to search
+      # engines — unlike a root redirect, a redirect this deep carries no homepage SEO cost.
+      - name: Write latest-report redirect
+        run: |
+          mkdir -p allure-history/allure
+          cat > allure-history/allure/index.html <<EOF
+          <!doctype html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta name="robots" content="noindex">
+            <meta http-equiv="refresh" content="0; url=./${{ github.run_number }}/">
+            <title>Kinotic test reports</title>
+          </head>
+          <body>Redirecting to the latest <a href="./${{ github.run_number }}/">Allure report</a></body>
+          </html>
+          EOF
+
+      - name: Deploy report to Github Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: allure-history
+          publish_branch: gh-pages
+          keep_files: true
+
+      - name: Add status to Commit
+        uses: guibranco/github-status-action-v2@v1.1.13
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          context: 'Test Report'
+          description: 'Report published'
+          state: 'success'
+          sha: ${{ github.sha }}
+          target_url: https://kinotic.ai/allure/${{ github.run_number }}

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -8,6 +8,13 @@ on:
       - 'website/**'
   workflow_dispatch:
 
+# Shares the gh-pages-deploy group with gradle-build.yml's Allure deploy so the two never push to
+# gh-pages at the same time. Without this, an Allure push landing between the "Preserve existing
+# Allure reports" checkout and the keep_files:false deploy below would be wiped.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   build_and_deploy_website:
     runs-on: ubuntu-latest
@@ -28,6 +35,21 @@ jobs:
         run: |
           cd website
           bun run generate
+
+      # The deploy below uses keep_files:false, which replaces the whole gh-pages branch. Fold the
+      # existing /allure tree into the publish dir first so the clean wipe keeps Allure history while
+      # still deleting stale website files (removed routes, old hashed bundles).
+      - name: Preserve existing Allure reports
+        uses: actions/checkout@v4
+        continue-on-error: true   # gh-pages won't exist on the very first deploy
+        with:
+          ref: gh-pages
+          path: gh-pages-current
+      - name: Fold Allure reports into site output
+        run: |
+          if [ -d gh-pages-current/allure ]; then
+            cp -a gh-pages-current/allure website/.output/public/allure
+          fi
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -37,18 +37,18 @@ jobs:
           bun run generate
 
       # The deploy below uses keep_files:false, which replaces the whole gh-pages branch. Fold the
-      # existing /allure tree into the publish dir first so the clean wipe keeps Allure history while
-      # still deleting stale website files (removed routes, old hashed bundles).
-      - name: Preserve existing Allure reports
+      # existing /test-results tree into the publish dir first so the clean wipe keeps the report
+      # history while still deleting stale website files (removed routes, old hashed bundles).
+      - name: Preserve existing test reports
         uses: actions/checkout@v4
         continue-on-error: true   # gh-pages won't exist on the very first deploy
         with:
           ref: gh-pages
           path: gh-pages-current
-      - name: Fold Allure reports into site output
+      - name: Fold test reports into site output
         run: |
-          if [ -d gh-pages-current/allure ]; then
-            cp -a gh-pages-current/allure website/.output/public/allure
+          if [ -d gh-pages-current/test-results ]; then
+            cp -a gh-pages-current/test-results website/.output/public/test-results
           fi
 
       - name: Deploy to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ Kinotic OS isn't just a development platform; it is a **SaaS Launchpad**. Develo
 
 ---
 
+## ✅ Test Reports
+
+Every push to `develop` and `main` runs the Java and `kinotic-js/e2e-tests` suites and publishes an [Allure](https://allurereport.org/) report with full trend history:
+
+* **Latest report:** [kinotic.ai/allure](https://kinotic.ai/allure/)
+
+---
+
 ## 🤝 Contributing
 We welcome contributions, just create PR. 
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Kinotic OS isn't just a development platform; it is a **SaaS Launchpad**. Develo
 
 Every push to `develop` and `main` runs the Java and `kinotic-js/e2e-tests` suites and publishes an [Allure](https://allurereport.org/) report with full trend history:
 
-* **Latest report:** [kinotic.ai/allure](https://kinotic.ai/allure/)
+* **Latest report:** [kinotic.ai/test-results](https://kinotic.ai/test-results/)
 
 ---
 

--- a/website/app/components/Header.vue
+++ b/website/app/components/Header.vue
@@ -45,6 +45,7 @@ watch(isMenuOpen, (val) => {
 
         <div class="hidden items-center gap-8 lg:flex">
           <NuxtLink to="/apps/introduction" class="text-[14px] font-medium leading-[120%] text-white transition hover:opacity-80">Docs</NuxtLink>
+          <a href="/test-results/" class="text-[14px] font-medium leading-[120%] text-white transition hover:opacity-80">Test Reports</a>
           <span class="h-5 w-px bg-white/20"></span>
           <a
             href="https://github.com/kinotic-ai/kinotic"
@@ -102,6 +103,7 @@ watch(isMenuOpen, (val) => {
         <div class="flex flex-col justify-between items-center gap-6 h-screen">
           <div class="flex flex-col justify-between items-center gap-8">
             <NuxtLink to="/apps/introduction" class="text-sm text-[#EDEEF2]" @click="isMenuOpen = false">Docs</NuxtLink>
+            <a href="/test-results/" class="text-sm text-[#EDEEF2]" @click="isMenuOpen = false">Test Reports</a>
           </div>
           <a
             href="https://github.com/kinotic-ai/kinotic"


### PR DESCRIPTION
## Summary

Refactors the CI/CD pipeline to decouple test execution from report publishing, enabling safer concurrent deployments to gh-pages across workflows while maintaining the fast cancel-previous-run behavior for builds.

## Changes

**gradle-build.yml:**
- Uncommented and updated E2E test execution step, changing path from `structures-js/structures-e2e` to `kinotic-js/e2e-tests`
- Replaced inline Allure report generation with artifact upload (`actions/upload-artifact@v4`), allowing results to be consumed by a separate job
- Created new `publish_test_report` job that:
  - Downloads merged test results from the build job
  - Generates Allure report with history
  - Publishes to gh-pages under `/test-results/` subfolder (was `/allure/`)
  - Generates a stable redirect at `/test-results/index.html` that points to the latest run, marked `noindex` for SEO safety
  - Uses `concurrency.group: gh-pages-deploy` with `cancel-in-progress: false` to serialize gh-pages pushes
- Updated commit status target URL to `https://kinotic.ai/test-results/${{ github.run_number }}`
- Improved test result aggregation with `find` to locate `allure-results` directories anywhere in the tree, excluding `node_modules` and the aggregate directory itself

**website-deploy.yml:**
- Added `concurrency` block with `group: gh-pages-deploy` to couple with gradle-build.yml's Allure deploy, preventing concurrent gh-pages pushes
- Added "Preserve existing test reports" step that checks out the current gh-pages branch and folds `/test-results/` into the website output before deployment
- Preserves test report history across website deployments that use `keep_files: false`

**README.md & website/app/components/Header.vue:**
- Added "Test Reports" section documenting the Allure report link
- Added navigation link to `/test-results/` in the website header

## Implementation Details

The redirect at `/test-results/index.html` uses `<meta http-equiv="refresh">` with `noindex` to provide a stable, crawler-safe entry point. This allows the README and site to link to a fixed URL without exposing individual run reports to search engines — the redirect itself carries no SEO cost because it's marked `noindex`, unlike a root-level redirect.

The `concurrency` group `gh-pages-deploy` is shared between both workflows with `cancel-in-progress: false`, ensuring that an Allure push landing between the website's "Preserve existing test reports" checkout and its `keep_files: false` deploy cannot wipe the report history.

https://claude.ai/code/session_011jukQ8ysfHWwf597vdT1Qv