### PR TITLE
Fail CI job when any test suite fails despite continue-on-error

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -140,6 +140,31 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      # The test/build steps above use continue-on-error so every suite runs and the merged Allure
+      # report stays complete regardless of failures. This final gate re-reads their outcomes (which
+      # are still 'failure' under continue-on-error) and fails the job when any failed, so a run with
+      # failing tests shows a red X instead of a green check. Placed after the upload so the report
+      # artifact is produced first; publish_test_report still runs because it is gated on
+      # !cancelled(), not on this job succeeding.
+      - name: Fail job if any test run failed
+        if: ${{ !cancelled() }}
+        run: |
+          failed=false
+          check() {
+            if [ "$2" = "failure" ]; then
+              echo "::error::$1 failed"
+              failed=true
+            fi
+          }
+          check "kinotic-sql + kinotic-migration build/test" "${{ steps.migration.outcome }}"
+          check "Gradle build" "${{ steps.gradle_build.outcome }}"
+          check "JS workspace tests" "${{ steps.run_workspace_tests.outcome }}"
+          check "E2E tests" "${{ steps.run_e2e_tests.outcome }}"
+          if [ "$failed" = true ]; then
+            exit 1
+          fi
+          echo "All test runs passed."
+
   # Publishing the Allure report is split into its own job so the gh-pages serialization
   # (concurrency below) covers only the gh-pages push, not the heavy build/publish job above —
   # which keeps its cancel-previous-run behavior. The shared group string couples this job with

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -140,12 +140,9 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      # The test/build steps above use continue-on-error so every suite runs and the merged Allure
-      # report stays complete regardless of failures. This final gate re-reads their outcomes (which
-      # are still 'failure' under continue-on-error) and fails the job when any failed, so a run with
-      # failing tests shows a red X instead of a green check. Placed after the upload so the report
-      # artifact is produced first; publish_test_report still runs because it is gated on
-      # !cancelled(), not on this job succeeding.
+      # The test steps use continue-on-error so every suite runs and the Allure report stays complete;
+      # this gate re-reads their outcomes (still 'failure' under continue-on-error) and fails the job
+      # if any failed, giving a red X instead of a green check.
       - name: Fail job if any test run failed
         if: ${{ !cancelled() }}
         run: |

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -37,15 +37,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      # Bun runs the kinotic-js/workspace tests (the @kinotic-ai/core suite below). The workspace is a
-      # Bun monorepo (bun.lock); e2e-tests uses its own node-gradle plugin and does not need this.
+      # Bun runs the kinotic-js/workspace test suites below (e2e-tests uses its own node-gradle plugin).
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
 
-      # Step 1: build + test the migration toolchain, then publish the kinotic-migration image.
-      # kinotic-test (in the main build below) starts a compose stack that pulls
-      # kinoticai/kinotic-migration:<version>, so the image must exist first. The `&&` publishes
-      # the image only if kinotic-sql and kinotic-migration tests pass.
+      # Build + test the migration toolchain and publish its image first: the main build's kinotic-test
+      # pulls kinoticai/kinotic-migration:<version>. `&&` gates the publish on the tests passing.
       - name: Build & test kinotic-sql + kinotic-migration, publish migration image
         id: migration
         continue-on-error: true
@@ -54,15 +51,14 @@ jobs:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
-      # Step 2: build and test everything else. kinotic-test pulls the migration image published above.
+      # Build + test everything else; kinotic-test pulls the migration image published above.
       - name: Build with Gradle
         id: gradle_build
         if: ${{ steps.migration.outcome == 'success' }}
         continue-on-error: true
         run: ./gradlew build
 
-      # All library Maven artifacts publish once here (applications publish images, not jars), so
-      # kinotic-sql deploys with the rest — no separate/duplicate deploy.
+      # All library jars publish here in one pass (apps publish images, not jars).
       - name: Publish to Maven Central with JReleaser
         if: ${{ steps.migration.outcome == 'success' && steps.gradle_build.outcome == 'success' }}
         run: ./gradlew publish && ./gradlew jreleaserDeploy --info
@@ -74,7 +70,7 @@ jobs:
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_KEY_NEW }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_KEY_PASS_NEW }}
 
