### PR TITLE
Add data stream retention and append methods to CrudServiceTemplate

### DIFF
--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/CrudServiceTemplate.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/CrudServiceTemplate.java
@@ -37,6 +37,7 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.type.TypeFactory;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -176,8 +177,32 @@ public class CrudServiceTemplate {
                                                        String indexPattern,
                                                        DataStreamVisibility dataStreamVisibility,
                                                        Map<String, Property> mappings) {
+        return createIndexTemplate(templateName, indexPattern, dataStreamVisibility, null, mappings);
+    }
+
+    /**
+     * Creates an index template with the given name, pattern, and mappings, optionally configuring a
+     * native data stream lifecycle retention period.
+     * @param templateName the name of the template
+     * @param indexPattern the pattern to match the index names
+     * @param dataStreamVisibility the visibility of the data stream or null if not a data stream
+     * @param dataRetention the data stream lifecycle retention period, or null for no managed lifecycle;
+     *                      Elasticsearch deletes data older than this from the stream's backing indices
+     * @param mappings the mappings to use for the index, or null if no mappings are needed
+     * @return a {@link CompletableFuture} that will complete when the index template has been created
+     */
+    public CompletableFuture<Void> createIndexTemplate(String templateName,
+                                                       String indexPattern,
+                                                       DataStreamVisibility dataStreamVisibility,
+                                                       Duration dataRetention,
+                                                       Map<String, Property> mappings) {
         Validate.notNull(templateName, "templateName cannot be null");
         Validate.notNull(indexPattern, "indexPattern cannot be null");
+        // data_retention is a data stream lifecycle concept; it has no meaning on a plain index template
+        if (dataRetention != null && dataStreamVisibility == null) {
+            throw new IllegalArgumentException(
+                    "dataRetention can only be set for data stream templates (dataStreamVisibility must be non-null)");
+        }
         return bindToContext(esAsyncClient.indices().putIndexTemplate(builder -> {
             builder.name(templateName)
                    .indexPatterns(List.of(indexPattern))
@@ -188,6 +213,9 @@ public class CrudServiceTemplate {
                                          .numberOfShards("3")
                                          .numberOfReplicas("2")
                                  );
+                                 if (dataRetention != null) {
+                                     t.lifecycle(l -> l.dataRetention(r -> r.time(dataRetention.toSeconds() + "s")));
+                                 }
                                  if(mappings != null && !mappings.isEmpty()) {
                                      t.mappings(m -> m
                                              .dynamic(DynamicMapping.Strict)
@@ -601,6 +629,42 @@ public class CrudServiceTemplate {
             }
             builder.refresh(Refresh.WaitFor);
         });
+    }
+
+    /**
+     * Appends a document to a data stream using Elasticsearch's {@code create} op-type. Data streams
+     * are append-only — the {@code index} op and updates/deletes by id are rejected — and the document
+     * id is auto-generated, so documents are retrieved by search rather than by id. The document must
+     * carry a {@code @timestamp} date field.
+     *
+     * @param dataStreamName name of the data stream to append to
+     * @param document       the document to append
+     * @return a {@link CompletableFuture} that will complete with the {@link IndexResponse}
+     */
+    public <T> CompletableFuture<IndexResponse> appendToDataStream(String dataStreamName, T document) {
+        return appendToDataStream(dataStreamName, document, null);
+    }
+
+    /**
+     * Appends a document to a data stream using Elasticsearch's {@code create} op-type, with full
+     * {@link IndexRequest} customization (e.g. {@code refresh}). Data streams are append-only and the
+     * document id is auto-generated; the document must carry a {@code @timestamp} date field.
+     *
+     * @param dataStreamName  name of the data stream to append to
+     * @param document        the document to append
+     * @param builderConsumer to customize the {@link IndexRequest}, or null if no customization is needed
+     * @return a {@link CompletableFuture} that will complete with the {@link IndexResponse}
+     */
+    public <T> CompletableFuture<IndexResponse> appendToDataStream(String dataStreamName,
+                                                                   T document,
+                                                                   Consumer<IndexRequest.Builder<T>> builderConsumer) {
+        return bindToContext(esAsyncClient.index((IndexRequest.Builder<T> builder) -> {
+            builder.index(dataStreamName).opType(OpType.Create).document(document);
+            if (builderConsumer != null) {
+                builderConsumer.accept(builder);
+            }
+            return builder;
+        }));
     }
 
     public CompletableFuture<Void> updateIndexMapping(String indexName,


### PR DESCRIPTION
System/domain code that backs data streams had no way to set a retention
lifecycle or to write append-only documents through CrudServiceTemplate.

- createIndexTemplate overload takes a Duration dataRetention, writing
  template.lifecycle.data_retention (native data stream lifecycle) so old data
  ages out; validates that retention is only set for data stream templates. The
  existing 4-arg method delegates with null retention (no behavior change).
- appendToDataStream writes via the create op-type with an auto-generated id,
  the only write mode data streams accept (the index op and by-id updates are
  rejected). Documents must carry @timestamp.

Verified against elasticsearch-java 9.2.4 (DataStreamLifecycle.dataRetention,
put_index_template.IndexTemplateMapping.lifecycle).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017pwyNckyheYecJGvZMghd9