### PR TITLE
Add KinoticOsCredentialsAuthProvider for client credential auth

### DIFF
--- a/kinotic-js/workspace/bun.lock
+++ b/kinotic-js/workspace/bun.lock
@@ -70,7 +70,7 @@
     },
     "packages/os-api": {
       "name": "@kinotic-ai/os-api",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "dependencies": {
         "@kinotic-ai/idl": "workspace:*",
         "@kinotic-ai/persistence": "workspace:*",

--- a/kinotic-js/workspace/packages/os-api/package.json
+++ b/kinotic-js/workspace/packages/os-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/os-api",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "type": "module",
   "files": [
     "dist"

--- a/kinotic-js/workspace/packages/os-api/src/api/security/KinoticOsCredentialsAuthProvider.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/security/KinoticOsCredentialsAuthProvider.ts
@@ -1,0 +1,26 @@
+import type { IAuthProvider } from '@kinotic-ai/core'
+
+/**
+ * {@link IAuthProvider} for Kinotic OS credential authentication. Sends the credential and
+ * scope as discrete WebSocket upgrade headers — {@code clientId}, {@code clientSecret}, and,
+ * when supplied, {@code organizationId} / {@code applicationId} — which the gateway matches
+ * against an {@code IamUser} at handshake time.
+ *
+ * Scope is structural, determined by which ids are given: neither → SYSTEM, organizationId
+ * only → ORGANIZATION, both → APPLICATION.
+ */
+export class KinoticOsCredentialsAuthProvider implements IAuthProvider {
+
+    private readonly authHeaders: Record<string, string>
+
+    constructor(clientId: string, clientSecret: string, organizationId?: string, applicationId?: string) {
+        const authHeaders: Record<string, string> = { clientId, clientSecret }
+        if (organizationId != null) authHeaders.organizationId = organizationId
+        if (applicationId != null) authHeaders.applicationId = applicationId
+        this.authHeaders = authHeaders
+    }
+
+    public getAuthHeaders(): Record<string, string> {
+        return this.authHeaders
+    }
+}

--- a/kinotic-js/workspace/packages/os-api/src/index.ts
+++ b/kinotic-js/workspace/packages/os-api/src/index.ts
@@ -62,6 +62,7 @@ export * from '@/api/security/ISystemParticipant'
 export * from '@/api/security/IOrganizationParticipant'
 export * from '@/api/security/IApplicationParticipant'
 export * from '@/api/security/ParticipantGuards'
+export * from '@/api/security/KinoticOsCredentialsAuthProvider'
 
 // Services
 export * from '@/api/services/IApplicationService'

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/KinoticSecurityService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/KinoticSecurityService.java
@@ -34,8 +34,8 @@ import java.util.concurrent.CompletableFuture;
  * <p>
  * <b>Two paths:</b>
  * <ol>
- *   <li><b>Email/password</b> — direct STOMP CONNECT with {@code login}/{@code passcode}
- *       headers. Looks up the {@link IamUser} by email + scope, verifies the bcrypt password.</li>
+ *   <li><b>Client credentials</b> — {@code clientId}/{@code clientSecret} upgrade headers.
+ *       Looks up the {@link IamUser} by email + scope, verifies the bcrypt password.</li>
  *   <li><b>Kinotic JWT</b> — {@code Authorization: Bearer <jwt>} header. The JWT was minted
  *       by {@link KinoticJwtIssuer} after a successful OIDC callback. We validate the JWT
  *       signature + audience, then look up the {@link IamUser} by id from the JWT
@@ -92,11 +92,11 @@ public class KinoticSecurityService implements SecurityService {
     private CompletableFuture<Participant> authenticateEmailPassword(String organizationId,
                                                                      String applicationId,
                                                                      Map<String, String> authInfo) {
-        String email = authInfo.get("login");
-        String password = authInfo.get("passcode");
+        String email = authInfo.get("clientId");
+        String password = authInfo.get("clientSecret");
 
         if (email == null || password == null) {
-            return CompletableFuture.failedFuture(new AuthenticationException("login and passcode headers are required for email/password authentication"));
+            return CompletableFuture.failedFuture(new AuthenticationException("clientId and clientSecret headers are required for credential authentication"));
         }
 
         return userService.findByEmail(email, organizationId, applicationId)


### PR DESCRIPTION
Adds support for client credential authentication in the Kinotic OS API, replacing the previous email/password authentication path.

## Summary

Introduces `KinoticOsCredentialsAuthProvider`, a new `IAuthProvider` implementation that authenticates using `clientId` and `clientSecret` headers, with optional `organizationId` and `applicationId` for scope determination. Updates the Java security service to match this new authentication scheme.

## Changes

- **New TypeScript class**: `KinoticOsCredentialsAuthProvider` implements `IAuthProvider` and constructs WebSocket upgrade headers from client credentials and optional scope identifiers (organization/application). Exported from the public API.

- **Java security service**: Updated `KinoticSecurityService.authenticateEmailPassword()` to read `clientId`/`clientSecret` headers instead of `login`/`passcode`, with matching error messages. The method name and internal logic remain unchanged — only the header names and documentation are updated to reflect the new credential type.

- **Documentation**: Updated class-level Javadoc in `KinoticSecurityService` to describe the client credentials path instead of email/password.

- **Version bump**: `@kinotic-ai/os-api` package version incremented from 1.13.0 to 1.14.0.

## Implementation Details

Scope is determined structurally: neither `organizationId` nor `applicationId` → SYSTEM scope; `organizationId` only → ORGANIZATION scope; both provided → APPLICATION scope. The provider stores headers as a simple record and returns them via `getAuthHeaders()` for use during WebSocket handshake.

https://claude.ai/code/session_01KtXkTVnWVTzd9ntHEPmayy