-      # The migration image was published in step 1; this publishes the remaining application image.
+      # Publishes the remaining application image (migration image was published above).
       - name: Publish kinotic-server image to Docker Hub
         if: ${{ steps.migration.outcome == 'success' && steps.gradle_build.outcome == 'success' }}
         run: ./gradlew :kinotic-server:bootBuildImage --publishImage
@@ -82,9 +78,8 @@ jobs:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
-      # The runner's bundled Docker Compose rejects include: + service overrides used by
-      # compose.kinotic-e2e-test.yml ("conflicts with imported resource"); install a current plugin.
-      # Must precede the testcontainers-driven suites below (JS workspace + E2E).
+      # Bundled Compose fails on compose.kinotic-e2e-test.yml's include: + overrides; install a current
+      # one before the testcontainers suites (JS workspace + E2E) below.
       - name: Set up Docker Compose
         if: ${{ !cancelled() }}
         continue-on-error: true
@@ -92,10 +87,8 @@ jobs:
         with:
           version: v5.1.4
 
-      # Run every kinotic-js/workspace package's test suite. The @kinotic-ai/core suite drives a real
-      # gateway: its globalSetup (test/setup.ts) starts the kinotic-server image published above via
-      # testcontainers when USE_GATEWAY_DOCKER=true; the other suites ignore that flag. Each suite's
-      # allure results are picked up by the aggregation step below.
+      # Run all workspace test suites. USE_GATEWAY_DOCKER makes the @kinotic-ai/core suite start the
+      # server image (published above) via testcontainers; the other suites ignore it.
       - name: Run JS Workspace Tests
         id: run_workspace_tests
         if: ${{ !cancelled() }}
@@ -116,9 +109,7 @@ jobs:
           gradle pnpmInstall
           gradle pnpmTest
 
-      # Aggregate Allure results from every module into one directory: the Java suites (allure-junit5)
-      # and the JS suites (allure-vitest: the kinotic-js/workspace packages and e2e-tests) each write
-      # their own allure-results. Find them wherever they land, skipping node_modules and the aggregate.
+      # Collect every module's allure-results into one dir, skipping node_modules and the aggregate.
       - name: Merge Test Results
         if: ${{ !cancelled() }}
         run: |
@@ -130,7 +121,7 @@ jobs:
               cp -a "$dir/." allure-results/ 2>/dev/null || true
             done
 
-      # Hand the merged results to the publish_test_report job, which runs on a separate runner.
+      # Pass the merged results to the publish_test_report job (separate runner).
       - name: Upload Allure results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
@@ -140,9 +131,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      # The test steps use continue-on-error so every suite runs and the Allure report stays complete;
-      # this gate re-reads their outcomes (still 'failure' under continue-on-error) and fails the job
-      # if any failed, giving a red X instead of a green check.
+      # Fail the job if any test step failed (their continue-on-error keeps the run going for the report).
       - name: Fail job if any test run failed
         if: ${{ !cancelled() }}
         run: |
@@ -162,10 +151,9 @@ jobs:
           fi
           echo "All test runs passed."
 
-  # Publishing the Allure report is split into its own job so the gh-pages serialization
-  # (concurrency below) covers only the gh-pages push, not the heavy build/publish job above —
-  # which keeps its cancel-previous-run behavior. The shared group string couples this job with
-  # the website deploy in website-deploy.yml so the two never push to gh-pages concurrently.
+  # Separate job so the concurrency group below serializes only the report push, leaving the build
+  # job's cancel-previous behavior intact. Shared group with website-deploy.yml prevents concurrent
+  # gh-pages pushes.
   publish_test_report:
     name: Publish Allure Report
     needs: gradle_build_and_publish
@@ -175,13 +163,11 @@ jobs:
       group: gh-pages-deploy
       cancel-in-progress: false
     env:
-      # Allure 3 report generator (the CLI that renders the new UI and reads/writes history.jsonl).
-      # Pinned so report output and trend handling stay reproducible across runs.
+      # Allure 3 CLI version, pinned for reproducible report output and history handling.
       ALLURE_VERSION: "3.12.0"
     steps:
