### PR TITLE
Migrate test report generation from Allure 2 to Allure 3

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -119,7 +119,25 @@ jobs:
     concurrency:
       group: gh-pages-deploy
       cancel-in-progress: false
+    env:
+      # Allure 3 report generator (the CLI that renders the new UI and reads/writes history.jsonl).
+      # Pinned so report output and trend handling stay reproducible across runs.
+      ALLURE_VERSION: "3.12.0"
     steps:
+      # Only allurerc.mjs is needed from the repo (historyPath is config-only — there is no CLI flag
+      # for it). Sparse-checkout avoids pulling the whole tree into this lightweight publish job.
+      # Must run before the artifact download below, since actions/checkout cleans its destination.
+      - name: Checkout report config
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: allurerc.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Download Allure results
         uses: actions/download-artifact@v6
         continue-on-error: true
@@ -134,15 +152,29 @@ jobs:
           ref: gh-pages
           path: gh-pages
 
+      # Render the report with the Allure 3 CLI (the "awesome" UI). The simple-elf action this
+      # replaces bundled the Allure 2 generator; Allure 3 has no drop-in publish action, so the
+      # history round-trip the action did implicitly is done explicitly here:
+      #   1. restore the prior run's history.jsonl from its stable gh-pages path (absent on run 1),
+      #   2. `allure generate` reads it (historyPath in allurerc.mjs), writes the per-run report,
+      #      and rewrites history.jsonl with this launch appended,
+      #   3. persist the updated history.jsonl back to the stable path for the next run.
+      # The Allure 3 generator reads the existing allure-junit5 (v2) and allure-vitest (v3) results
+      # unchanged. Each run is an immutable folder under test-results/<run_number>/.
       - name: Generate Allure report
-        uses: simple-elf/allure-report-action@v1.13
-        id: allure-report
-        with:
-          allure_results: allure-results
-          gh_pages: gh-pages
-          subfolder: test-results
-          allure_report: allure-report
-          allure_history: allure-history
+        run: |
+          if [ ! -d allure-results ] || [ -z "$(ls -A allure-results 2>/dev/null)" ]; then
+            echo "No allure-results found; skipping report generation."
+            exit 0
+          fi
+          if [ -f gh-pages/test-results/history.jsonl ]; then
+            cp gh-pages/test-results/history.jsonl history.jsonl
+          fi
+          npx --yes "allure@${ALLURE_VERSION}" generate allure-results \
+            --config allurerc.mjs \
+            --output "allure-history/test-results/${{ github.run_number }}"
+          mkdir -p allure-history/test-results
+          cp history.jsonl allure-history/test-results/history.jsonl
 
       # Stable, crawler-safe entry point. /test-results/ redirects to the newest run and is marked
       # noindex, so it is linkable from the site and README without exposing report pages to search
@@ -151,13 +183,10 @@ jobs:
       # future switch away from Allure.
       - name: Write latest-report redirect
         run: |
-          # simple-elf/allure-report-action runs as root in a container and already writes its own
-          # index.html here, but pointing at the github.io URL — wrong for the kinotic.ai custom
-          # domain. Take ownership of the root-created tree, then replace it with a relative,
-          # noindex redirect to the newest run that works regardless of host. mkdir first so chown
-          # has a target even if the report step produced nothing.
+          # Replace any prior index.html at this path with a relative, noindex redirect to the newest
+          # run that works regardless of host (the github.io default would be wrong for the kinotic.ai
+          # custom domain). mkdir guarantees a target even if the generate step produced nothing.
           mkdir -p allure-history/test-results
-          sudo chown -R "$(id -u):$(id -g)" allure-history
           cat > allure-history/test-results/index.html <<EOF
           <!doctype html>
           <html lang="en">

--- a/allurerc.mjs
+++ b/allurerc.mjs
@@ -1,0 +1,13 @@
+// Allure 3 report config. Deliberately no `import { defineConfig } from "allure"`: the repo root is
+// not a Node package, so the publish_test_report job runs the generator via `npx allure` with no
+// local node_modules — a bare import of "allure" would fail to resolve there. defineConfig is only
+// a typing helper; a plain object is all the generator reads.
+//
+// historyPath is the single accumulating JSONL file backing the report's trends. The CI job
+// (.github/workflows/gradle-build.yml) restores the previous run's copy here before `allure
+// generate` and persists the rewritten file back to gh-pages afterward. It must stay at a stable
+// path — never inside a per-run report folder, or every run would start from empty history.
+export default {
+  name: "Kinotic Test Report",
+  historyPath: "./history.jsonl",
+};


### PR DESCRIPTION
Replaces the deprecated `simple-elf/allure-report-action` (Allure 2) with direct invocation of the Allure 3 CLI, enabling the new UI and explicit history management for trend tracking across runs.

## Changes

- **Workflow (`gradle-build.yml`)**: 
  - Added `ALLURE_VERSION` env var pinning Allure 3.12.0 for reproducible report output
  - Added checkout step with sparse-checkout to pull only `allurerc.mjs` (avoids cloning the full tree for a lightweight publish job)
  - Added Node.js 22 setup (required by Allure 3 CLI)
  - Replaced `simple-elf/allure-report-action` with explicit bash script that:
    - Skips report generation if no results exist
    - Restores prior run's `history.jsonl` from gh-pages (absent on first run)
    - Invokes `allure generate` with the config file to render the report and rewrite history
    - Persists updated `history.jsonl` back to gh-pages for the next run
  - Removed `sudo chown` call (no longer needed; Node runs as the workflow user, not root)
  - Updated redirect comment to reflect the new explicit history handling

- **Config file (`allurerc.mjs`)**: 
  - New Allure 3 configuration file specifying report name and stable `historyPath` for trend data
  - Deliberately avoids `import { defineConfig }` since the publish job runs via `npx allure` with no local node_modules

## Implementation Details

The Allure 3 generator reads existing allure-junit5 (v2) and allure-vitest (v3) results unchanged. Each run produces an immutable folder under `test-results/<run_number>/`, while `history.jsonl` at `test-results/history.jsonl` accumulates across runs to power the trends UI. The workflow explicitly manages this round-trip: restore → generate → persist, replacing the implicit handling the old action provided.

https://claude.ai/code/session_01MvxEjUs662xpj6WkDq5tgp