### PR TITLE
Migrate authentication headers from STOMP login/passcode to OAuth2 client credentials

### DIFF
--- a/kinotic-js/workspace/packages/core/test/KinoticClient.test.ts
+++ b/kinotic-js/workspace/packages/core/test/KinoticClient.test.ts
@@ -60,7 +60,7 @@ describe('Kinotic Client Tests', () => {
         console.log(`Connecting to Kinotic Gateway running at`)
 
         let connectedInfo: ConnectedInfo = await logFailure(kinotic.connect(createConnectionInfo(SessionKeepAliveMode.ACTIVITY,
-                                                                                                   {login: ParticipantConstants.CLI_PARTICIPANT_ID})),
+                                                                                                   {clientId: ParticipantConstants.CLI_PARTICIPANT_ID})),
                                                             'Failed to connect to Kinotic Gateway')
 
         validateConnectedInfo(connectedInfo, ['ANONYMOUS'])

--- a/kinotic-js/workspace/packages/core/test/TestHelper.ts
+++ b/kinotic-js/workspace/packages/core/test/TestHelper.ts
@@ -10,17 +10,16 @@ import * as path from 'path'
  * the STOMP CONNECT frame is processed.
  */
 export interface AuthHeaders {
-    login: string
-    passcode: string
-    authScopeType: 'SYSTEM' | 'ORGANIZATION' | 'APPLICATION'
-    authScopeId: string
+    clientId: string
+    clientSecret: string
+    organizationId?: string
+    applicationId?: string
 }
 
 const DEFAULT_AUTH_HEADERS: AuthHeaders = {
-    login: 'kinotic@kinotic.local',
-    passcode: 'kinotic',
-    authScopeType: 'ORGANIZATION',
-    authScopeId: 'kinotic-test'
+    clientId: 'kinotic@kinotic.local',
+    clientSecret: 'kinotic',
+    organizationId: 'kinotic-test'
 }
 
 /**


### PR DESCRIPTION
Replaces the legacy STOMP CONNECT frame authentication model with OAuth2 client credentials flow across the test helper and client test suite.

**Changes:**

- `TestHelper.ts` — Updated `AuthHeaders` interface to use OAuth2 client credentials:
  - `login` → `clientId`
  - `passcode` → `clientSecret`
  - Replaced `authScopeType` enum (`'SYSTEM' | 'ORGANIZATION' | 'APPLICATION'`) with optional `organizationId` and `applicationId` fields
  - Updated `DEFAULT_AUTH_HEADERS` to reflect new credential names and removed explicit `authScopeType`

- `KinoticClient.test.ts` — Updated connection test to use new credential field name:
  - Changed `{login: ParticipantConstants.CLI_PARTICIPANT_ID}` to `{clientId: ParticipantConstants.CLI_PARTICIPANT_ID}`

This aligns the test infrastructure with the OAuth2 authentication scheme, removing the STOMP-specific login/passcode model in favor of client ID/secret credentials with optional scope targeting.

https://claude.ai/code/session_01KtXkTVnWVTzd9ntHEPmayy