-      # Only allurerc.mjs is needed from the repo (historyPath is config-only — there is no CLI flag
-      # for it). Sparse-checkout avoids pulling the whole tree into this lightweight publish job.
-      # Must run before the artifact download below, since actions/checkout cleans its destination.
+      # Sparse-checkout just allurerc.mjs (needed for historyPath). Must precede the download below,
+      # since checkout cleans its destination.
       - name: Checkout report config
         uses: actions/checkout@v7
         with:
@@ -207,15 +193,11 @@ jobs:
           ref: gh-pages
           path: gh-pages
 
-      # Render the report with the Allure 3 CLI (the "awesome" UI). The simple-elf action this
-      # replaces bundled the Allure 2 generator; Allure 3 has no drop-in publish action, so the
-      # history round-trip the action did implicitly is done explicitly here:
-      #   1. restore the prior run's history.jsonl from its stable gh-pages path (absent on run 1),
-      #   2. `allure generate` reads it (historyPath in allurerc.mjs), writes the per-run report,
-      #      and rewrites history.jsonl with this launch appended,
-      #   3. persist the updated history.jsonl back to the stable path for the next run.
-      # The Allure 3 generator reads the existing allure-junit5 (v2) and allure-vitest (v3) results
-      # unchanged. Each run is an immutable folder under test-results/<run_number>/.
+      # Allure 3 has no drop-in publish action, so do the history round-trip explicitly:
+      #   1. restore the prior run's history.jsonl from gh-pages (absent on run 1),
+      #   2. `allure generate` reads it (historyPath in allurerc.mjs), writes the report, appends this run,
+      #   3. persist the updated history.jsonl for the next run.
+      # Each run is an immutable folder under test-results/<run_number>/.
       - name: Generate Allure report
         run: |
           if [ ! -d allure-results ] || [ -z "$(ls -A allure-results 2>/dev/null)" ]; then
@@ -231,16 +213,13 @@ jobs:
           mkdir -p allure-history/test-results
           cp history.jsonl allure-history/test-results/history.jsonl
 
-      # Stable, crawler-safe entry point. /test-results/ redirects to the newest run and is marked
-      # noindex, so it is linkable from the site and README without exposing report pages to search
-      # engines — unlike a root redirect, a redirect this deep carries no homepage SEO cost. The
-      # folder is named for the artifact (test-results), not the tool, so the public URL survives a
-      # future switch away from Allure.
+      # Stable noindex entry point: /test-results/ redirects to the newest run, linkable without
+      # exposing report pages to search engines. Named for the artifact, not the tool, so the URL
+      # survives a switch away from Allure.
       - name: Write latest-report redirect
         run: |
-          # Replace any prior index.html at this path with a relative, noindex redirect to the newest
-          # run that works regardless of host (the github.io default would be wrong for the kinotic.ai
-          # custom domain). mkdir guarantees a target even if the generate step produced nothing.
+          # Relative redirect (host-agnostic for the kinotic.ai domain) to the newest run; mkdir
+          # guarantees a target even if generate produced nothing.
           mkdir -p allure-history/test-results
           cat > allure-history/test-results/index.html <<EOF
           <!doctype html>


### PR DESCRIPTION
## Summary

Add a final validation step to the Gradle build workflow that re-evaluates test outcomes and fails the job if any test suite failed, ensuring runs with failing tests display a red X instead of a green check.

## Changes

- **New job gate after artifact upload**: Added a `Fail job if any test run failed` step that runs after all test suites and artifact uploads complete (`if: !cancelled()`)
- **Outcome re-evaluation**: Checks the stored outcomes from four test/build steps:
  - `kinotic-sql + kinotic-migration build/test`
  - `Gradle build`
  - `JS workspace tests`
  - `E2E tests`
- **Conditional failure**: Exits with code 1 if any outcome is `failure`, otherwise reports success
- **Artifact preservation**: Placed after the Allure report upload so the artifact is produced before the job fails; `publish_test_report` still runs because it gates on `!cancelled()` rather than this job's success

## Implementation Details

The test/build steps use `continue-on-error: true` to ensure all suites run and the merged Allure report stays complete regardless of individual failures. This new step preserves that behavior while restoring the expected CI signal: a failed test run now correctly fails the workflow job, making the distinction between "all tests passed" and "some tests failed" visible in the GitHub UI.

https://claude.ai/code/session_01LHtCAkxPo5GcY7VLwZSeKQ