### PR TITLE
Move auth handlers to domain module and introduce SuppliesGatewayRoutes

### DIFF
--- a/kinotic-api-gateway/build.gradle
+++ b/kinotic-api-gateway/build.gradle
@@ -14,8 +14,6 @@ dependencies {
     implementation 'io.vertx:vertx-core'
     implementation 'io.vertx:vertx-web'
     implementation 'io.vertx:vertx-health-check'
-    implementation 'io.vertx:vertx-auth-common'
-    implementation 'io.vertx:vertx-auth-oauth2'
 
     implementation 'org.apache.ignite:ignite-core'
 

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/ApiGatewayVertcleFactory.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/ApiGatewayVertcleFactory.java
@@ -17,10 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.kinotic.core.api.config.SslHelper;
 import org.kinotic.core.internal.utils.CorsUtil;
 import org.kinotic.domain.api.config.KinoticDomainProperties;
+import org.kinotic.domain.api.rest.SuppliesGatewayRoutes;
 import org.kinotic.gateway.api.config.KinoticApiGatewayProperties;
-import org.kinotic.gateway.internal.endpoints.rest.*;
-import org.kinotic.github.api.rest.GitHubGatewayRoutes;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -36,15 +34,7 @@ public class ApiGatewayVertcleFactory {
     private final KinoticApiGatewayProperties properties;
     private final KinoticDomainProperties domainProperties;
     private final StompServerHandlerFactory stompServerHandlerFactory;
-    private final OrganizationLoginHandler organizationLoginHandler;
-    private final OrganizationSignupHandler organizationSignupHandler;
-    private final ApplicationLoginHandler applicationLoginHandler;
-    private final InviteHandler inviteHandler;
-    private final CliDeviceLoginHandler cliDeviceLoginHandler;
-    private final SessionEndpointHandler sessionEndpointHandler;
-    // Optional: the GitHub module's component scan is off when kinotic.disableGithub=true,
-    // so this bean is absent and its webhook routes simply aren't mounted.
-    private final ObjectProvider<GitHubGatewayRoutes> githubGatewayRoutes;
+    private final List<SuppliesGatewayRoutes> gatewayRoutes;
     private final HealthChecks healthChecks;
     private final Vertx vertx;
     private final SessionStore sessionStore;
@@ -76,14 +66,9 @@ public class ApiGatewayVertcleFactory {
 
         router.route("/api/*").handler(sessionHandler);
 
-        // REST endpoints under /api
-        organizationLoginHandler.mountRoutes(router);
-        organizationSignupHandler.mountRoutes(router);
-        applicationLoginHandler.mountRoutes(router);
-        inviteHandler.mountRoutes(router);
-        cliDeviceLoginHandler.mountRoutes(router);
-        sessionEndpointHandler.mountRoutes(router);
-        githubGatewayRoutes.ifAvailable(routes -> routes.mountRoutes(router));
+        // REST endpoints under /api — every bean supplying gateway routes is collected and mounted
+        // here, so a disabled module contributes nothing and the gateway still boots.
+        gatewayRoutes.forEach(routes -> routes.mountRoutes(router));
 
         StompServerOptions stompServerOptions = properties.getApiGateway().getStomp();
         // we override the body length with the continuum properties

--- a/kinotic-domain/build.gradle
+++ b/kinotic-domain/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     implementation 'io.vertx:vertx-auth-common'
     implementation 'io.vertx:vertx-auth-jwt'
+    implementation 'io.vertx:vertx-auth-oauth2'
     implementation 'io.vertx:vertx-core'
     implementation 'io.vertx:vertx-web'
     implementation 'io.vertx:vertx-web-client'

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/rest/SuppliesGatewayRoutes.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/rest/SuppliesGatewayRoutes.java
@@ -1,0 +1,20 @@
+package org.kinotic.domain.api.rest;
+
+import io.vertx.ext.web.Router;
+
+/**
+ * Contract for any component that contributes REST routes to the API gateway. The gateway collects
+ * every {@link SuppliesGatewayRoutes} bean and mounts them, so a module adds routes simply by
+ * publishing an implementation — no edits to the gateway are required, and the gateway still boots
+ * when a module (and therefore its routes) is absent.
+ */
+public interface SuppliesGatewayRoutes {
+
+    /**
+     * Registers this supplier's routes on the given router. Called once during gateway startup with
+     * the router that already has the gateway's global handlers (CORS, body, session) installed.
+     *
+     * @param router the gateway router to mount routes on
+     */
+    void mountRoutes(Router router);
+}

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/ApplicationLoginHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/ApplicationLoginHandler.java
@@ -1,14 +1,15 @@
-package org.kinotic.gateway.internal.endpoints.rest;
+package org.kinotic.domain.internal.api.rest;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
+import org.kinotic.domain.api.rest.SuppliesGatewayRoutes;
 import io.vertx.ext.web.RoutingContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.kinotic.gateway.internal.endpoints.rest.support.AuthEndpointSupport;
-import org.kinotic.gateway.internal.endpoints.rest.support.CallbackResult;
-import org.kinotic.gateway.internal.endpoints.rest.support.OidcFlowOrchestrator;
+import org.kinotic.domain.internal.api.rest.support.AuthEndpointSupport;
+import org.kinotic.domain.internal.api.rest.support.CallbackResult;
+import org.kinotic.domain.internal.api.rest.support.OidcFlowOrchestrator;
 import org.kinotic.domain.api.model.iam.AuthType;
 import org.kinotic.domain.api.model.iam.IamUser;
 import org.kinotic.domain.api.model.iam.OidcConfiguration;
@@ -33,7 +34,7 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ApplicationLoginHandler {
+public class ApplicationLoginHandler implements SuppliesGatewayRoutes {
 
     private final IamUserService iamUserService;
     private final ApplicationRepository applicationRepository;
@@ -43,6 +44,7 @@ public class ApplicationLoginHandler {
     private final OidcFlowOrchestrator oidcFlowOrchestrator;
     private final AuthEndpointSupport authEndpointSupport;
 
+    @Override
     public void mountRoutes(Router router) {
         router.get("/api/auth/app/:orgId/:appId/login/providers").handler(this::handleProviders);
         router.post("/api/auth/app/:orgId/:appId/login/lookup").handler(this::handleLookup);

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/CliDeviceLoginHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/CliDeviceLoginHandler.java
@@ -1,9 +1,10 @@
-package org.kinotic.gateway.internal.endpoints.rest;
+package org.kinotic.domain.internal.api.rest;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.web.Router;
+import org.kinotic.domain.api.rest.SuppliesGatewayRoutes;
 import io.vertx.ext.web.RoutingContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +13,7 @@ import org.kinotic.domain.api.model.iam.DeviceCodePollResult;
 import org.kinotic.domain.api.model.iam.IamUser;
 import org.kinotic.domain.api.services.iam.DeviceCodeGrantService;
 import org.kinotic.domain.api.services.iam.RefreshTokenService;
-import org.kinotic.gateway.internal.endpoints.rest.support.AuthEndpointSupport;
+import org.kinotic.domain.internal.api.rest.support.AuthEndpointSupport;
 import org.kinotic.domain.internal.api.services.iam.KinoticJwtIssuer;
 import org.springframework.stereotype.Component;
 
@@ -32,7 +33,7 @@ import java.util.Date;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class CliDeviceLoginHandler {
+public class CliDeviceLoginHandler implements SuppliesGatewayRoutes {
 
     /** Access-token TTL for the CLI's short-lived JWT. */
     private static final int JWT_TTL_SECONDS = 60;
@@ -43,6 +44,7 @@ public class CliDeviceLoginHandler {
     private final KinoticDomainProperties domainProperties;
     private final KinoticJwtIssuer jwtIssuer;
 
+    @Override
     public void mountRoutes(Router router) {
         router.post("/api/auth/device/start").handler(this::handleStart);
         router.post("/api/auth/device/token").handler(this::handleToken);

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/InviteHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/InviteHandler.java
@@ -1,8 +1,9 @@
-package org.kinotic.gateway.internal.endpoints.rest;
+package org.kinotic.domain.internal.api.rest;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
+import org.kinotic.domain.api.rest.SuppliesGatewayRoutes;
 import io.vertx.ext.web.RoutingContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,11 +15,11 @@ import org.kinotic.domain.api.services.iam.InviteService;
 import org.kinotic.domain.api.services.iam.OrgSignupOidcConfigurationService;
 import org.kinotic.domain.internal.api.repositories.ApplicationRepository;
 import org.kinotic.domain.internal.api.repositories.OidcConfigurationRepository;
-import org.kinotic.gateway.internal.endpoints.rest.support.AuthEndpointSupport;
-import org.kinotic.gateway.internal.endpoints.rest.support.CallbackResult;
-import org.kinotic.gateway.internal.endpoints.rest.support.OAuth2Util;
-import org.kinotic.gateway.internal.endpoints.rest.support.OidcCallbackException;
-import org.kinotic.gateway.internal.endpoints.rest.support.OidcFlowOrchestrator;
+import org.kinotic.domain.internal.api.rest.support.AuthEndpointSupport;
+import org.kinotic.domain.internal.api.rest.support.CallbackResult;
+import org.kinotic.domain.internal.api.rest.support.OAuth2Util;
+import org.kinotic.domain.internal.api.rest.support.OidcCallbackException;
+import org.kinotic.domain.internal.api.rest.support.OidcFlowOrchestrator;
 import org.kinotic.domain.api.services.iam.OidcConfigurationService;
 import org.springframework.stereotype.Component;
 
@@ -38,7 +39,7 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class InviteHandler {
+public class InviteHandler implements SuppliesGatewayRoutes {
 
     /** Frontend path of the unauthenticated invitation-accept page. */
     private static final String INVITE_ACCEPT_PATH = "/invite/accept";
@@ -52,6 +53,7 @@ public class InviteHandler {
     private final OidcFlowOrchestrator oidcFlowOrchestrator;
     private final AuthEndpointSupport authEndpointSupport;
 
+    @Override
     public void mountRoutes(Router router) {
         router.get("/api/auth/invite/details").handler(this::handleDetails);
         router.post("/api/auth/invite/accept").handler(this::handleLocalAccept);

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OidcErrorCodes.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OidcErrorCodes.java
@@ -1,4 +1,4 @@
-package org.kinotic.gateway.internal.endpoints.rest;
+package org.kinotic.domain.internal.api.rest;
 
 /**
  * The {@code ?error=} codes the auth flows surface back to the SPA on failure. The SPA

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationLoginHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationLoginHandler.java
@@ -1,15 +1,16 @@
-package org.kinotic.gateway.internal.endpoints.rest;
+package org.kinotic.domain.internal.api.rest;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
+import org.kinotic.domain.api.rest.SuppliesGatewayRoutes;
 import io.vertx.ext.web.RoutingContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.kinotic.gateway.internal.endpoints.rest.support.AuthEndpointSupport;
-import org.kinotic.gateway.internal.endpoints.rest.support.CallbackResult;
-import org.kinotic.gateway.internal.endpoints.rest.support.OidcFlowOrchestrator;
+import org.kinotic.domain.internal.api.rest.support.AuthEndpointSupport;
+import org.kinotic.domain.internal.api.rest.support.CallbackResult;
+import org.kinotic.domain.internal.api.rest.support.OidcFlowOrchestrator;
 import org.kinotic.domain.api.model.iam.AuthType;
 import org.kinotic.domain.api.model.iam.IamUser;
 import org.kinotic.domain.api.model.iam.OidcConfiguration;
@@ -34,7 +35,7 @@ import java.util.Set;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class OrganizationLoginHandler {
+public class OrganizationLoginHandler implements SuppliesGatewayRoutes {
 
     private final AuthEndpointSupport authEndpointSupport;
     private final IamUserService iamUserService;
@@ -44,6 +45,7 @@ public class OrganizationLoginHandler {
     private final OrgSignupOidcConfigurationService orgSignupOidcConfigurationService;
     private final OidcConfigurationRepository oidcConfigurationRepository;
 
+    @Override
     public void mountRoutes(Router router) {
         router.get("/api/auth/org/login/providers").handler(this::handleProviders);
         router.post("/api/auth/org/login/lookup").handler(this::handleLookup);

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationSignupHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationSignupHandler.java
@@ -1,13 +1,14 @@
-package org.kinotic.gateway.internal.endpoints.rest;
+package org.kinotic.domain.internal.api.rest;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
+import org.kinotic.domain.api.rest.SuppliesGatewayRoutes;
 import io.vertx.ext.web.RoutingContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.domain.api.model.Organization;
-import org.kinotic.gateway.internal.endpoints.rest.support.*;
+import org.kinotic.domain.internal.api.rest.support.*;
 import org.kinotic.domain.api.model.iam.IamUser;
 import org.kinotic.domain.api.model.iam.OidcProviderKind;
 import org.kinotic.domain.api.model.iam.OrgSignupOidcConfiguration;
@@ -29,7 +30,7 @@ import java.util.Map;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class OrganizationSignupHandler {
+public class OrganizationSignupHandler implements SuppliesGatewayRoutes {
 
     private final IamUserService iamUserService;
     private final OrgSignupOidcConfigurationService orgSignupOidcConfigurationService;
@@ -37,6 +38,7 @@ public class OrganizationSignupHandler {
     private final OidcFlowOrchestrator oidcFlowOrchestrator;
     private final AuthEndpointSupport authEndpointSupport;
 
+    @Override
     public void mountRoutes(Router router) {
         // Email/password: form submit, then completion after the user clicks the email link.
         router.post("/api/auth/org/signup").handler(this::handleLocalSignUp);

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/SessionEndpointHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/SessionEndpointHandler.java
@@ -1,6 +1,7 @@
-package org.kinotic.gateway.internal.endpoints.rest;
+package org.kinotic.domain.internal.api.rest;
 
 import io.vertx.ext.web.Router;
+import org.kinotic.domain.api.rest.SuppliesGatewayRoutes;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
 import io.vertx.ext.web.handler.SessionHandler;
@@ -19,8 +20,9 @@ import org.springframework.stereotype.Component;
  * </ul>
  */
 @Component
-public class SessionEndpointHandler {
+public class SessionEndpointHandler implements SuppliesGatewayRoutes {
 
+    @Override
     public void mountRoutes(Router router) {
         router.get("/api/auth/me").handler(this::handleMe);
         router.post("/api/auth/logout").handler(this::handleLogout);

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
@@ -1,4 +1,4 @@
-package org.kinotic.gateway.internal.endpoints.rest.support;
+package org.kinotic.domain.internal.api.rest.support;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -11,7 +11,7 @@ import java.util.function.Function;
 import org.kinotic.core.api.security.ConnectedInfo;
 import org.kinotic.core.api.security.Participant;
 import org.kinotic.domain.api.config.KinoticDomainProperties;
-import org.kinotic.gateway.internal.endpoints.rest.OidcErrorCodes;
+import org.kinotic.domain.internal.api.rest.OidcErrorCodes;
 import org.kinotic.domain.api.model.iam.BaseOidcConfiguration;
 import org.kinotic.domain.api.model.iam.IamUser;
 import org.kinotic.domain.internal.utils.DomainUtil;

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/CallbackResult.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/CallbackResult.java
@@ -1,4 +1,4 @@
-package org.kinotic.gateway.internal.endpoints.rest.support;
+package org.kinotic.domain.internal.api.rest.support;
 
 import org.kinotic.domain.api.model.iam.BaseOidcConfiguration;
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OAuth2Util.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OAuth2Util.java
@@ -1,4 +1,4 @@
-package org.kinotic.gateway.internal.endpoints.rest.support;
+package org.kinotic.domain.internal.api.rest.support;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.auth.oauth2.providers.OpenIDConnectAuth;

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcCallbackException.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcCallbackException.java
@@ -1,4 +1,4 @@
-package org.kinotic.gateway.internal.endpoints.rest.support;
+package org.kinotic.domain.internal.api.rest.support;
 
 import lombok.Getter;
 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
@@ -1,4 +1,4 @@
-package org.kinotic.gateway.internal.endpoints.rest.support;
+package org.kinotic.domain.internal.api.rest.support;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -15,7 +15,7 @@ import io.vertx.ext.web.Session;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.core.api.secret.SecretReferenceResolver;
-import org.kinotic.gateway.internal.endpoints.rest.OidcErrorCodes;
+import org.kinotic.domain.internal.api.rest.OidcErrorCodes;
 import org.kinotic.domain.api.model.iam.BaseOidcConfiguration;
 import org.kinotic.domain.api.model.iam.OidcConfiguration;
 import org.kinotic.domain.api.model.iam.OrgSignupOidcConfiguration;

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowSession.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowSession.java
@@ -1,4 +1,4 @@
-package org.kinotic.gateway.internal.endpoints.rest.support;
+package org.kinotic.domain.internal.api.rest.support;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;

--- a/kinotic-github/src/main/java/org/kinotic/github/api/rest/GitHubGatewayRoutes.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/api/rest/GitHubGatewayRoutes.java
@@ -2,6 +2,7 @@ package org.kinotic.github.api.rest;
 
 import io.vertx.ext.web.Router;
 import lombok.RequiredArgsConstructor;
+import org.kinotic.domain.api.rest.SuppliesGatewayRoutes;
 import org.kinotic.github.internal.api.rest.GitHubWebhookHandler;
 import org.springframework.stereotype.Component;
 
@@ -16,10 +17,11 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class GitHubGatewayRoutes {
+public class GitHubGatewayRoutes implements SuppliesGatewayRoutes {
 
     private final GitHubWebhookHandler webhookHandler;
 
+    @Override
     public void mountRoutes(Router router) {
         webhookHandler.mountRoute(router);
     }


### PR DESCRIPTION
Refactor the API gateway's route mounting to use a plugin-based architecture, decoupling route registration from the gateway's verticle factory.

## Summary

This change introduces `SuppliesGatewayRoutes`, a contract for any component that contributes REST routes to the API gateway. The gateway now collects all beans implementing this interface and mounts them automatically, eliminating the need to edit the gateway factory when adding or removing route handlers.

## Key Changes

- **New interface**: `SuppliesGatewayRoutes` in `kinotic-domain` defines the contract for route suppliers
  - Single method: `void mountRoutes(Router router)`
  - Enables modules to contribute routes without gateway factory changes

- **Moved auth handlers** from `kinotic-api-gateway` to `kinotic-domain`:
  - `OrganizationLoginHandler`
  - `OrganizationSignupHandler`
  - `ApplicationLoginHandler`
  - `InviteHandler`
  - `CliDeviceLoginHandler`
  - `SessionEndpointHandler`
  - All moved from `org.kinotic.gateway.internal.endpoints.rest` to `org.kinotic.domain.internal.api.rest`

- **Updated support classes** to follow the same package move:
  - `AuthEndpointSupport`, `OidcFlowOrchestrator`, `CallbackResult`, `OAuth2Util`, `OidcCallbackException`, `OidcFlowSession`, `OidcErrorCodes`
  - All moved to `org.kinotic.domain.internal.api.rest.support`

- **Simplified gateway factory** (`ApiGatewayVertcleFactory`):
  - Replaced individual handler field injections with `List<SuppliesGatewayRoutes> gatewayRoutes`
  - Changed from explicit handler mounting to `gatewayRoutes.forEach(routes -> routes.mountRoutes(router))`
  - Removed `ObjectProvider<GitHubGatewayRoutes>` conditional mounting

- **Updated GitHub module**: `GitHubGatewayRoutes` now implements `SuppliesGatewayRoutes`
  - Integrates seamlessly with the new plugin architecture

- **Dependency adjustments**:
  - Removed `vertx-auth-common` and `vertx-auth-oauth2` from `kinotic-api-gateway` (no longer needed there)
  - Added `vertx-auth-oauth2` to `kinotic-domain` (where auth handlers now live)

## Implementation Details

The gateway still boots successfully when a module is disabled — the module simply contributes no beans implementing `SuppliesGatewayRoutes`, so nothing is mounted. This replaces the previous `ObjectProvider` pattern used for optional GitHub routes with a uniform, extensible mechanism.

https://claude.ai/code/session_016PpM8Fp9Tvvekstk84ru7C