### PR TITLE
Standardize test suite hierarchy across packages

### DIFF
--- a/kinotic-js/e2e-tests/test/k8s/k8s-cache-eviction.test.ts
+++ b/kinotic-js/e2e-tests/test/k8s/k8s-cache-eviction.test.ts
@@ -43,11 +43,12 @@ Object.assign(global, { WebSocket });
  * - K8S_STOMP_PORT: Continuum STOMP port (default: 58503)
  * - K8S_STARTING_LOCAL_PORT: Starting local port for port-forwards (default: 58511)
  */
-describe('E2E Tests', () => {
+describe('Kinotic JS', () => {
     let k8s: K8sTestHelper;
 
     beforeAll(async () => {
-        await allure.suite('K8s Cache Eviction Tests');
+        await allure.suite('e2e-tests/k8s');
+        await allure.subSuite('K8s Cache Eviction');
         k8s = new K8sTestHelper();
 
         if (!k8s.isEnabled()) {

--- a/kinotic-js/e2e-tests/test/native/AdminEntityService.test.ts
+++ b/kinotic-js/e2e-tests/test/native/AdminEntityService.test.ts
@@ -28,11 +28,11 @@ interface LocalTestContext {
     entityService: IEntityRepository<PersonWithTenant>
 }
 
-describe('E2E Tests', () => {
+describe('Kinotic JS', () => {
 
     beforeAll(async () => {
-        await allure.suite('Typescript Client')
-        await allure.subSuite('Admin EntityService Tests')
+        await allure.suite('e2e-tests/native')
+        await allure.subSuite('AdminEntityService')
         await initKinoticClient()
     }, 300000)
 

--- a/kinotic-js/e2e-tests/test/native/AdminNamedQuery.test.ts
+++ b/kinotic-js/e2e-tests/test/native/AdminNamedQuery.test.ts
@@ -30,11 +30,11 @@ interface LocalTestContext {
     entityService: IEntityRepository<PersonWithTenant>
 }
 
-describe('E2E Tests', () => {
+describe('Kinotic JS', () => {
 
     beforeAll(async () => {
-        await allure.suite('Typescript Client')
-        await allure.subSuite('Admin Named Query Tests')
+        await allure.suite('e2e-tests/native')
+        await allure.subSuite('AdminNamedQuery')
         await initKinoticClient()
     }, 300000)
 

--- a/kinotic-js/e2e-tests/test/native/DataStream.test.ts
+++ b/kinotic-js/e2e-tests/test/native/DataStream.test.ts
@@ -31,10 +31,10 @@ interface LocalTestContext {
     entityService: IEntityRepository<Alert>
 }
 
-describe('E2E Tests', () => {
+describe('Kinotic JS', () => {
     beforeAll(async () => {
-        await allure.suite('Typescript Client')
-        await allure.subSuite('Data Stream Tests')
+        await allure.suite('e2e-tests/native')
+        await allure.subSuite('DataStream')
         await initKinoticClient()
     }, 300000)
 

--- a/kinotic-js/e2e-tests/test/native/EntityService.test.ts
+++ b/kinotic-js/e2e-tests/test/native/EntityService.test.ts
@@ -30,11 +30,11 @@ interface LocalTestContext {
     entityService: IEntityRepository<Person>
 }
 
-describe('E2E Tests', () => {
+describe('Kinotic JS', () => {
 
     beforeAll(async () => {
-        await allure.suite('Typescript Client')
-        await allure.subSuite('EntityService Tests')
+        await allure.suite('e2e-tests/native')
+        await allure.subSuite('EntityService')
         await initKinoticClient()
     }, 300000)
 

--- a/kinotic-js/e2e-tests/test/native/MigrationService.testx.ts
+++ b/kinotic-js/e2e-tests/test/native/MigrationService.testx.ts
@@ -23,11 +23,11 @@ interface LocalTestContext {
     applicationId: string
 }
 
-describe('Migration Service End To End Tests', () => {
+describe('Kinotic JS', () => {
 
     beforeAll(async () => {
-        await allure.suite('Typescript Client')
-        await allure.subSuite('Migration Service Tests')
+        await allure.suite('e2e-tests/native')
+        await allure.subSuite('MigrationService')
         await initKinoticClient()
     }, 300000)
 

--- a/kinotic-js/e2e-tests/test/native/NamedQuery.test.ts
+++ b/kinotic-js/e2e-tests/test/native/NamedQuery.test.ts
@@ -28,11 +28,11 @@ interface LocalTestContext {
     entityService: IEntityRepository<Person>
 }
 
-describe('E2E Tests', () => {
+describe('Kinotic JS', () => {
 
     beforeAll(async () => {
-        await allure.suite('Typescript Client')
-        await allure.subSuite('Named Query Tests')
+        await allure.suite('e2e-tests/native')
+        await allure.subSuite('NamedQuery')
         await initKinoticClient()
     }, 300000)
 

--- a/kinotic-js/e2e-tests/test/native/Versioned.test.ts
+++ b/kinotic-js/e2e-tests/test/native/Versioned.test.ts
@@ -27,11 +27,11 @@ interface LocalTestContext {
     entityService: IEntityRepository<Vehicle>
 }
 
-describe('E2E Tests', () => {
+describe('Kinotic JS', () => {
 
     beforeAll(async () => {
-        await allure.suite('Typescript Client')
-        await allure.subSuite('Versioned Tests')
+        await allure.suite('e2e-tests/native')
+        await allure.subSuite('Versioned')
         await initKinoticClient()
     }, 300000)
 

--- a/kinotic-js/workspace/packages/core/test/Context.test.ts
+++ b/kinotic-js/workspace/packages/core/test/Context.test.ts
@@ -5,99 +5,101 @@ import { createConnectionInfo, logFailure, validateConnectedInfo } from "./TestH
 import { firstValueFrom, Observable } from "rxjs"
 import { v4 as uuidv4 } from "uuid"
 
-describe('Kinotic JS Client', () => {
-  describe("Context Injection", () => {
-      let contextService: TestServiceWithContext
-      let replyToId: string
-      let testInterceptor: { intercept: (event: IEvent, context: any) => Promise<any> }
+describe('Kinotic JS', () => {
+  describe('packages/core', () => {
+    describe("Context Injection", () => {
+        let contextService: TestServiceWithContext
+        let replyToId: string
+        let testInterceptor: { intercept: (event: IEvent, context: any) => Promise<any> }
 
-      beforeAll(async () => {
-          const connectionInfo = createConnectionInfo()
-          const connectedInfo: ConnectedInfo = await logFailure(
-              Kinotic.connect(connectionInfo),
-              "Failed to connect to Kinotic Gateway"
-          )
-          validateConnectedInfo(connectedInfo)
-          replyToId = connectedInfo.replyToId
+        beforeAll(async () => {
+            const connectionInfo = createConnectionInfo()
+            const connectedInfo: ConnectedInfo = await logFailure(
+                Kinotic.connect(connectionInfo),
+                "Failed to connect to Kinotic Gateway"
+            )
+            validateConnectedInfo(connectedInfo)
+            replyToId = connectedInfo.replyToId
 
-          // Register service
-          contextService = new TestServiceWithContext()
+            // Register service
+            contextService = new TestServiceWithContext()
 
-          // Define valid interceptor
-          testInterceptor = {
-              async intercept(event: IEvent, context: any) {
-                  const headers = event.headers
-                  const realm = headers.get("x-realm") || "default"
-                  return {
-                      ...context,
-                      realm,
-                      apiKey: realm === "tenant1" ? "key1" : "key2"
-                  }
-              }
-          }
+            // Define valid interceptor
+            testInterceptor = {
+                async intercept(event: IEvent, context: any) {
+                    const headers = event.headers
+                    const realm = headers.get("x-realm") || "default"
+                    return {
+                        ...context,
+                        realm,
+                        apiKey: realm === "tenant1" ? "key1" : "key2"
+                    }
+                }
+            }
 
-          // Set up valid interceptor
-          Kinotic.serviceRegistry.registerContextInterceptor(testInterceptor)
-      }, 1000 * 60 * 10) // 10 minutes
+            // Set up valid interceptor
+            Kinotic.serviceRegistry.registerContextInterceptor(testInterceptor)
+        }, 1000 * 60 * 10) // 10 minutes
 
-      afterAll(async () => {
-          await expect(Kinotic.disconnect()).resolves.toBeUndefined()
-      })
+        afterAll(async () => {
+            await expect(Kinotic.disconnect()).resolves.toBeUndefined()
+        })
 
-      const createTestEvent = (cri: string, replyTo: string, args?: any[] | null, headers?: Map<string, string>): IEvent => {
-          const eventHeaders = headers ? new Map(headers) : new Map()
-          eventHeaders.set(EventConstants.REPLY_TO_HEADER, replyTo)
-          eventHeaders.set(EventConstants.CONTENT_TYPE_HEADER, "application/json")
-          const event = new Event(cri, eventHeaders)
-          if (args != null) {
-              event.setDataString(JSON.stringify(args))
-          }
-          return event
-      }
+        const createTestEvent = (cri: string, replyTo: string, args?: any[] | null, headers?: Map<string, string>): IEvent => {
+            const eventHeaders = headers ? new Map(headers) : new Map()
+            eventHeaders.set(EventConstants.REPLY_TO_HEADER, replyTo)
+            eventHeaders.set(EventConstants.CONTENT_TYPE_HEADER, "application/json")
+            const event = new Event(cri, eventHeaders)
+            if (args != null) {
+                event.setDataString(JSON.stringify(args))
+            }
+            return event
+        }
 
-      const sendAndReceiveEvent = async (cri: string, args?: any[] | null, headers?: Map<string, string>): Promise<any> => {
-          const replyTo = `${EventConstants.REPLY_DESTINATION_PREFIX}${replyToId}:${uuidv4()}@continuum.js.EventBus/replyHandler`
-          const event = createTestEvent(cri, replyTo, args, headers)
-          const response: Observable<IEvent> = Kinotic.eventBus.observe(replyTo)
-          const resultPromise = firstValueFrom(response)
-          Kinotic.eventBus.send(event)
-          const result = await resultPromise
-          if (result.hasHeader(EventConstants.ERROR_HEADER)) {
-              throw new Error(result.getHeader(EventConstants.ERROR_HEADER))
-          }
-          return JSON.parse(result.getDataString())
-      }
+        const sendAndReceiveEvent = async (cri: string, args?: any[] | null, headers?: Map<string, string>): Promise<any> => {
+            const replyTo = `${EventConstants.REPLY_DESTINATION_PREFIX}${replyToId}:${uuidv4()}@continuum.js.EventBus/replyHandler`
+            const event = createTestEvent(cri, replyTo, args, headers)
+            const response: Observable<IEvent> = Kinotic.eventBus.observe(replyTo)
+            const resultPromise = firstValueFrom(response)
+            Kinotic.eventBus.send(event)
+            const result = await resultPromise
+            if (result.hasHeader(EventConstants.ERROR_HEADER)) {
+                throw new Error(result.getHeader(EventConstants.ERROR_HEADER))
+            }
+            return JSON.parse(result.getDataString())
+        }
 
-      describe.sequential("Context injection tests", () => {
-          it("should inject context with default realm", async () => {
-              const result = await sendAndReceiveEvent("srv://com.example.TestServiceWithContext/greetWithContext", ["Alice"])
-              expect(result).toBe("Hello, Alice! Realm: default, API Key: key2")
-          })
+        describe.sequential("Context injection tests", () => {
+            it("should inject context with default realm", async () => {
+                const result = await sendAndReceiveEvent("srv://com.example.TestServiceWithContext/greetWithContext", ["Alice"])
+                expect(result).toBe("Hello, Alice! Realm: default, API Key: key2")
+            })
 
-          it("should inject context with tenant1 realm", async () => {
-              const headers = new Map([["x-realm", "tenant1"]])
-              const result = await sendAndReceiveEvent("srv://com.example.TestServiceWithContext/greetWithContext", ["Bob"], headers)
-              expect(result).toBe("Hello, Bob! Realm: tenant1, API Key: key1")
-          })
+            it("should inject context with tenant1 realm", async () => {
+                const headers = new Map([["x-realm", "tenant1"]])
+                const result = await sendAndReceiveEvent("srv://com.example.TestServiceWithContext/greetWithContext", ["Bob"], headers)
+                expect(result).toBe("Hello, Bob! Realm: tenant1, API Key: key1")
+            })
 
-          it("should handle async context injection", async () => {
-              const headers = new Map([["x-realm", "tenant2"]])
-              const result = await sendAndReceiveEvent("srv://com.example.TestServiceWithContext/fetchDataWithContext", [42], headers)
-              expect(result).toEqual({ id: 42, value: "Data for 42", realm: "tenant2", apiKey: "key2" })
-          })
+            it("should handle async context injection", async () => {
+                const headers = new Map([["x-realm", "tenant2"]])
+                const result = await sendAndReceiveEvent("srv://com.example.TestServiceWithContext/fetchDataWithContext", [42], headers)
+                expect(result).toEqual({ id: 42, value: "Data for 42", realm: "tenant2", apiKey: "key2" })
+            })
 
-          it("should propagate interceptor error", async () => {
-              // Set up failing interceptor
-              Kinotic.serviceRegistry.registerContextInterceptor({
-                  async intercept(event: IEvent, context: any) {
-                      throw new Error("Interceptor failure")
-                  }
-              })
-              await expect(sendAndReceiveEvent("srv://com.example.TestServiceWithContext/greetWithContext", ["Charlie"])).rejects.toThrow("Internal server error")
+            it("should propagate interceptor error", async () => {
+                // Set up failing interceptor
+                Kinotic.serviceRegistry.registerContextInterceptor({
+                    async intercept(event: IEvent, context: any) {
+                        throw new Error("Interceptor failure")
+                    }
+                })
+                await expect(sendAndReceiveEvent("srv://com.example.TestServiceWithContext/greetWithContext", ["Charlie"])).rejects.toThrow("Internal server error")
 
-              // Restore valid interceptor
-              Kinotic.serviceRegistry.registerContextInterceptor(testInterceptor)
-          })
-      })
+                // Restore valid interceptor
+                Kinotic.serviceRegistry.registerContextInterceptor(testInterceptor)
+            })
+        })
+    })
   })
 })

--- a/kinotic-js/workspace/packages/core/test/DisableStickySession.test.ts
+++ b/kinotic-js/workspace/packages/core/test/DisableStickySession.test.ts
@@ -7,50 +7,52 @@ import { createConnectionInfo, logFailure, validateConnectedInfo } from './TestH
 // This is required when running Kinotic from node
 Object.assign(global, { WebSocket})
 
-describe('Kinotic JS Client', () => {
-  describe('Disable Sticky Session Tests', () => {
-      let connectionInfo: ConnectionInfo
+describe('Kinotic JS', () => {
+  describe('packages/core', () => {
+    describe('Disable Sticky Session Tests', () => {
+        let connectionInfo: ConnectionInfo
 
-      beforeAll(async () => {
-          console.log('Starting Kinotic Gateway for sticky session test')
+        beforeAll(async () => {
+            console.log('Starting Kinotic Gateway for sticky session test')
 
-          connectionInfo = createConnectionInfo(SessionKeepAliveMode.NONE)
-      }, 1000 * 60 * 10) // 10 minutes
+            connectionInfo = createConnectionInfo(SessionKeepAliveMode.NONE)
+        }, 1000 * 60 * 10) // 10 minutes
 
-      afterAll(async () => {
+        afterAll(async () => {
 
-      })
+        })
 
-      it('should connect with sessionKeepAlive NONE and hard disconnect and reconnect', {"timeout": 1000 * 60 * 2}, async () => {
-          // Connect to the gateway without keeping the session alive after disconnect
-          const continuum = new KinoticSingleton()
-          let connectedInfo: ConnectedInfo = await logFailure(continuum.connect(connectionInfo),
-                                                              'Failed to connect to Kinotic Gateway')
-          validateConnectedInfo(connectedInfo)
+        it('should connect with sessionKeepAlive NONE and hard disconnect and reconnect', {"timeout": 1000 * 60 * 2}, async () => {
+            // Connect to the gateway without keeping the session alive after disconnect
+            const continuum = new KinoticSingleton()
+            let connectedInfo: ConnectedInfo = await logFailure(continuum.connect(connectionInfo),
+                                                                'Failed to connect to Kinotic Gateway')
+            validateConnectedInfo(connectedInfo)
 
-          // We use force here true. Otherwise, the server will clean up the session
-          await expect(continuum.disconnect(true)).resolves.toBeUndefined()
+            // We use force here true. Otherwise, the server will clean up the session
+            await expect(continuum.disconnect(true)).resolves.toBeUndefined()
 
-          connectedInfo = await logFailure(continuum.connect(connectionInfo),
-                                              'Failed to connect to Kinotic Gateway with sessionKeepAlive NONE')
+            connectedInfo = await logFailure(continuum.connect(connectionInfo),
+                                                'Failed to connect to Kinotic Gateway with sessionKeepAlive NONE')
 
-          validateConnectedInfo(connectedInfo)
+            validateConnectedInfo(connectedInfo)
 
-          await expect(continuum.disconnect()).resolves.toBeUndefined()
-      })
+            await expect(continuum.disconnect()).resolves.toBeUndefined()
+        })
 
-      it('send RPC call with sessionKeepAlive NONE', {"timeout": 1000 * 60 * 2}, async () => {
-          // First connection and RPC call
-          let connectedInfo: ConnectedInfo = await logFailure(Kinotic.connect(connectionInfo),
-                                                              'Failed to connect to Kinotic Gateway')
+        it('send RPC call with sessionKeepAlive NONE', {"timeout": 1000 * 60 * 2}, async () => {
+            // First connection and RPC call
+            let connectedInfo: ConnectedInfo = await logFailure(Kinotic.connect(connectionInfo),
+                                                                'Failed to connect to Kinotic Gateway')
 
-          validateConnectedInfo(connectedInfo)
+            validateConnectedInfo(connectedInfo)
 
-          const firstResult = await TEST_SERVICE.testMethodWithString("FirstCall")
-          expect(firstResult).toBe("Hello FirstCall")
+            const firstResult = await TEST_SERVICE.testMethodWithString("FirstCall")
+            expect(firstResult).toBe("Hello FirstCall")
 
-          await expect(Kinotic.disconnect()).resolves.toBeUndefined()
-      })
+            await expect(Kinotic.disconnect()).resolves.toBeUndefined()
+        })
 
+    })
   })
 })

--- a/kinotic-js/workspace/packages/core/test/DisableStickySession_GatewayRestart.test.ts
+++ b/kinotic-js/workspace/packages/core/test/DisableStickySession_GatewayRestart.test.ts
@@ -9,82 +9,84 @@ import {KINOTIC_DOCKER_IMAGE} from './TestHelper.js'
 // This is required when running Kinotic from node
 Object.assign(global, { WebSocket})
 
-describe('Kinotic JS Client', () => {
-  describe('Disable Sticky Session Gateway Restart Reconnection Tests', () => {
-      let container: StartedTestContainer
-      let connectionInfo: ConnectionInfo = new ConnectionInfo()
+describe('Kinotic JS', () => {
+  describe('packages/core', () => {
+    describe('Disable Sticky Session Gateway Restart Reconnection Tests', () => {
+        let container: StartedTestContainer
+        let connectionInfo: ConnectionInfo = new ConnectionInfo()
 
-      beforeAll(async () => {
-          // Start the Kinotic Gateway container
-          console.log('Starting Kinotic Gateway for sticky session gateway restart reconnection test')
+        beforeAll(async () => {
+            // Start the Kinotic Gateway container
+            console.log('Starting Kinotic Gateway for sticky session gateway restart reconnection test')
 
-          container = await new GenericContainer(KINOTIC_DOCKER_IMAGE)
-              .withExposedPorts({container: 58503, host: 58599})
-              .withEnvironment({SPRING_PROFILES_ACTIVE: "clienttest"})
-              .withPullPolicy(PullPolicy.alwaysPull())
-              .withWaitStrategy(Wait.forHttp('/health', 58503).forStatusCodeMatching(c => c === 200 || c === 204))
-              .withName('disable-sticky-session-reconnect-test')
-              .start()
+            container = await new GenericContainer(KINOTIC_DOCKER_IMAGE)
+                .withExposedPorts({container: 58503, host: 58599})
+                .withEnvironment({SPRING_PROFILES_ACTIVE: "clienttest"})
+                .withPullPolicy(PullPolicy.alwaysPull())
+                .withWaitStrategy(Wait.forHttp('/health', 58503).forStatusCodeMatching(c => c === 200 || c === 204))
+                .withName('disable-sticky-session-reconnect-test')
+                .start()
 
-          // Create connection info without keeping the session alive after disconnect
-          connectionInfo.host = container.getHost()
-          connectionInfo.port = 58599
-          connectionInfo.maxConnectionAttempts = 0
-          connectionInfo.sessionKeepAlive = SessionKeepAliveMode.NONE
-          connectionInfo.webSocketFactory = authedWebSocketFactory(connectionInfo.host, connectionInfo.port)
+            // Create connection info without keeping the session alive after disconnect
+            connectionInfo.host = container.getHost()
+            connectionInfo.port = 58599
+            connectionInfo.maxConnectionAttempts = 0
+            connectionInfo.sessionKeepAlive = SessionKeepAliveMode.NONE
+            connectionInfo.webSocketFactory = authedWebSocketFactory(connectionInfo.host, connectionInfo.port)
 
-          console.log(`Kinotic Gateway running at ${connectionInfo.host}:${connectionInfo.port}`)
-      }, 1000 * 60 * 10) // 10 minutes
+            console.log(`Kinotic Gateway running at ${connectionInfo.host}:${connectionInfo.port}`)
+        }, 1000 * 60 * 10) // 10 minutes
 
-      afterAll(async () => {
-          // Clean up
-          await container.stop({timeout: 60000, remove: true, removeVolumes: true})
-      })
+        afterAll(async () => {
+            // Clean up
+            await container.stop({timeout: 60000, remove: true, removeVolumes: true})
+        })
 
-      it('should handle gateway restart with sessionKeepAlive NONE and reconnect', {"timeout": 1000 * 60 * 5}, async () => {
+        it('should handle gateway restart with sessionKeepAlive NONE and reconnect', {"timeout": 1000 * 60 * 5}, async () => {
 
-          // First connection and RPC call
-          const continuum = new KinoticSingleton()
-          let connectedInfo: ConnectedInfo = await logFailure(continuum.connect(connectionInfo),
-                                                              'Failed to connect to Kinotic Gateway')
-          validateConnectedInfo(connectedInfo)
-          console.log(`Kinotic connected at ${connectionInfo.host}:${connectionInfo.port}`)
+            // First connection and RPC call
+            const continuum = new KinoticSingleton()
+            let connectedInfo: ConnectedInfo = await logFailure(continuum.connect(connectionInfo),
+                                                                'Failed to connect to Kinotic Gateway')
+            validateConnectedInfo(connectedInfo)
+            console.log(`Kinotic connected at ${connectionInfo.host}:${connectionInfo.port}`)
 
-          const testService = new TestService(continuum)
+            const testService = new TestService(continuum)
 
-          const firstResult = await testService.testMethodWithString("FirstCall")
-          expect(firstResult).toBe("Hello FirstCall")
+            const firstResult = await testService.testMethodWithString("FirstCall")
+            expect(firstResult).toBe("Hello FirstCall")
 
-          // Stop the gateway
-          console.log('Stopping Kinotic Gateway...')
-          await container.stop({timeout: 60000, remove: true, removeVolumes: true})
-          // Wait a moment for cleanup
-          await new Promise(resolve => setTimeout(resolve, 10000))
-          console.log('Starting Kinotic Gateway again...')
-          container = await new GenericContainer(KINOTIC_DOCKER_IMAGE)
-              .withExposedPorts({container: 58503, host: 58599})
-              .withEnvironment({SPRING_PROFILES_ACTIVE: "clienttest"})
-              .withPullPolicy(PullPolicy.alwaysPull())
-              .withWaitStrategy(Wait.forHttp('/health', 58503).forStatusCodeMatching(c => c === 200 || c === 204))
-              .withName('disable-sticky-session-reconnect-test')
-              .start()
+            // Stop the gateway
+            console.log('Stopping Kinotic Gateway...')
+            await container.stop({timeout: 60000, remove: true, removeVolumes: true})
+            // Wait a moment for cleanup
+            await new Promise(resolve => setTimeout(resolve, 10000))
+            console.log('Starting Kinotic Gateway again...')
+            container = await new GenericContainer(KINOTIC_DOCKER_IMAGE)
+                .withExposedPorts({container: 58503, host: 58599})
+                .withEnvironment({SPRING_PROFILES_ACTIVE: "clienttest"})
+                .withPullPolicy(PullPolicy.alwaysPull())
+                .withWaitStrategy(Wait.forHttp('/health', 58503).forStatusCodeMatching(c => c === 200 || c === 204))
+                .withName('disable-sticky-session-reconnect-test')
+                .start()
 
-          // Update connection info with new port mapping
-          console.log(`Kinotic Gateway restarted`)
+            // Update connection info with new port mapping
+            console.log(`Kinotic Gateway restarted`)
 
-          // Connect again and make another RPC call
-          while(!continuum.eventBus.isConnected()){
-              await new Promise(resolve => setTimeout(resolve, 5000))
-              console.log('Waiting for Kinotic Gateway to restart...')
-          }
+            // Connect again and make another RPC call
+            while(!continuum.eventBus.isConnected()){
+                await new Promise(resolve => setTimeout(resolve, 5000))
+                console.log('Waiting for Kinotic Gateway to restart...')
+            }
 
-          console.log('Kinotic Gateway restarted')
+            console.log('Kinotic Gateway restarted')
 
-          const secondResult = await testService.testMethodWithString("SecondCall")
-          expect(secondResult).toBe("Hello SecondCall")
+            const secondResult = await testService.testMethodWithString("SecondCall")
+            expect(secondResult).toBe("Hello SecondCall")
 
-          await continuum.disconnect()
-      })
+            await continuum.disconnect()
+        })
 
+    })
   })
 })

--- a/kinotic-js/workspace/packages/core/test/EventBus.test.ts
+++ b/kinotic-js/workspace/packages/core/test/EventBus.test.ts
@@ -7,42 +7,44 @@ import {createConnectionInfo, logFailure, validateConnectedInfo} from './TestHel
 // This is required when running Kinotic from node
 Object.assign(global, { WebSocket})
 
-describe('Kinotic JS Client', () => {
-  describe('Kinotic RPC Tests', () => {
+describe('Kinotic JS', () => {
+  describe('packages/core', () => {
+    describe('Kinotic RPC Tests', () => {
 
-      beforeAll(async () => {
-          const connectionInfo = createConnectionInfo()
-          let connectedInfo: ConnectedInfo = await logFailure(Kinotic.connect(connectionInfo), 'Failed to connect to Kinotic Gateway')
-          validateConnectedInfo(connectedInfo)
-      }, 1000 * 60 * 10) // 10 minutes
+        beforeAll(async () => {
+            const connectionInfo = createConnectionInfo()
+            let connectedInfo: ConnectedInfo = await logFailure(Kinotic.connect(connectionInfo), 'Failed to connect to Kinotic Gateway')
+            validateConnectedInfo(connectedInfo)
+        }, 1000 * 60 * 10) // 10 minutes
 
-      afterAll(async () =>{
-          await expect(Kinotic.disconnect()).resolves.toBeUndefined()
-      })
+        afterAll(async () =>{
+            await expect(Kinotic.disconnect()).resolves.toBeUndefined()
+        })
 
-      it('should fail invalid service request', async () => {
-          const toSend: IEvent = new Event('srv://org.mindignited.continuum.gatewayserver.clienttest.ITestService/testMethodWithString')
-          toSend.setHeader(EventConstants.REPLY_TO_HEADER, '')
-          toSend.setHeader(EventConstants.CONTENT_TYPE_HEADER, EventConstants.CONTENT_JSON)
-          const correlationId = uuidv4()
-          toSend.setHeader(EventConstants.CORRELATION_ID_HEADER, correlationId)
-          toSend.setDataString('["Bob"]')
+        it('should fail invalid service request', async () => {
+            const toSend: IEvent = new Event('srv://org.mindignited.continuum.gatewayserver.clienttest.ITestService/testMethodWithString')
+            toSend.setHeader(EventConstants.REPLY_TO_HEADER, '')
+            toSend.setHeader(EventConstants.CONTENT_TYPE_HEADER, EventConstants.CONTENT_JSON)
+            const correlationId = uuidv4()
+            toSend.setHeader(EventConstants.CORRELATION_ID_HEADER, correlationId)
+            toSend.setDataString('["Bob"]')
 
-          let errorEncountered = new Promise<Error>((resolve) => {
-              Kinotic.eventBus.fatalErrors.subscribe((error: Error) => {
-                  resolve(error)
-              })
-          })
+            let errorEncountered = new Promise<Error>((resolve) => {
+                Kinotic.eventBus.fatalErrors.subscribe((error: Error) => {
+                    resolve(error)
+                })
+            })
 
-          Kinotic.eventBus.send(toSend)
+            Kinotic.eventBus.send(toSend)
 
-          const error = await errorEncountered
-          expect(error.message).toBe('STOMP connection error')
-          expect((error.cause as Error).message).toBe('reply-to header invalid, scheme: null is not valid for service requests')
+            const error = await errorEncountered
+            expect(error.message).toBe('STOMP connection error')
+            expect((error.cause as Error).message).toBe('reply-to header invalid, scheme: null is not valid for service requests')
 
-          expect(Kinotic.eventBus.isConnectionActive()).toBeFalsy()
+            expect(Kinotic.eventBus.isConnectionActive()).toBeFalsy()
 
-      })
+        })
 
+    })
   })
 })

--- a/kinotic-js/workspace/packages/core/test/KinoticClient.test.ts
+++ b/kinotic-js/workspace/packages/core/test/KinoticClient.test.ts
@@ -7,84 +7,86 @@ import {createConnectionInfo, logFailure, validateConnectedInfo} from './TestHel
 // This is required when running Kinotic from node
 Object.assign(global, { WebSocket})
 
-describe('Kinotic JS Client', () => {
-  describe('Kinotic Client Tests', () => {
+describe('Kinotic JS', () => {
+  describe('packages/core', () => {
+    describe('Kinotic Client Tests', () => {
 
-      async function connectToKinotic(kinotic: KinoticSingleton) {
-          return await logFailure(kinotic.connect(createConnectionInfo()),
-                                  'Failed to connect to Kinotic Gateway')
-      }
+        async function connectToKinotic(kinotic: KinoticSingleton) {
+            return await logFailure(kinotic.connect(createConnectionInfo()),
+                                    'Failed to connect to Kinotic Gateway')
+        }
 
-      it('should connect and disconnect', async () => {
-          const kinotic = new KinoticSingleton()
-          const connectedInfo = await connectToKinotic(kinotic)
-          validateConnectedInfo(connectedInfo)
+        it('should connect and disconnect', async () => {
+            const kinotic = new KinoticSingleton()
+            const connectedInfo = await connectToKinotic(kinotic)
+            validateConnectedInfo(connectedInfo)
 
-          await expect(kinotic.disconnect()).resolves.toBeUndefined()
-      })
+            await expect(kinotic.disconnect()).resolves.toBeUndefined()
+        })
 
-      it('should connect and disconnect multiple times and still be able to call services', async () => {
-          const kinotic = new KinoticSingleton()
-          const testService = new TestService(kinotic);
+        it('should connect and disconnect multiple times and still be able to call services', async () => {
+            const kinotic = new KinoticSingleton()
+            const testService = new TestService(kinotic);
 
-          console.log(`Connecting to Kinotic Gateway running at the first time`)
-          let connectedInfo = await connectToKinotic(kinotic)
-          validateConnectedInfo(connectedInfo)
+            console.log(`Connecting to Kinotic Gateway running at the first time`)
+            let connectedInfo = await connectToKinotic(kinotic)
+            validateConnectedInfo(connectedInfo)
 
-          console.log(`Calling Service the first time`)
-          console.log(await testService.testMethodWithString("Bob"))
+            console.log(`Calling Service the first time`)
+            console.log(await testService.testMethodWithString("Bob"))
 
-          await expect(kinotic.disconnect()).resolves.toBeUndefined()
+            await expect(kinotic.disconnect()).resolves.toBeUndefined()
 
-          console.log(`Connecting to Kinotic Gateway running at the second time`)
-          connectedInfo = await connectToKinotic(kinotic)
-          validateConnectedInfo(connectedInfo)
+            console.log(`Connecting to Kinotic Gateway running at the second time`)
+            connectedInfo = await connectToKinotic(kinotic)
+            validateConnectedInfo(connectedInfo)
 
-          console.log(`Calling Service the second time`)
-          await expect(testService.testMethodWithString("Bob")).resolves.toBe("Hello Bob")
+            console.log(`Calling Service the second time`)
+            await expect(testService.testMethodWithString("Bob")).resolves.toBe("Hello Bob")
 
-          await expect(kinotic.disconnect()).resolves.toBeUndefined()
+            await expect(kinotic.disconnect()).resolves.toBeUndefined()
 
-          console.log(`Connecting to Kinotic Gateway running at the third time`)
-          connectedInfo = await connectToKinotic(kinotic)
-          validateConnectedInfo(connectedInfo)
+            console.log(`Connecting to Kinotic Gateway running at the third time`)
+            connectedInfo = await connectToKinotic(kinotic)
+            validateConnectedInfo(connectedInfo)
 
-          console.log(`Calling Service the third time`)
-          await expect(testService.testMethodWithString("Bob")).resolves.toBe("Hello Bob")
+            console.log(`Calling Service the third time`)
+            await expect(testService.testMethodWithString("Bob")).resolves.toBe("Hello Bob")
 
-          await expect(kinotic.disconnect()).resolves.toBeUndefined()
-      })
+            await expect(kinotic.disconnect()).resolves.toBeUndefined()
+        })
 
-      it('should allow kinotic CLI to connect but not send any data', async () => {
-          const kinotic = new KinoticSingleton()
-          const testService = new TestService(kinotic);
-          console.log(`Connecting to Kinotic Gateway running at`)
+        it('should allow kinotic CLI to connect but not send any data', async () => {
+            const kinotic = new KinoticSingleton()
+            const testService = new TestService(kinotic);
+            console.log(`Connecting to Kinotic Gateway running at`)
 
-          let connectedInfo: ConnectedInfo = await logFailure(kinotic.connect(createConnectionInfo(SessionKeepAliveMode.ACTIVITY,
-                                                                                                     {clientId: ParticipantConstants.CLI_PARTICIPANT_ID})),
-                                                              'Failed to connect to Kinotic Gateway')
+            let connectedInfo: ConnectedInfo = await logFailure(kinotic.connect(createConnectionInfo(SessionKeepAliveMode.ACTIVITY,
+                                                                                                       {clientId: ParticipantConstants.CLI_PARTICIPANT_ID})),
+                                                                'Failed to connect to Kinotic Gateway')
 
-          validateConnectedInfo(connectedInfo, ['ANONYMOUS'])
+            validateConnectedInfo(connectedInfo, ['ANONYMOUS'])
 
-          const promise = new Promise((resolve, reject) => {
-              kinotic.eventBus.fatalErrors.subscribe((error: Error) => {
-                  resolve(error)
-              })
-          })
+            const promise = new Promise((resolve, reject) => {
+                kinotic.eventBus.fatalErrors.subscribe((error: Error) => {
+                    resolve(error)
+                })
+            })
 
-          console.log('Sending invalid event from kinotic client')
-          kinotic.eventBus.send(new Event(EventConstants.SERVICE_DESTINATION_PREFIX+ 'blah'))
+            console.log('Sending invalid event from kinotic client')
+            kinotic.eventBus.send(new Event(EventConstants.SERVICE_DESTINATION_PREFIX+ 'blah'))
 
-          const error = await logFailure(promise, 'Failed to receive error from fatalErrors observable')
+            const error = await logFailure(promise, 'Failed to receive error from fatalErrors observable')
 
-          expect(error).toBeDefined()
+            expect(error).toBeDefined()
 
-          // make sure client was automatically disconnected
-          expect(kinotic.eventBus.isConnectionActive(),
-              'Client to be disconnected').toBe(false)
+            // make sure client was automatically disconnected
+            expect(kinotic.eventBus.isConnectionActive(),
+                'Client to be disconnected').toBe(false)
 
-          await expect(kinotic.disconnect()).resolves.toBeUndefined()
+            await expect(kinotic.disconnect()).resolves.toBeUndefined()
 
-      })
+        })
+    })
   })
 })

--- a/kinotic-js/workspace/packages/core/test/KinoticRpc.test.ts
+++ b/kinotic-js/workspace/packages/core/test/KinoticRpc.test.ts
@@ -8,146 +8,148 @@ import {createConnectionInfo, logFailure, validateConnectedInfo} from './TestHel
 // This is required when running Kinotic from node
 Object.assign(global, { WebSocket})
 
-describe('Kinotic JS Client', () => {
-  describe('Kinotic RPC Tests', () => {
+describe('Kinotic JS', () => {
+  describe('packages/core', () => {
+    describe('Kinotic RPC Tests', () => {
 
-      beforeAll(async () => {
-          const connectionInfo =  createConnectionInfo()
-          let connectedInfo: ConnectedInfo = await logFailure(Kinotic.connect(connectionInfo), 'Failed to connect to Kinotic Gateway')
-          validateConnectedInfo(connectedInfo)
-      }, 1000 * 60 * 10) // 10 minutes
+        beforeAll(async () => {
+            const connectionInfo =  createConnectionInfo()
+            let connectedInfo: ConnectedInfo = await logFailure(Kinotic.connect(connectionInfo), 'Failed to connect to Kinotic Gateway')
+            validateConnectedInfo(connectedInfo)
+        }, 1000 * 60 * 10) // 10 minutes
 
-      afterAll(async () =>{
-          await expect(Kinotic.disconnect()).resolves.toBeUndefined()
-      })
+        afterAll(async () =>{
+            await expect(Kinotic.disconnect()).resolves.toBeUndefined()
+        })
 
 
-      it('should execute method with string parameter', async () =>{
-          await expect(TEST_SERVICE.testMethodWithString("Bob")).resolves.toBe("Hello Bob")
-      })
+        it('should execute method with string parameter', async () =>{
+            await expect(TEST_SERVICE.testMethodWithString("Bob")).resolves.toBe("Hello Bob")
+        })
 
-      it('should return missing method error', async () => {
-          await expect(TEST_SERVICE.testMissingMethod()).rejects.toThrowError('No method could be resolved for methodId /testMissingMethod')
-      })
+        it('should return missing method error', async () => {
+            await expect(TEST_SERVICE.testMissingMethod()).rejects.toThrowError('No method could be resolved for methodId /testMissingMethod')
+        })
 
-      it('should return missing service error', async () => {
-          await expect(NON_EXISTENT_SERVICE.probablyNotHome()).rejects.toThrowError('(NO_HANDLERS,-1) No handlers for address srv://com.namespace.NonExistentService')
-      })
+        it('should return missing service error', async () => {
+            await expect(NON_EXISTENT_SERVICE.probablyNotHome()).rejects.toThrowError('(NO_HANDLERS,-1) No handlers for address srv://com.namespace.NonExistentService')
+        })
 
-      // --- Participant Context Tests ---
+        // --- Participant Context Tests ---
 
-      it('should get participant id from vert.x context', async () => {
-          const result = await TEST_SERVICE.getParticipantIdFromContext()
-          expect(result).toBeDefined()
-          expect(result.length).toBeGreaterThan(0)
-      })
+        it('should get participant id from vert.x context', async () => {
+            const result = await TEST_SERVICE.getParticipantIdFromContext()
+            expect(result).toBeDefined()
+            expect(result.length).toBeGreaterThan(0)
+        })
 
-      it('should get participant id from vert.x context via dispatch', async () => {
-          const result = await TEST_SERVICE.getParticipantIdFromContextViaDispatch()
-          expect(result).toBeDefined()
-          expect(result.length).toBeGreaterThan(0)
-      })
+        it('should get participant id from vert.x context via dispatch', async () => {
+            const result = await TEST_SERVICE.getParticipantIdFromContextViaDispatch()
+            expect(result).toBeDefined()
+            expect(result.length).toBeGreaterThan(0)
+        })
 
-      it('should get participant id from vert.x context in executeBlocking', async () => {
-          const result = await TEST_SERVICE.getParticipantIdFromContextInExecuteBlocking()
-          expect(result).toBeDefined()
-          expect(result.length).toBeGreaterThan(0)
-      })
+        it('should get participant id from vert.x context in executeBlocking', async () => {
+            const result = await TEST_SERVICE.getParticipantIdFromContextInExecuteBlocking()
+            expect(result).toBeDefined()
+            expect(result.length).toBeGreaterThan(0)
+        })
 
-      it('should have participant parameter match context participant', async () => {
-          const result = await TEST_SERVICE.verifyParticipantParameterMatchesContext()
-          expect(result).toBeDefined()
-          expect(result.length).toBeGreaterThan(0)
-      })
+        it('should have participant parameter match context participant', async () => {
+            const result = await TEST_SERVICE.verifyParticipantParameterMatchesContext()
+            expect(result).toBeDefined()
+            expect(result.length).toBeGreaterThan(0)
+        })
 
-      it('should get full participant with all fields from context', async () => {
-          const result = await TEST_SERVICE.getFullParticipantFromContext()
-          expect(result).toBeDefined()
-          expect(result.id).toBeDefined()
-          expect(result.id.length).toBeGreaterThan(0)
-          expect(result.roles).toBeDefined()
-          expect(Array.isArray(result.roles)).toBe(true)
-          expect(result.roles.length).toBeGreaterThan(0)
-      })
+        it('should get full participant with all fields from context', async () => {
+            const result = await TEST_SERVICE.getFullParticipantFromContext()
+            expect(result).toBeDefined()
+            expect(result.id).toBeDefined()
+            expect(result.id.length).toBeGreaterThan(0)
+            expect(result.roles).toBeDefined()
+            expect(Array.isArray(result.roles)).toBe(true)
+            expect(result.roles.length).toBeGreaterThan(0)
+        })
 
-      it('should handle participant-only parameter method', async () => {
-          const result = await TEST_SERVICE.getParticipantOnlyParam()
-          expect(result).toBeDefined()
-          expect(result.id).toBeDefined()
-          expect(result.id.length).toBeGreaterThan(0)
-          expect(result.roles).toBeDefined()
-          expect(Array.isArray(result.roles)).toBe(true)
-      })
+        it('should handle participant-only parameter method', async () => {
+            const result = await TEST_SERVICE.getParticipantOnlyParam()
+            expect(result).toBeDefined()
+            expect(result.id).toBeDefined()
+            expect(result.id.length).toBeGreaterThan(0)
+            expect(result.roles).toBeDefined()
+            expect(Array.isArray(result.roles)).toBe(true)
+        })
 
-      it('should get participant id through Mono reactive chain', async () => {
-          const result = await TEST_SERVICE.getParticipantIdFromMonoChain()
-          expect(result).toBeDefined()
-          expect(result).toMatch(/^mono:/)
-      })
+        it('should get participant id through Mono reactive chain', async () => {
+            const result = await TEST_SERVICE.getParticipantIdFromMonoChain()
+            expect(result).toBeDefined()
+            expect(result).toMatch(/^mono:/)
+        })
 
-      it('should get participant id from nested executeBlocking', async () => {
-          const result = await TEST_SERVICE.getParticipantIdFromNestedExecuteBlocking()
-          expect(result).toBeDefined()
-          expect(result.length).toBeGreaterThan(0)
-      })
+        it('should get participant id from nested executeBlocking', async () => {
+            const result = await TEST_SERVICE.getParticipantIdFromNestedExecuteBlocking()
+            expect(result).toBeDefined()
+            expect(result.length).toBeGreaterThan(0)
+        })
 
-      it('should return consistent participant id across repeated reads', async () => {
-          const results = await TEST_SERVICE.getParticipantIdRepeated(10)
-          expect(results).toBeDefined()
-          expect(results.length).toBe(10)
-          const firstId = results[0]
-          for (const id of results) {
-              expect(id).toBe(firstId)
-          }
-      })
+        it('should return consistent participant id across repeated reads', async () => {
+            const results = await TEST_SERVICE.getParticipantIdRepeated(10)
+            expect(results).toBeDefined()
+            expect(results.length).toBe(10)
+            const firstId = results[0]
+            for (const id of results) {
+                expect(id).toBe(firstId)
+            }
+        })
 
-      it('should match participant param and context with first-arg participant', async () => {
-          const result = await TEST_SERVICE.participantFirstArgWithContext(' rocks')
-          expect(result).toBeDefined()
-          expect(result).toMatch(/ rocks$/)
-      })
+        it('should match participant param and context with first-arg participant', async () => {
+            const result = await TEST_SERVICE.participantFirstArgWithContext(' rocks')
+            expect(result).toBeDefined()
+            expect(result).toMatch(/ rocks$/)
+        })
 
-      it('should match participant param and context with last-arg participant', async () => {
-          const result = await TEST_SERVICE.participantLastArgWithContext('Hello ')
-          expect(result).toBeDefined()
-          expect(result).toMatch(/^Hello /)
-      })
+        it('should match participant param and context with last-arg participant', async () => {
+            const result = await TEST_SERVICE.participantLastArgWithContext('Hello ')
+            expect(result).toBeDefined()
+            expect(result).toMatch(/^Hello /)
+        })
 
-      it('should maintain participant context isolation across concurrent requests', async () => {
-          const results = await Promise.all([
-              TEST_SERVICE.getParticipantIdFromContext(),
-              TEST_SERVICE.getParticipantIdFromContext(),
-              TEST_SERVICE.getParticipantIdFromContext(),
-              TEST_SERVICE.getParticipantIdFromContext(),
-              TEST_SERVICE.getParticipantIdFromContext(),
-          ])
-          expect(results.length).toBe(5)
-          const firstId = results[0]
-          for (const id of results) {
-              expect(id).toBe(firstId)
-          }
-      })
+        it('should maintain participant context isolation across concurrent requests', async () => {
+            const results = await Promise.all([
+                TEST_SERVICE.getParticipantIdFromContext(),
+                TEST_SERVICE.getParticipantIdFromContext(),
+                TEST_SERVICE.getParticipantIdFromContext(),
+                TEST_SERVICE.getParticipantIdFromContext(),
+                TEST_SERVICE.getParticipantIdFromContext(),
+            ])
+            expect(results.length).toBe(5)
+            const firstId = results[0]
+            for (const id of results) {
+                expect(id).toBe(firstId)
+            }
+        })
 
-      it('should verify participant param matches context inside Mono chain', async () => {
-          const result = await TEST_SERVICE.verifyParticipantInMonoChain()
-          expect(result).toBeDefined()
-          expect(result.length).toBeGreaterThan(0)
-      })
+        it('should verify participant param matches context inside Mono chain', async () => {
+            const result = await TEST_SERVICE.verifyParticipantInMonoChain()
+            expect(result).toBeDefined()
+            expect(result.length).toBeGreaterThan(0)
+        })
 
-      it('should maintain participant across mixed concurrent requests', async () => {
-          const [contextId, dispatchId, blockingId, monoId, fullParticipant] = await Promise.all([
-              TEST_SERVICE.getParticipantIdFromContext(),
-              TEST_SERVICE.getParticipantIdFromContextViaDispatch(),
-              TEST_SERVICE.getParticipantIdFromContextInExecuteBlocking(),
-              TEST_SERVICE.getParticipantIdFromMonoChain(),
-              TEST_SERVICE.getFullParticipantFromContext(),
-          ])
-          expect(contextId).toBeDefined()
-          expect(contextId).toBe(dispatchId)
-          expect(contextId).toBe(blockingId)
-          expect('mono:' + contextId).toBe(monoId)
-          expect(fullParticipant.id).toBe(contextId)
-      })
+        it('should maintain participant across mixed concurrent requests', async () => {
+            const [contextId, dispatchId, blockingId, monoId, fullParticipant] = await Promise.all([
+                TEST_SERVICE.getParticipantIdFromContext(),
+                TEST_SERVICE.getParticipantIdFromContextViaDispatch(),
+                TEST_SERVICE.getParticipantIdFromContextInExecuteBlocking(),
+                TEST_SERVICE.getParticipantIdFromMonoChain(),
+                TEST_SERVICE.getFullParticipantFromContext(),
+            ])
+            expect(contextId).toBeDefined()
+            expect(contextId).toBe(dispatchId)
+            expect(contextId).toBe(blockingId)
+            expect('mono:' + contextId).toBe(monoId)
+            expect(fullParticipant.id).toBe(contextId)
+        })
 
+    })
   })
 })

--- a/kinotic-js/workspace/packages/core/test/KinoticUnavailable.test.ts
+++ b/kinotic-js/workspace/packages/core/test/KinoticUnavailable.test.ts
@@ -10,71 +10,73 @@ import {KINOTIC_DOCKER_IMAGE} from './TestHelper.js'
 Object.assign(global, { WebSocket})
 
 // These tests live in their own fle because if working improperly, the can cause the test to hang
-describe('Kinotic JS Client', () => {
-  describe('Kinotic Unavailable Tests', () => {
+describe('Kinotic JS', () => {
+  describe('packages/core', () => {
+    describe('Kinotic Unavailable Tests', () => {
 
-      it('should fail fast on connection attempt', async () => {
-          const host: string = 'notavailable'
-          const port: number = 58503
-          console.log(`Trying to Connecting to Unavailable Kinotic Gateway`)
-          const ci = new ConnectionInfo()
-          ci.host = host
-          ci.port = port
-          ci.maxConnectionAttempts = 3
-          ci.webSocketFactory = authedWebSocketFactory(host, port)
+        it('should fail fast on connection attempt', async () => {
+            const host: string = 'notavailable'
+            const port: number = 58503
+            console.log(`Trying to Connecting to Unavailable Kinotic Gateway`)
+            const ci = new ConnectionInfo()
+            ci.host = host
+            ci.port = port
+            ci.maxConnectionAttempts = 3
+            ci.webSocketFactory = authedWebSocketFactory(host, port)
 
-          // The reconnect-exhausted failure carries the underlying WS/DNS error as the Error cause
-          // rather than concatenating its (environment-specific) text into the message.
-          // connect() rejects with the fatal error's message string (StompConnectionManager
-          // rejects with err.message); the underlying WS/DNS error is environment-specific, so
-          // assert only the stable reconnect-exhausted message.
-          const error: unknown = await Kinotic.connect(ci).then(() => null, (e) => e)
-          expect(error).toBe('Max number of reconnection attempts reached')
+            // The reconnect-exhausted failure carries the underlying WS/DNS error as the Error cause
+            // rather than concatenating its (environment-specific) text into the message.
+            // connect() rejects with the fatal error's message string (StompConnectionManager
+            // rejects with err.message); the underlying WS/DNS error is environment-specific, so
+            // assert only the stable reconnect-exhausted message.
+            const error: unknown = await Kinotic.connect(ci).then(() => null, (e) => e)
+            expect(error).toBe('Max number of reconnection attempts reached')
 
-          await expect(Kinotic.disconnect()).resolves.toBeUndefined()
-      }, 1000 * 60 * 10) // 10 minutes
+            await expect(Kinotic.disconnect()).resolves.toBeUndefined()
+        }, 1000 * 60 * 10) // 10 minutes
 
-      it('should connect to gateway and then fail after reconnection attempts after gateway is offline',
-         {"timeout": 1000 * 60 * 3},
-         async () => {
-             let container: StartedTestContainer
-             let connectionInfo: ConnectionInfo = new ConnectionInfo()
+        it('should connect to gateway and then fail after reconnection attempts after gateway is offline',
+           {"timeout": 1000 * 60 * 3},
+           async () => {
+               let container: StartedTestContainer
+               let connectionInfo: ConnectionInfo = new ConnectionInfo()
 
-             // Start the Kinotic Gateway container
-             console.log('Starting Kinotic Gateway for sticky session gateway restart reconnection test')
+               // Start the Kinotic Gateway container
+               console.log('Starting Kinotic Gateway for sticky session gateway restart reconnection test')
 
-             container = await new GenericContainer(KINOTIC_DOCKER_IMAGE)
-                 .withExposedPorts({container: 58503, host: 58590})
-                 .withEnvironment({SPRING_PROFILES_ACTIVE: "clienttest"})
-                 .withPullPolicy(PullPolicy.alwaysPull())
-                 .withWaitStrategy(Wait.forHttp('/health', 58503).forStatusCodeMatching(c => c === 200 || c === 204))
-                 .withName('maxretries-container')
-                 .start()
+               container = await new GenericContainer(KINOTIC_DOCKER_IMAGE)
+                   .withExposedPorts({container: 58503, host: 58590})
+                   .withEnvironment({SPRING_PROFILES_ACTIVE: "clienttest"})
+                   .withPullPolicy(PullPolicy.alwaysPull())
+                   .withWaitStrategy(Wait.forHttp('/health', 58503).forStatusCodeMatching(c => c === 200 || c === 204))
+                   .withName('maxretries-container')
+                   .start()
 
-             // Create connection info with default activity-based session keep alive
-             connectionInfo.host = container.getHost()
-             connectionInfo.port = 58590
-             connectionInfo.maxConnectionAttempts = 3
-             connectionInfo.sessionKeepAlive = SessionKeepAliveMode.ACTIVITY
-             connectionInfo.webSocketFactory = authedWebSocketFactory(connectionInfo.host, connectionInfo.port)
-             console.log(`Kinotic Gateway running at ${connectionInfo.host}:${connectionInfo.port}`)
+               // Create connection info with default activity-based session keep alive
+               connectionInfo.host = container.getHost()
+               connectionInfo.port = 58590
+               connectionInfo.maxConnectionAttempts = 3
+               connectionInfo.sessionKeepAlive = SessionKeepAliveMode.ACTIVITY
+               connectionInfo.webSocketFactory = authedWebSocketFactory(connectionInfo.host, connectionInfo.port)
+               console.log(`Kinotic Gateway running at ${connectionInfo.host}:${connectionInfo.port}`)
 
-             const continuum = new KinoticSingleton()
-             let connectedInfo: ConnectedInfo = await logFailure(continuum.connect(connectionInfo),
-                                                                 'Failed to connect to Kinotic Gateway')
-             validateConnectedInfo(connectedInfo)
-             console.log(`Kinotic Gateway started at ${connectionInfo.host}:${connectionInfo.port}`)
+               const continuum = new KinoticSingleton()
+               let connectedInfo: ConnectedInfo = await logFailure(continuum.connect(connectionInfo),
+                                                                   'Failed to connect to Kinotic Gateway')
+               validateConnectedInfo(connectedInfo)
+               console.log(`Kinotic Gateway started at ${connectionInfo.host}:${connectionInfo.port}`)
 
-             const testService = new TestService(continuum)
+               const testService = new TestService(continuum)
 
-             // stop the gateway
-             await container.stop()
+               // stop the gateway
+               await container.stop()
 
-             await expect(testService.testMethodWithString("Bob")).rejects.toThrowError(new Error('Connection disconnected'))
+               await expect(testService.testMethodWithString("Bob")).rejects.toThrowError(new Error('Connection disconnected'))
 
-             await continuum.disconnect()
+               await continuum.disconnect()
 
-         })
+           })
 
+    })
   })
 })

--- a/kinotic-js/workspace/packages/core/test/Publish.test.ts
+++ b/kinotic-js/workspace/packages/core/test/Publish.test.ts
@@ -6,195 +6,197 @@ import { createConnectionInfo, logFailure, validateConnectedInfo } from "./TestH
 import { firstValueFrom, Observable } from "rxjs"
 import { v4 as uuidv4 } from "uuid"
 
-describe('Kinotic JS Client', () => {
-  describe("Publish Mechanism", () => {
-      let noScopeService: TestServiceNoScope
-      let scopedService: TestServiceWithScope
-      let replyToId: string
+describe('Kinotic JS', () => {
+  describe('packages/core', () => {
+    describe("Publish Mechanism", () => {
+        let noScopeService: TestServiceNoScope
+        let scopedService: TestServiceWithScope
+        let replyToId: string
 
-      beforeAll(async () => {
-          const connectionInfo = createConnectionInfo()
-          const connectedInfo: ConnectedInfo = await logFailure(
-              Kinotic.connect(connectionInfo),
-              "Failed to connect to Kinotic Gateway"
-          )
-          validateConnectedInfo(connectedInfo)
-          replyToId = connectedInfo.replyToId // Capture the replyToId from the server
+        beforeAll(async () => {
+            const connectionInfo = createConnectionInfo()
+            const connectedInfo: ConnectedInfo = await logFailure(
+                Kinotic.connect(connectionInfo),
+                "Failed to connect to Kinotic Gateway"
+            )
+            validateConnectedInfo(connectedInfo)
+            replyToId = connectedInfo.replyToId // Capture the replyToId from the server
 
-          // Register services once
-          noScopeService = new TestServiceNoScope()
-          scopedService = new TestServiceWithScope()
-      }, 1000 * 60 * 10) // 10 minutes
+            // Register services once
+            noScopeService = new TestServiceNoScope()
+            scopedService = new TestServiceWithScope()
+        }, 1000 * 60 * 10) // 10 minutes
 
-      afterAll(async () => {
-          await expect(Kinotic.disconnect()).resolves.toBeUndefined()
-      })
+        afterAll(async () => {
+            await expect(Kinotic.disconnect()).resolves.toBeUndefined()
+        })
 
-      const createTestEvent = (cri: string, replyTo: string, args?: any[] | null): IEvent => {
-          const event = new Event(cri, new Map([
-                                                   [EventConstants.REPLY_TO_HEADER, replyTo],
-                                                   [EventConstants.CONTENT_TYPE_HEADER, "application/json"],
-                                               ]))
-          if (args != null) {
-              event.setDataString(JSON.stringify(args))
-          }
-          return event
-      }
+        const createTestEvent = (cri: string, replyTo: string, args?: any[] | null): IEvent => {
+            const event = new Event(cri, new Map([
+                                                     [EventConstants.REPLY_TO_HEADER, replyTo],
+                                                     [EventConstants.CONTENT_TYPE_HEADER, "application/json"],
+                                                 ]))
+            if (args != null) {
+                event.setDataString(JSON.stringify(args))
+            }
+            return event
+        }
 
-      const sendAndReceiveEvent = async (cri: string, args?: any[] | null): Promise<any> => {
-          const replyTo = `${EventConstants.REPLY_DESTINATION_PREFIX}${replyToId}:${uuidv4()}@continuum.js.EventBus/replyHandler`
-          const event = createTestEvent(cri, replyTo, args)
-          const response: Observable<IEvent> = Kinotic.eventBus.observe(replyTo)
-          const resultPromise = firstValueFrom(response)
-          Kinotic.eventBus.send(event)
-          const result = await resultPromise
-          if (result.hasHeader(EventConstants.ERROR_HEADER)) {
-              throw new Error(result.getHeader(EventConstants.ERROR_HEADER))
-          }
-          return JSON.parse(result.getDataString())
-      }
+        const sendAndReceiveEvent = async (cri: string, args?: any[] | null): Promise<any> => {
+            const replyTo = `${EventConstants.REPLY_DESTINATION_PREFIX}${replyToId}:${uuidv4()}@continuum.js.EventBus/replyHandler`
+            const event = createTestEvent(cri, replyTo, args)
+            const response: Observable<IEvent> = Kinotic.eventBus.observe(replyTo)
+            const resultPromise = firstValueFrom(response)
+            Kinotic.eventBus.send(event)
+            const result = await resultPromise
+            if (result.hasHeader(EventConstants.ERROR_HEADER)) {
+                throw new Error(result.getHeader(EventConstants.ERROR_HEADER))
+            }
+            return JSON.parse(result.getDataString())
+        }
 
-      describe("Non-async methods without scope", () => {
-          it("should invoke greet synchronously", async () => {
-              const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/greet", ["Alice"])
-              expect(result).toBe("Hello, Alice!")
-          })
+        describe("Non-async methods without scope", () => {
+            it("should invoke greet synchronously", async () => {
+                const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/greet", ["Alice"])
+                expect(result).toBe("Hello, Alice!")
+            })
 
-          it("should invoke combine with multiple args synchronously", async () => {
-              const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/combine", ["test", 42])
-              expect(result).toBe("test - 42")
-          })
-      })
+            it("should invoke combine with multiple args synchronously", async () => {
+                const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/combine", ["test", 42])
+                expect(result).toBe("test - 42")
+            })
+        })
 
-      describe("Async methods without scope", () => {
-          it("should invoke fetchData asynchronously", async () => {
-              const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/fetchData", [42])
-              expect(result).toEqual({ id: 42, value: "Data for 42" })
-          })
+        describe("Async methods without scope", () => {
+            it("should invoke fetchData asynchronously", async () => {
+                const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/fetchData", [42])
+                expect(result).toEqual({ id: 42, value: "Data for 42" })
+            })
 
-          it("should invoke multiArgs with multiple args asynchronously", async () => {
-              const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/multiArgs", [1, "two", true])
-              expect(result).toEqual({ x: 1, y: "two", z: true })
-          })
-      })
+            it("should invoke multiArgs with multiple args asynchronously", async () => {
+                const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/multiArgs", [1, "two", true])
+                expect(result).toEqual({ x: 1, y: "two", z: true })
+            })
+        })
 
-      describe("Non-async methods with scope", () => {
-          it("should invoke greet with scope synchronously", async () => {
-              const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/greet", ["Bob"])
-              expect(result).toBe("Hello, Bob from tenant!")
-          })
+        describe("Non-async methods with scope", () => {
+            it("should invoke greet with scope synchronously", async () => {
+                const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/greet", ["Bob"])
+                expect(result).toBe("Hello, Bob from tenant!")
+            })
 
-          it("should invoke combine with scope synchronously", async () => {
-              const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/combine", ["test", 42])
-              expect(result).toBe("test - 42 in tenant")
-          })
-      })
+            it("should invoke combine with scope synchronously", async () => {
+                const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/combine", ["test", 42])
+                expect(result).toBe("test - 42 in tenant")
+            })
+        })
 
-      describe("Async methods with scope", () => {
-          it("should invoke fetchData with scope asynchronously", async () => {
-              const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/fetchData", [99])
-              expect(result).toEqual({ id: 99, value: "Data for 99", scope: "tenant" })
-          })
+        describe("Async methods with scope", () => {
+            it("should invoke fetchData with scope asynchronously", async () => {
+                const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/fetchData", [99])
+                expect(result).toEqual({ id: 99, value: "Data for 99", scope: "tenant" })
+            })
 
-          it("should invoke multiArgs with scope asynchronously", async () => {
-              const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/multiArgs", [1, "two", true])
-              expect(result).toEqual({ x: 1, y: "two", z: true, scope: "tenant" })
-          })
-      })
+            it("should invoke multiArgs with scope asynchronously", async () => {
+                const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/multiArgs", [1, "two", true])
+                expect(result).toEqual({ x: 1, y: "two", z: true, scope: "tenant" })
+            })
+        })
 
-      describe("Method parsing and conflict avoidance", () => {
-          it("should distinguish between methods with different names (no scope)", async () => {
-              const greetResult = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/greet", ["Charlie"])
-              const combineResult = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/combine", ["test", 123])
-              expect(greetResult).toBe("Hello, Charlie!")
-              expect(combineResult).toBe("test - 123")
-          })
+        describe("Method parsing and conflict avoidance", () => {
+            it("should distinguish between methods with different names (no scope)", async () => {
+                const greetResult = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/greet", ["Charlie"])
+                const combineResult = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/combine", ["test", 123])
+                expect(greetResult).toBe("Hello, Charlie!")
+                expect(combineResult).toBe("test - 123")
+            })
 
-          it("should distinguish between methods with different names (with scope)", async () => {
-              const greetResult = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/greet", ["Charlie"])
-              const combineResult = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/combine", ["test", 123])
-              expect(greetResult).toBe("Hello, Charlie from tenant!")
-              expect(combineResult).toBe("test - 123 in tenant")
-          })
+            it("should distinguish between methods with different names (with scope)", async () => {
+                const greetResult = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/greet", ["Charlie"])
+                const combineResult = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/combine", ["test", 123])
+                expect(greetResult).toBe("Hello, Charlie from tenant!")
+                expect(combineResult).toBe("test - 123 in tenant")
+            })
 
-          it("should handle scoped vs unscoped services independently", async () => {
-              const noScopeResult = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/greet", ["Dave"])
-              const scopeResult = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/greet", ["Eve"])
-              expect(noScopeResult).toBe("Hello, Dave!")
-              expect(scopeResult).toBe("Hello, Eve from tenant!")
-          })
-      })
+            it("should handle scoped vs unscoped services independently", async () => {
+                const noScopeResult = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/greet", ["Dave"])
+                const scopeResult = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/greet", ["Eve"])
+                expect(noScopeResult).toBe("Hello, Dave!")
+                expect(scopeResult).toBe("Hello, Eve from tenant!")
+            })
+        })
 
-      describe("Error propagation", () => {
-          describe("Non-async errors without scope", () => {
-              it("should propagate synchronous error", async () => {
-                  await expect(sendAndReceiveEvent("srv://com.example.TestServiceNoScope/failSync")).rejects.toThrow("Sync failure")
-              })
-          })
+        describe("Error propagation", () => {
+            describe("Non-async errors without scope", () => {
+                it("should propagate synchronous error", async () => {
+                    await expect(sendAndReceiveEvent("srv://com.example.TestServiceNoScope/failSync")).rejects.toThrow("Sync failure")
+                })
+            })
 
-          describe("Async errors without scope", () => {
-              it("should propagate asynchronous error", async () => {
-                  await expect(sendAndReceiveEvent("srv://com.example.TestServiceNoScope/failAsync")).rejects.toThrow("Async failure")
-              })
-          })
+            describe("Async errors without scope", () => {
+                it("should propagate asynchronous error", async () => {
+                    await expect(sendAndReceiveEvent("srv://com.example.TestServiceNoScope/failAsync")).rejects.toThrow("Async failure")
+                })
+            })
 
-          describe("Non-async errors with scope", () => {
-              it("should propagate synchronous error with scope", async () => {
-                  await expect(sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/failSync")).rejects.toThrow("Scoped sync failure")
-              })
-          })
+            describe("Non-async errors with scope", () => {
+                it("should propagate synchronous error with scope", async () => {
+                    await expect(sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/failSync")).rejects.toThrow("Scoped sync failure")
+                })
+            })
 
-          describe("Async errors with scope", () => {
-              it("should propagate asynchronous error with scope", async () => {
-                  await expect(sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/failAsync")).rejects.toThrow("Scoped async failure")
-              })
-          })
+            describe("Async errors with scope", () => {
+                it("should propagate asynchronous error with scope", async () => {
+                    await expect(sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/failAsync")).rejects.toThrow("Scoped async failure")
+                })
+            })
 
-          describe("Argument count mismatch", () => {
-              it("should fail when too many arguments are provided to greet", async () => {
-                  await expect(sendAndReceiveEvent("srv://com.example.TestServiceNoScope/greet", ["Alice", "Extra"])).rejects.toThrow(
-                      "Argument count mismatch for method greet: expected 1, got 2"
-                  )
-              })
+            describe("Argument count mismatch", () => {
+                it("should fail when too many arguments are provided to greet", async () => {
+                    await expect(sendAndReceiveEvent("srv://com.example.TestServiceNoScope/greet", ["Alice", "Extra"])).rejects.toThrow(
+                        "Argument count mismatch for method greet: expected 1, got 2"
+                    )
+                })
 
-              it("should fail when too few arguments are provided to combine", async () => {
-                  await expect(sendAndReceiveEvent("srv://com.example.TestServiceNoScope/combine", ["test"])).rejects.toThrow(
-                      "Argument count mismatch for method combine: expected 2, got 1"
-                  )
-              })
-          })
+                it("should fail when too few arguments are provided to combine", async () => {
+                    await expect(sendAndReceiveEvent("srv://com.example.TestServiceNoScope/combine", ["test"])).rejects.toThrow(
+                        "Argument count mismatch for method combine: expected 2, got 1"
+                    )
+                })
+            })
 
-          describe("Complex object handling", () => {
-              it("should process complex object without scope", async () => {
-                  const complexObj = { name: "Alice", age: 30, details: { active: true, score: 85 } }
-                  const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/processComplexObject", [complexObj])
-                  expect(result).toBe("Alice is 30 years old, active: true, score: 85")
-              })
+            describe("Complex object handling", () => {
+                it("should process complex object without scope", async () => {
+                    const complexObj = { name: "Alice", age: 30, details: { active: true, score: 85 } }
+                    const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/processComplexObject", [complexObj])
+                    expect(result).toBe("Alice is 30 years old, active: true, score: 85")
+                })
 
-              it("should process complex object with scope", async () => {
-                  const complexObj = { name: "Bob", age: 25, details: { active: false, score: 90 } }
-                  const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/processComplexObject", [complexObj])
-                  expect(result).toBe("Bob is 25 years old, active: false, score: 90 in tenant")
-              })
+                it("should process complex object with scope", async () => {
+                    const complexObj = { name: "Bob", age: 25, details: { active: false, score: 90 } }
+                    const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/processComplexObject", [complexObj])
+                    expect(result).toBe("Bob is 25 years old, active: false, score: 90 in tenant")
+                })
 
-              it("should process list of complex objects without scope", async () => {
-                  const list = [
-                      { id: 1, tags: ["a", "b"] },
-                      { id: 2, tags: ["c"] }
-                  ]
-                  const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/processListOfComplexObjects", [list])
-                  expect(result).toBe(6) // 1 + 2 (ids) + 2 + 1 (tag counts) = 6
-              })
+                it("should process list of complex objects without scope", async () => {
+                    const list = [
+                        { id: 1, tags: ["a", "b"] },
+                        { id: 2, tags: ["c"] }
+                    ]
+                    const result = await sendAndReceiveEvent("srv://com.example.TestServiceNoScope/processListOfComplexObjects", [list])
+                    expect(result).toBe(6) // 1 + 2 (ids) + 2 + 1 (tag counts) = 6
+                })
 
-              it("should process list of complex objects with scope", async () => {
-                  const list = [
-                      { id: 1, tags: ["a", "b"] },
-                      { id: 2, tags: ["c"] }
-                  ]
-                  const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/processListOfComplexObjects", [list])
-                  expect(result).toBe(12) // 1 + 2 (ids) + 2 + 1 (tag counts) + 6 (tenant.length) = 12
-              })
-          })
-      })
+                it("should process list of complex objects with scope", async () => {
+                    const list = [
+                        { id: 1, tags: ["a", "b"] },
+                        { id: 2, tags: ["c"] }
+                    ]
+                    const result = await sendAndReceiveEvent("srv://tenant@com.example.TestServiceWithScope/processListOfComplexObjects", [list])
+                    expect(result).toBe(12) // 1 + 2 (ids) + 2 + 1 (tag counts) + 6 (tenant.length) = 12
+                })
+            })
+        })
+    })
   })
 })

--- a/kinotic-js/workspace/packages/spawn/bunfig.toml
+++ b/kinotic-js/workspace/packages/spawn/bunfig.toml
@@ -1,5 +1,6 @@
 [test]
 # Installs the bun:test module mock that captures Allure results. Each file's tests are nested
-# under a describe('Kinotic Spawn', ...) so allure-bun derives parentSuite="Kinotic Spawn" from the
-# top of the suite path, bucketing the spawn suite alongside the other kinotic-js suites.
+# under describe('Kinotic JS', () => describe('packages/spawn', ...)) so allure-bun derives
+# parentSuite="Kinotic JS" and suite="packages/spawn" from the top of the suite path, bucketing the
+# spawn suite under the shared Kinotic JS tree alongside the other kinotic-js suites.
 preload = ["allure-bun/setup"]

--- a/kinotic-js/workspace/packages/spawn/test/NodeSpawnRenderer.test.ts
+++ b/kinotic-js/workspace/packages/spawn/test/NodeSpawnRenderer.test.ts
@@ -4,97 +4,99 @@ import os from 'node:os'
 import path from 'node:path'
 import {assertPathWithin, lintSpawnDir, NodeSpawnRenderer} from '../src/node/index'
 
-describe('Kinotic Spawn', () => {
-  const tmpDirs: string[] = []
+describe('Kinotic JS', () => {
+  describe('packages/spawn', () => {
+    const tmpDirs: string[] = []
 
-  function spawnDirWith(files: Record<string, string>): string {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-node-src-'))
-    tmpDirs.push(dir)
-    for (const [rel, content] of Object.entries(files)) {
-      const p = path.join(dir, rel)
-      fs.mkdirSync(path.dirname(p), {recursive: true})
-      fs.writeFileSync(p, content)
+    function spawnDirWith(files: Record<string, string>): string {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-node-src-'))
+      tmpDirs.push(dir)
+      for (const [rel, content] of Object.entries(files)) {
+        const p = path.join(dir, rel)
+        fs.mkdirSync(path.dirname(p), {recursive: true})
+        fs.writeFileSync(p, content)
+      }
+      return dir
     }
-    return dir
-  }
 
-  function freshDestination(): string {
-    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-node-dst-'))
-    tmpDirs.push(base)
-    return path.join(base, 'out')
-  }
-
-  afterEach(() => {
-    for (const dir of tmpDirs.splice(0)) {
-      fs.rmSync(dir, {recursive: true, force: true})
+    function freshDestination(): string {
+      const base = fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-node-dst-'))
+      tmpDirs.push(base)
+      return path.join(base, 'out')
     }
-  })
 
-  describe('NodeSpawnRenderer', () => {
-
-    it('renders a spawn from disk to disk, excluding spawn.json', async () => {
-      const spawnDir = spawnDirWith({
-        'spawn.json': JSON.stringify({globals: {flavor: 'x'}}),
-        'package.json.liquid': '{"name": "{{ projectName }}", "flavor": "{{ flavor }}"}',
-        'src/{{ projectName | upperFirst }}.ts.liquid': 'export class {{ projectName | upperFirst }} {}',
-        '.gitignore': 'node_modules\n',
-      })
-      const destination = freshDestination()
-
-      const context = await new NodeSpawnRenderer().render(spawnDir, destination, {context: {projectName: 'acme'}})
-
-      expect(JSON.parse(fs.readFileSync(path.join(destination, 'package.json'), 'utf8')))
-        .toEqual({name: 'acme', flavor: 'x'})
-      expect(fs.readFileSync(path.join(destination, 'src/Acme.ts'), 'utf8')).toBe('export class Acme {}')
-      expect(fs.readFileSync(path.join(destination, '.gitignore'), 'utf8')).toBe('node_modules\n')
-      expect(fs.existsSync(path.join(destination, 'spawn.json'))).toBe(false)
-      expect(context.flavor).toBe('x')
+    afterEach(() => {
+      for (const dir of tmpDirs.splice(0)) {
+        fs.rmSync(dir, {recursive: true, force: true})
+      }
     })
 
-    it('throws when the destination already exists', async () => {
-      const spawnDir = spawnDirWith({'a.txt': 'x'})
-      const destination = fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-node-dst-'))
-      tmpDirs.push(destination)
+    describe('NodeSpawnRenderer', () => {
 
-      await expect(new NodeSpawnRenderer().render(spawnDir, destination, {context: {}}))
-        .rejects.toThrow(/already exists/)
-    })
+      it('renders a spawn from disk to disk, excluding spawn.json', async () => {
+        const spawnDir = spawnDirWith({
+          'spawn.json': JSON.stringify({globals: {flavor: 'x'}}),
+          'package.json.liquid': '{"name": "{{ projectName }}", "flavor": "{{ flavor }}"}',
+          'src/{{ projectName | upperFirst }}.ts.liquid': 'export class {{ projectName | upperFirst }} {}',
+          '.gitignore': 'node_modules\n',
+        })
+        const destination = freshDestination()
 
-    it('refuses to write outside the destination when a path escapes the root', async () => {
-      const spawnDir = spawnDirWith({'{{ out }}.txt': 'pwned'})
-      const destination = freshDestination()
+        const context = await new NodeSpawnRenderer().render(spawnDir, destination, {context: {projectName: 'acme'}})
 
-      await expect(new NodeSpawnRenderer().render(spawnDir, destination, {context: {out: '../../../escape'}}))
-        .rejects.toThrow(/escapes/)
-      expect(fs.existsSync(path.resolve(destination, '../../../escape.txt'))).toBe(false)
-    })
-
-    it('refuses an inheritance ref that escapes the root', async () => {
-      const spawnDir = spawnDirWith({'spawn.json': JSON.stringify({inherits: '../../../../etc'})})
-      const destination = freshDestination()
-
-      await expect(new NodeSpawnRenderer().render(spawnDir, destination, {context: {}}))
-        .rejects.toThrow(/escapes/)
-    })
-
-    it('assertPathWithin allows internal ../ but rejects escapes and absolutes', () => {
-      const root = path.resolve('/tmp/root')
-      expect(assertPathWithin(root, 'a/b.txt')).toBe(path.join(root, 'a/b.txt'))
-      expect(assertPathWithin(root, 'a/../b.txt')).toBe(path.join(root, 'b.txt'))
-      expect(() => assertPathWithin(root, '../escape')).toThrow(/escapes/)
-      expect(() => assertPathWithin(root, '/etc/passwd')).toThrow(/escapes/)
-    })
-
-    it('lintSpawnDir reports undeclared variables from a spawn directory', async () => {
-      const spawnDir = spawnDirWith({
-        'spawn.json': JSON.stringify({propertySchema: {projectName: {type: 'string'}}}),
-        'a.txt.liquid': '{{ projectName }} {{ missing }}',
+        expect(JSON.parse(fs.readFileSync(path.join(destination, 'package.json'), 'utf8')))
+          .toEqual({name: 'acme', flavor: 'x'})
+        expect(fs.readFileSync(path.join(destination, 'src/Acme.ts'), 'utf8')).toBe('export class Acme {}')
+        expect(fs.readFileSync(path.join(destination, '.gitignore'), 'utf8')).toBe('node_modules\n')
+        expect(fs.existsSync(path.join(destination, 'spawn.json'))).toBe(false)
+        expect(context.flavor).toBe('x')
       })
 
-      const result = await lintSpawnDir(spawnDir)
+      it('throws when the destination already exists', async () => {
+        const spawnDir = spawnDirWith({'a.txt': 'x'})
+        const destination = fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-node-dst-'))
+        tmpDirs.push(destination)
 
-      expect(result.undeclared).toEqual([{name: 'missing', files: ['a.txt.liquid']}])
+        await expect(new NodeSpawnRenderer().render(spawnDir, destination, {context: {}}))
+          .rejects.toThrow(/already exists/)
+      })
+
+      it('refuses to write outside the destination when a path escapes the root', async () => {
+        const spawnDir = spawnDirWith({'{{ out }}.txt': 'pwned'})
+        const destination = freshDestination()
+
+        await expect(new NodeSpawnRenderer().render(spawnDir, destination, {context: {out: '../../../escape'}}))
+          .rejects.toThrow(/escapes/)
+        expect(fs.existsSync(path.resolve(destination, '../../../escape.txt'))).toBe(false)
+      })
+
+      it('refuses an inheritance ref that escapes the root', async () => {
+        const spawnDir = spawnDirWith({'spawn.json': JSON.stringify({inherits: '../../../../etc'})})
+        const destination = freshDestination()
+
+        await expect(new NodeSpawnRenderer().render(spawnDir, destination, {context: {}}))
+          .rejects.toThrow(/escapes/)
+      })
+
+      it('assertPathWithin allows internal ../ but rejects escapes and absolutes', () => {
+        const root = path.resolve('/tmp/root')
+        expect(assertPathWithin(root, 'a/b.txt')).toBe(path.join(root, 'a/b.txt'))
+        expect(assertPathWithin(root, 'a/../b.txt')).toBe(path.join(root, 'b.txt'))
+        expect(() => assertPathWithin(root, '../escape')).toThrow(/escapes/)
+        expect(() => assertPathWithin(root, '/etc/passwd')).toThrow(/escapes/)
+      })
+
+      it('lintSpawnDir reports undeclared variables from a spawn directory', async () => {
+        const spawnDir = spawnDirWith({
+          'spawn.json': JSON.stringify({propertySchema: {projectName: {type: 'string'}}}),
+          'a.txt.liquid': '{{ projectName }} {{ missing }}',
+        })
+
+        const result = await lintSpawnDir(spawnDir)
+
+        expect(result.undeclared).toEqual([{name: 'missing', files: ['a.txt.liquid']}])
+      })
+
     })
-
   })
 })

--- a/kinotic-js/workspace/packages/spawn/test/SpawnEngine.test.ts
+++ b/kinotic-js/workspace/packages/spawn/test/SpawnEngine.test.ts
@@ -2,206 +2,208 @@ import {describe, expect, it, vi} from 'bun:test'
 import {SpawnEngine} from '../src/index'
 import type {PropertyResolver, SpawnTree} from '../src/index'
 
-describe('Kinotic Spawn', () => {
-  describe('SpawnEngine', () => {
+describe('Kinotic JS', () => {
+  describe('packages/spawn', () => {
+    describe('SpawnEngine', () => {
 
-    it('renders liquid content and strips the .liquid suffix', async () => {
-      const spawn: SpawnTree = {
-        'package.json.liquid': '{"name": "{{projectName}}"}',
-      }
+      it('renders liquid content and strips the .liquid suffix', async () => {
+        const spawn: SpawnTree = {
+          'package.json.liquid': '{"name": "{{projectName}}"}',
+        }
 
-      const result = await new SpawnEngine().renderSpawn(spawn, {context: {projectName: 'my-app'}})
+        const result = await new SpawnEngine().renderSpawn(spawn, {context: {projectName: 'my-app'}})
 
-      expect(result.files).toEqual({'package.json': '{"name": "my-app"}'})
-    })
-
-    it('renders liquid expressions in paths', async () => {
-      const spawn: SpawnTree = {
-        'src/{{ package | packageToPath }}/{{ name | upperFirst }}.ts.liquid': 'export class {{ name | upperFirst }} {}',
-      }
-
-      const result = await new SpawnEngine().renderSpawn(spawn, {context: {package: 'org.kinotic.demo', name: 'widget'}})
-
-      expect(result.files).toEqual({'src/org/kinotic/demo/Widget.ts': 'export class Widget {}'})
-      // sources maps the rendered destination back to its template path
-      expect(result.sources).toEqual({
-        'src/org/kinotic/demo/Widget.ts': 'src/{{ package | packageToPath }}/{{ name | upperFirst }}.ts.liquid',
+        expect(result.files).toEqual({'package.json': '{"name": "my-app"}'})
       })
-    })
 
-    it('applies the camelCase and encodePackage filters', async () => {
-      const spawn: SpawnTree = {
-        'out.txt.liquid': '{{ "my-cool name" | camelCase }} {{ "my-pkg.2.demo" | encodePackage }}',
-      }
+      it('renders liquid expressions in paths', async () => {
+        const spawn: SpawnTree = {
+          'src/{{ package | packageToPath }}/{{ name | upperFirst }}.ts.liquid': 'export class {{ name | upperFirst }} {}',
+        }
 
-      const result = await new SpawnEngine().renderSpawn(spawn)
+        const result = await new SpawnEngine().renderSpawn(spawn, {context: {package: 'org.kinotic.demo', name: 'widget'}})
 
-      expect(result.files['out.txt']).toBe('myCoolName my_pkg._2.demo')
-    })
+        expect(result.files).toEqual({'src/org/kinotic/demo/Widget.ts': 'export class Widget {}'})
+        // sources maps the rendered destination back to its template path
+        expect(result.sources).toEqual({
+          'src/org/kinotic/demo/Widget.ts': 'src/{{ package | packageToPath }}/{{ name | upperFirst }}.ts.liquid',
+        })
+      })
 
-    it('copies non-template files verbatim, including binary content', async () => {
-      const binary = new Uint8Array([0, 159, 146, 150])
-      const spawn: SpawnTree = {
-        'tsconfig.json': '{"strict": true}',
-        'logo.png': binary,
-      }
+      it('applies the camelCase and encodePackage filters', async () => {
+        const spawn: SpawnTree = {
+          'out.txt.liquid': '{{ "my-cool name" | camelCase }} {{ "my-pkg.2.demo" | encodePackage }}',
+        }
 
-      const result = await new SpawnEngine().renderSpawn(spawn)
+        const result = await new SpawnEngine().renderSpawn(spawn)
 
-      expect(result.files['tsconfig.json']).toBe('{"strict": true}')
-      expect(result.files['logo.png']).toBe(binary)
-    })
+        expect(result.files['out.txt']).toBe('myCoolName my_pkg._2.demo')
+      })
 
-    it('excludes spawn.json and .DS_Store from the rendered files', async () => {
-      const spawn: SpawnTree = {
-        'spawn.json': '{}',
-        '.DS_Store': new Uint8Array([1]),
-        'nested/.DS_Store': new Uint8Array([1]),
-        'keep.txt': 'kept',
-      }
+      it('copies non-template files verbatim, including binary content', async () => {
+        const binary = new Uint8Array([0, 159, 146, 150])
+        const spawn: SpawnTree = {
+          'tsconfig.json': '{"strict": true}',
+          'logo.png': binary,
+        }
 
-      const result = await new SpawnEngine().renderSpawn(spawn)
+        const result = await new SpawnEngine().renderSpawn(spawn)
 
-      expect(Object.keys(result.files)).toEqual(['keep.txt'])
-    })
+        expect(result.files['tsconfig.json']).toBe('{"strict": true}')
+        expect(result.files['logo.png']).toBe(binary)
+      })
 
-    it('merges spawn.json globals under the provided context', async () => {
-      const spawn: SpawnTree = {
-        'spawn.json': JSON.stringify({globals: {apiVersion: '^1.0.9', projectName: 'from-globals'}}),
-        'out.txt.liquid': '{{ projectName }} {{ apiVersion }}',
-      }
+      it('excludes spawn.json and .DS_Store from the rendered files', async () => {
+        const spawn: SpawnTree = {
+          'spawn.json': '{}',
+          '.DS_Store': new Uint8Array([1]),
+          'nested/.DS_Store': new Uint8Array([1]),
+          'keep.txt': 'kept',
+        }
 
-      const result = await new SpawnEngine().renderSpawn(spawn, {context: {projectName: 'from-context'}})
+        const result = await new SpawnEngine().renderSpawn(spawn)
 
-      expect(result.files['out.txt']).toBe('from-context ^1.0.9')
-      expect(result.context).toEqual({projectName: 'from-context', apiVersion: '^1.0.9'})
-    })
+        expect(Object.keys(result.files)).toEqual(['keep.txt'])
+      })
 
-    it('fails on a propertySchema entry missing from the context when no resolver is given', async () => {
-      const spawn: SpawnTree = {
-        'spawn.json': JSON.stringify({propertySchema: {projectName: {type: 'string'}}}),
-      }
+      it('merges spawn.json globals under the provided context', async () => {
+        const spawn: SpawnTree = {
+          'spawn.json': JSON.stringify({globals: {apiVersion: '^1.0.9', projectName: 'from-globals'}}),
+          'out.txt.liquid': '{{ projectName }} {{ apiVersion }}',
+        }
 
-      await expect(new SpawnEngine().renderSpawn(spawn))
-        .rejects.toThrow("No value provided for required property 'projectName'")
-    })
+        const result = await new SpawnEngine().renderSpawn(spawn, {context: {projectName: 'from-context'}})
 
-    it('obtains missing properties from the resolver with rendered message and default', async () => {
-      const spawn: SpawnTree = {
-        'spawn.json': JSON.stringify({
-          globals: {projectName: 'demo'},
-          propertySchema: {
-            libraryName: {
-              type: 'string',
-              description: 'Library name for {{ projectName }}',
-              default: '{{ projectName }}-lib',
+        expect(result.files['out.txt']).toBe('from-context ^1.0.9')
+        expect(result.context).toEqual({projectName: 'from-context', apiVersion: '^1.0.9'})
+      })
+
+      it('fails on a propertySchema entry missing from the context when no resolver is given', async () => {
+        const spawn: SpawnTree = {
+          'spawn.json': JSON.stringify({propertySchema: {projectName: {type: 'string'}}}),
+        }
+
+        await expect(new SpawnEngine().renderSpawn(spawn))
+          .rejects.toThrow("No value provided for required property 'projectName'")
+      })
+
+      it('obtains missing properties from the resolver with rendered message and default', async () => {
+        const spawn: SpawnTree = {
+          'spawn.json': JSON.stringify({
+            globals: {projectName: 'demo'},
+            propertySchema: {
+              libraryName: {
+                type: 'string',
+                description: 'Library name for {{ projectName }}',
+                default: '{{ projectName }}-lib',
+              },
             },
-          },
-        }),
-        'out.txt.liquid': '{{ libraryName }}',
-      }
-      const resolver: PropertyResolver = {
-        resolve: vi.fn(async (key, schema, message, defaultValue) => defaultValue),
-      }
+          }),
+          'out.txt.liquid': '{{ libraryName }}',
+        }
+        const resolver: PropertyResolver = {
+          resolve: vi.fn(async (key, schema, message, defaultValue) => defaultValue),
+        }
 
-      const result = await new SpawnEngine().renderSpawn(spawn, {propertyResolver: resolver})
+        const result = await new SpawnEngine().renderSpawn(spawn, {propertyResolver: resolver})
 
-      expect(resolver.resolve).toHaveBeenCalledWith(
-        'libraryName',
-        expect.objectContaining({type: 'string'}),
-        'Library name for demo',
-        'demo-lib',
-      )
-      expect(result.files['out.txt']).toBe('demo-lib')
-    })
-
-    it('does not invoke the resolver for properties already in the context', async () => {
-      const spawn: SpawnTree = {
-        'spawn.json': JSON.stringify({propertySchema: {projectName: {type: 'string'}}}),
-        'out.txt.liquid': '{{ projectName }}',
-      }
-      const resolver: PropertyResolver = {resolve: vi.fn()}
-
-      const result = await new SpawnEngine().renderSpawn(spawn, {
-        context: {projectName: 'provided'},
-        propertyResolver: resolver,
+        expect(resolver.resolve).toHaveBeenCalledWith(
+          'libraryName',
+          expect.objectContaining({type: 'string'}),
+          'Library name for demo',
+          'demo-lib',
+        )
+        expect(result.files['out.txt']).toBe('demo-lib')
       })
 
-      expect(resolver.resolve).not.toHaveBeenCalled()
-      expect(result.files['out.txt']).toBe('provided')
-    })
+      it('does not invoke the resolver for properties already in the context', async () => {
+        const spawn: SpawnTree = {
+          'spawn.json': JSON.stringify({propertySchema: {projectName: {type: 'string'}}}),
+          'out.txt.liquid': '{{ projectName }}',
+        }
+        const resolver: PropertyResolver = {resolve: vi.fn()}
 
-    it('follows inheritance: derived files and globals override the base', async () => {
-      const base: SpawnTree = {
-        'spawn.json': JSON.stringify({globals: {flavor: 'base', baseOnly: 'yes'}}),
-        'shared.txt.liquid': 'base {{ flavor }}',
-        'base.txt': 'base file',
-      }
-      const derived: SpawnTree = {
-        'spawn.json': JSON.stringify({inherits: '../base', globals: {flavor: 'derived'}}),
-        'shared.txt.liquid': 'derived {{ flavor }} {{ baseOnly }}',
-      }
-      const loadInherited = vi.fn(async (_ref: string) => base)
+        const result = await new SpawnEngine().renderSpawn(spawn, {
+          context: {projectName: 'provided'},
+          propertyResolver: resolver,
+        })
 
-      const result = await new SpawnEngine().renderSpawn(derived, {loadInherited})
-
-      expect(loadInherited).toHaveBeenCalledWith('../base')
-      expect(result.files).toEqual({
-        'shared.txt': 'derived derived yes',
-        'base.txt': 'base file',
+        expect(resolver.resolve).not.toHaveBeenCalled()
+        expect(result.files['out.txt']).toBe('provided')
       })
-    })
 
-    it('fails when a spawn inherits but no loadInherited callback is provided', async () => {
-      const spawn: SpawnTree = {
-        'spawn.json': JSON.stringify({inherits: '../base'}),
-      }
+      it('follows inheritance: derived files and globals override the base', async () => {
+        const base: SpawnTree = {
+          'spawn.json': JSON.stringify({globals: {flavor: 'base', baseOnly: 'yes'}}),
+          'shared.txt.liquid': 'base {{ flavor }}',
+          'base.txt': 'base file',
+        }
+        const derived: SpawnTree = {
+          'spawn.json': JSON.stringify({inherits: '../base', globals: {flavor: 'derived'}}),
+          'shared.txt.liquid': 'derived {{ flavor }} {{ baseOnly }}',
+        }
+        const loadInherited = vi.fn(async (_ref: string) => base)
 
-      await expect(new SpawnEngine().renderSpawn(spawn))
-        .rejects.toThrow("Spawn inherits '../base' but no loadInherited callback was provided")
-    })
+        const result = await new SpawnEngine().renderSpawn(derived, {loadInherited})
 
-    it('renders the bundled project spawn shape end to end', async () => {
-      const spawn: SpawnTree = {
-        'spawn.json': JSON.stringify({
-          globals: {kinoticApiVersion: '^1.0.9'},
-          propertySchema: {projectName: {type: 'string', description: 'The name of the project you want to create'}},
-        }),
-        'package.json.liquid': '{"name": "{{projectName}}", "catalog": {"@kinotic-ai/core": "{{ kinoticApiVersion }}"}}',
-        'packages/domain/package.json.liquid': '{"name": "{{ projectName }}/domain"}',
-        'packages/domain/model/.gitkeep': '',
-        '.gitignore': 'node_modules\n',
-      }
-
-      const result = await new SpawnEngine().renderSpawn(spawn, {context: {projectName: 'acme'}})
-
-      expect(result.files).toEqual({
-        'package.json': '{"name": "acme", "catalog": {"@kinotic-ai/core": "^1.0.9"}}',
-        'packages/domain/package.json': '{"name": "acme/domain"}',
-        'packages/domain/model/.gitkeep': '',
-        '.gitignore': 'node_modules\n',
+        expect(loadInherited).toHaveBeenCalledWith('../base')
+        expect(result.files).toEqual({
+          'shared.txt': 'derived derived yes',
+          'base.txt': 'base file',
+        })
       })
-    })
 
-    it('throws on an undeclared variable instead of rendering empty (strictVariables)', async () => {
-      await expect(new SpawnEngine().renderSpawn({'a.txt.liquid': '{{ missing }}'}, {context: {}}))
-        .rejects.toThrow(/undefined variable: missing/)
-    })
+      it('fails when a spawn inherits but no loadInherited callback is provided', async () => {
+        const spawn: SpawnTree = {
+          'spawn.json': JSON.stringify({inherits: '../base'}),
+        }
 
-    it('throws on an undeclared variable in a path', async () => {
-      await expect(new SpawnEngine().renderSpawn({'{{ missing }}/a.txt': 'hi'}, {context: {}}))
-        .rejects.toThrow(/undefined variable: missing/)
-    })
+        await expect(new SpawnEngine().renderSpawn(spawn))
+          .rejects.toThrow("Spawn inherits '../base' but no loadInherited callback was provided")
+      })
 
-    it('throws on an undeclared variable even inside a conditional or with a default filter', async () => {
-      // strictVariables looks the variable up before the filter/branch runs, so neither
-      // {% if %} nor `| default:` rescues an undeclared variable — declare optionals as
-      // globals with a real value instead.
-      await expect(new SpawnEngine().renderSpawn({'a.txt.liquid': '{% if missing %}y{% endif %}'}, {context: {}}))
-        .rejects.toThrow(/undefined variable: missing/)
-      await expect(new SpawnEngine().renderSpawn({'a.txt.liquid': '{{ missing | default: "x" }}'}, {context: {}}))
-        .rejects.toThrow(/undefined variable: missing/)
-    })
+      it('renders the bundled project spawn shape end to end', async () => {
+        const spawn: SpawnTree = {
+          'spawn.json': JSON.stringify({
+            globals: {kinoticApiVersion: '^1.0.9'},
+            propertySchema: {projectName: {type: 'string', description: 'The name of the project you want to create'}},
+          }),
+          'package.json.liquid': '{"name": "{{projectName}}", "catalog": {"@kinotic-ai/core": "{{ kinoticApiVersion }}"}}',
+          'packages/domain/package.json.liquid': '{"name": "{{ projectName }}/domain"}',
+          'packages/domain/model/.gitkeep': '',
+          '.gitignore': 'node_modules\n',
+        }
 
+        const result = await new SpawnEngine().renderSpawn(spawn, {context: {projectName: 'acme'}})
+
+        expect(result.files).toEqual({
+          'package.json': '{"name": "acme", "catalog": {"@kinotic-ai/core": "^1.0.9"}}',
+          'packages/domain/package.json': '{"name": "acme/domain"}',
+          'packages/domain/model/.gitkeep': '',
+          '.gitignore': 'node_modules\n',
+        })
+      })
+
+      it('throws on an undeclared variable instead of rendering empty (strictVariables)', async () => {
+        await expect(new SpawnEngine().renderSpawn({'a.txt.liquid': '{{ missing }}'}, {context: {}}))
+          .rejects.toThrow(/undefined variable: missing/)
+      })
+
+      it('throws on an undeclared variable in a path', async () => {
+        await expect(new SpawnEngine().renderSpawn({'{{ missing }}/a.txt': 'hi'}, {context: {}}))
+          .rejects.toThrow(/undefined variable: missing/)
+      })
+
+      it('throws on an undeclared variable even inside a conditional or with a default filter', async () => {
+        // strictVariables looks the variable up before the filter/branch runs, so neither
+        // {% if %} nor `| default:` rescues an undeclared variable — declare optionals as
+        // globals with a real value instead.
+        await expect(new SpawnEngine().renderSpawn({'a.txt.liquid': '{% if missing %}y{% endif %}'}, {context: {}}))
+          .rejects.toThrow(/undefined variable: missing/)
+        await expect(new SpawnEngine().renderSpawn({'a.txt.liquid': '{{ missing | default: "x" }}'}, {context: {}}))
+          .rejects.toThrow(/undefined variable: missing/)
+      })
+
+    })
   })
 })

--- a/kinotic-js/workspace/packages/spawn/test/SpawnLint.test.ts
+++ b/kinotic-js/workspace/packages/spawn/test/SpawnLint.test.ts
@@ -2,79 +2,81 @@ import {describe, expect, it, vi} from 'bun:test'
 import {SpawnEngine} from '../src/index'
 import type {SpawnTree} from '../src/index'
 
-describe('Kinotic Spawn', () => {
-  describe('SpawnEngine.lint', () => {
+describe('Kinotic JS', () => {
+  describe('packages/spawn', () => {
+    describe('SpawnEngine.lint', () => {
 
-    it('reports a variable used but not declared, with the files it appears in', async () => {
-      const spawn: SpawnTree = {
-        'spawn.json': JSON.stringify({
-          globals: {kinoticApiVersion: '^1.0.9'},
-          propertySchema: {projectName: {type: 'string'}, organization: {type: 'string'}},
-        }),
-        'package.json.liquid': '{"name": "{{ projectName }}", "core": "{{ kinoticApiVersion }}"}',
-        'src/{{ application | upperFirst }}.ts.liquid': '// {{ projectName }} for {{ organization }}',
-      }
+      it('reports a variable used but not declared, with the files it appears in', async () => {
+        const spawn: SpawnTree = {
+          'spawn.json': JSON.stringify({
+            globals: {kinoticApiVersion: '^1.0.9'},
+            propertySchema: {projectName: {type: 'string'}, organization: {type: 'string'}},
+          }),
+          'package.json.liquid': '{"name": "{{ projectName }}", "core": "{{ kinoticApiVersion }}"}',
+          'src/{{ application | upperFirst }}.ts.liquid': '// {{ projectName }} for {{ organization }}',
+        }
 
-      const result = await new SpawnEngine().lint(spawn)
+        const result = await new SpawnEngine().lint(spawn)
 
-      // application is used only in the path template and is declared nowhere
-      expect(result.undeclared).toEqual([
-        {name: 'application', files: ['src/{{ application | upperFirst }}.ts.liquid']},
-      ])
+        // application is used only in the path template and is declared nowhere
+        expect(result.undeclared).toEqual([
+          {name: 'application', files: ['src/{{ application | upperFirst }}.ts.liquid']},
+        ])
+      })
+
+      it('is clean when every variable is declared in propertySchema or globals', async () => {
+        const spawn: SpawnTree = {
+          'spawn.json': JSON.stringify({
+            globals: {kinoticApiVersion: '^1.0.9'},
+            propertySchema: {projectName: {type: 'string'}},
+          }),
+          'package.json.liquid': '{"name": "{{ projectName }}", "core": "{{ kinoticApiVersion }}"}',
+        }
+
+        const result = await new SpawnEngine().lint(spawn)
+
+        expect(result.undeclared).toEqual([])
+      })
+
+      it('does not flag registered filters or loop/assign locals as variables', async () => {
+        const spawn: SpawnTree = {
+          'spawn.json': JSON.stringify({propertySchema: {items: {type: 'string'}}}),
+          'out.txt.liquid': '{% for entry in items %}{{ entry | upperFirst }}{% endfor %}{% assign x = 1 %}{{ x }}',
+        }
+
+        const result = await new SpawnEngine().lint(spawn)
+
+        // entry (loop local), x (assign local), and upperFirst (filter) are not undeclared; items is declared
+        expect(result.undeclared).toEqual([])
+      })
+
+      it('treats a var declared in an inherited spawn as declared', async () => {
+        const base: SpawnTree = {
+          'spawn.json': JSON.stringify({propertySchema: {projectName: {type: 'string'}}}),
+        }
+        const derived: SpawnTree = {
+          'spawn.json': JSON.stringify({inherits: '../base'}),
+          'out.txt.liquid': '{{ projectName }}',
+        }
+        const loadInherited = vi.fn(async () => base)
+
+        const result = await new SpawnEngine().lint(derived, {loadInherited})
+
+        expect(result.undeclared).toEqual([])
+      })
+
+      it('collects every file a variable appears in, sorted', async () => {
+        const spawn: SpawnTree = {
+          'spawn.json': JSON.stringify({propertySchema: {}}),
+          'b.txt.liquid': '{{ missing }}',
+          'a.txt.liquid': '{{ missing }}',
+        }
+
+        const result = await new SpawnEngine().lint(spawn)
+
+        expect(result.undeclared).toEqual([{name: 'missing', files: ['a.txt.liquid', 'b.txt.liquid']}])
+      })
+
     })
-
-    it('is clean when every variable is declared in propertySchema or globals', async () => {
-      const spawn: SpawnTree = {
-        'spawn.json': JSON.stringify({
-          globals: {kinoticApiVersion: '^1.0.9'},
-          propertySchema: {projectName: {type: 'string'}},
-        }),
-        'package.json.liquid': '{"name": "{{ projectName }}", "core": "{{ kinoticApiVersion }}"}',
-      }
-
-      const result = await new SpawnEngine().lint(spawn)
-
-      expect(result.undeclared).toEqual([])
-    })
-
-    it('does not flag registered filters or loop/assign locals as variables', async () => {
-      const spawn: SpawnTree = {
-        'spawn.json': JSON.stringify({propertySchema: {items: {type: 'string'}}}),
-        'out.txt.liquid': '{% for entry in items %}{{ entry | upperFirst }}{% endfor %}{% assign x = 1 %}{{ x }}',
-      }
-
-      const result = await new SpawnEngine().lint(spawn)
-
-      // entry (loop local), x (assign local), and upperFirst (filter) are not undeclared; items is declared
-      expect(result.undeclared).toEqual([])
-    })
-
-    it('treats a var declared in an inherited spawn as declared', async () => {
-      const base: SpawnTree = {
-        'spawn.json': JSON.stringify({propertySchema: {projectName: {type: 'string'}}}),
-      }
-      const derived: SpawnTree = {
-        'spawn.json': JSON.stringify({inherits: '../base'}),
-        'out.txt.liquid': '{{ projectName }}',
-      }
-      const loadInherited = vi.fn(async () => base)
-
-      const result = await new SpawnEngine().lint(derived, {loadInherited})
-
-      expect(result.undeclared).toEqual([])
-    })
-
-    it('collects every file a variable appears in, sorted', async () => {
-      const spawn: SpawnTree = {
-        'spawn.json': JSON.stringify({propertySchema: {}}),
-        'b.txt.liquid': '{{ missing }}',
-        'a.txt.liquid': '{{ missing }}',
-      }
-
-      const result = await new SpawnEngine().lint(spawn)
-
-      expect(result.undeclared).toEqual([{name: 'missing', files: ['a.txt.liquid', 'b.txt.liquid']}])
-    })
-
   })
 })


### PR DESCRIPTION
Restructure test suite organization to establish a consistent hierarchy across all packages in the monorepo.

## Summary
Updated test suite `describe()` blocks to follow a uniform naming convention: top-level suite is always `'Kinotic JS'`, with a second level identifying the package (e.g., `'packages/core'`, `'packages/spawn'`), followed by feature-specific suites. This creates a predictable test hierarchy that improves test reporting, organization, and discoverability across the codebase.

## Changes
- **packages/core tests**: Renamed top-level suite from `'Kinotic JS Client'` to `'Kinotic JS'` and added `'packages/core'` as second-level suite in:
  - `Publish.test.ts`
  - `KinoticRpc.test.ts`
  - `Context.test.ts`
  - `DisableStickySession_GatewayRestart.test.ts`
  - `KinoticUnavailable.test.ts`
  - `KinoticClient.test.ts`
  - `DisableStickySession.test.ts`
  - `EventBus.test.ts`

- **packages/spawn tests**: Renamed top-level suite from `'Kinotic Spawn'` to `'Kinotic JS'` and added `'packages/spawn'` as second-level suite in:
  - `SpawnEngine.test.ts`
  - `NodeSpawnRenderer.test.ts`
  - `SpawnLint.test.ts`

- **e2e-tests**: Updated top-level suite from `'E2E Tests'` or `'Migration Service End To End Tests'` to `'Kinotic JS'` in:
  - `AdminEntityService.test.ts`
  - `AdminNamedQuery.test.ts`
  - `DataStream.test.ts`
  - `EntityService.test.ts`
  - `MigrationService.testx.ts`
  - `NamedQuery.test.ts`
  - `Versioned.test.ts`
  - `k8s-cache-eviction.test.ts`

- **bunfig.toml**: Updated comment to reflect new test hierarchy convention.

All test logic and assertions remain unchanged; only the organizational structure of the test suites was modified.

https://claude.ai/code/session_01XiWnUGcUoYzuGZLNwU9z7P