### PR TITLE
Clarify device approval flow in CLI device login handler

### DIFF
--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/rest/CliDeviceLoginHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/rest/CliDeviceLoginHandler.java
@@ -64,6 +64,9 @@ public class CliDeviceLoginHandler {
     private void handleStart(RoutingContext ctx) {
         Future.fromCompletionStage(deviceCodeGrantService.start())
               .onSuccess(start -> {
+                  // /device is a kinotic-frontend SPA route (DeviceVerification.vue), not a gateway
+                  // route — hence appBaseUrl (SPA origin), not apiBaseUrl. The signed-in browser
+                  // approves there via DeviceApprovalService over STOMP; this gateway only emits the URL.
                   String verificationUri = domainProperties.getDomain().getAppBaseUrl() + "/device";
                   JsonObject body = new JsonObject()
                           .put("device_code", start.deviceCode())

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/rest/CliDeviceLoginHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/rest/CliDeviceLoginHandler.java
@@ -26,15 +26,6 @@ import java.util.Date;
  * drives the user through a browser login, and afterwards keeps only a rotating refresh
  * token from which it mints the short-lived access tokens used on STOMP CONNECT.
  *
- * <ul>
- *   <li>{@code POST /api/auth/device/start} — begins a flow; returns the device/user codes
- *       and the browser verification URL.</li>
- *   <li>{@code POST /api/auth/device/token} — polled by the CLI; returns
- *       {@code authorization_pending} until approved, then an access/refresh token pair.</li>
- *   <li>{@code POST /api/auth/device/refresh} — exchanges a refresh token for a new
- *       access/refresh token pair (rotation).</li>
- * </ul>
- *
  * <p>Error responses use the RFC 8628 / RFC 6749 shape {@code {"error":"<code>"}} so the CLI
  * can branch on the code.
  */
@@ -58,6 +49,10 @@ public class CliDeviceLoginHandler {
         router.post("/api/auth/device/refresh").handler(this::handleRefresh);
     }
 
+    /**
+     * {@code POST /api/auth/device/start} — begins a flow; returns the device/user codes
+     * and the browser verification URL.
+     */
     private void handleStart(RoutingContext ctx) {
         Future.fromCompletionStage(deviceCodeGrantService.start())
               .onSuccess(start -> {
@@ -82,6 +77,10 @@ public class CliDeviceLoginHandler {
               });
     }
 
+    /**
+     * {@code POST /api/auth/device/token} — polled by the CLI; returns
+     * {@code authorization_pending} until approved, then an access/refresh token pair.
+     */
     private void handleToken(RoutingContext ctx) {
         String deviceCode = stringField(ctx, "device_code");
         if (deviceCode == null) {
@@ -113,6 +112,10 @@ public class CliDeviceLoginHandler {
               });
     }
 
+    /**
+     * {@code POST /api/auth/device/refresh} — exchanges a refresh token for a new
+     * access/refresh token pair (rotation).
+     */
     private void handleRefresh(RoutingContext ctx) {
         String refreshToken = stringField(ctx, "refresh_token");
         if (refreshToken == null) {

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/rest/CliDeviceLoginHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/rest/CliDeviceLoginHandler.java
@@ -35,9 +35,6 @@ import java.util.Date;
  *       access/refresh token pair (rotation).</li>
  * </ul>
  *
- * <p>The approve step is the {@code DeviceApprovalService} Kinotic service the browser
- * invokes over its authenticated connection, not a REST route.
- *
  * <p>Error responses use the RFC 8628 / RFC 6749 shape {@code {"error":"<code>"}} so the CLI
  * can branch on the code.
  */


### PR DESCRIPTION
Moves documentation of the device approval flow from class-level Javadoc to an inline comment at the point where it's relevant to the code.

**Summary**

The class-level Javadoc contained a paragraph explaining that the approve step is handled by `DeviceApprovalService` over an authenticated browser connection, not as a REST route. This detail is implementation-specific and more useful to maintainers of the `handleStart` method than to callers of the class.

**Changes**

- Removed the approve-step explanation from class-level Javadoc (lines 38–40)
- Added an inline comment in `handleStart` (lines 64–66) explaining why `/device` uses `appBaseUrl` (SPA origin) rather than `apiBaseUrl`, and clarifying that the gateway only emits the URL while the browser approves via `DeviceApprovalService` over STOMP

This follows the convention that Javadoc documents the contract from the caller's perspective, while inline comments explain implementation details for maintainers.

https://claude.ai/code/session_01Ku5MeMEA56N4rsJs5fVrMr