### PR TITLE
Centralize Allure test suite labeling via TestLifecycleListener

### DIFF
--- a/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
@@ -143,6 +143,12 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 }
 
+// Shared Allure test support compiled into every module: ModuleSuiteListener (an Allure
+// TestLifecycleListener registered via META-INF/services) rewrites each test's suite labels to
+// Kinotic Java > <module> > <class>, grouping all Java module tests under one bucket.
+sourceSets.test.java.srcDir(rootProject.file('gradle/allure-support/java'))
+sourceSets.test.resources.srcDir(rootProject.file('gradle/allure-support/resources'))
+
 test {
     useJUnitPlatform()
     // Keep the Allure report correct under org.gradle.caching.
@@ -151,6 +157,8 @@ test {
     //  - declare it as a task output so a cached/up-to-date test task restores the results FROM-CACHE instead of producing nothing
     //  - delete it before each execution so a re-run doesn't accumulate stale result files.
     systemProperty 'allure.results.directory', 'build/allure-results'
+    // Module name consumed by ModuleSuiteListener to set the suite (middle) level of the Allure tree.
+    systemProperty 'kinotic.allure.module', project.name
     outputs.dir(layout.buildDirectory.dir('allure-results')).withPropertyName('allureResults')
     doFirst { delete layout.buildDirectory.dir('allure-results') }
     jvmArgs(

--- a/gradle/allure-support/java/org/kinotic/test/allure/ModuleSuiteListener.java
+++ b/gradle/allure-support/java/org/kinotic/test/allure/ModuleSuiteListener.java
@@ -1,0 +1,56 @@
+package org.kinotic.test.allure;
+
+import io.qameta.allure.listener.TestLifecycleListener;
+import io.qameta.allure.model.Label;
+import io.qameta.allure.model.TestResult;
+
+import java.util.List;
+
+/**
+ * Groups every Java module's tests under a single {@code Kinotic Java} bucket in the merged Allure
+ * report, mirroring the {@code Kinotic JS} tree: {@code Kinotic Java > <module> > <class>}.
+ *
+ * <p>The module name is supplied per module by the build via the {@code kinotic.allure.module}
+ * system property. When that property is absent the listener does nothing, leaving the default
+ * labels untouched.
+ */
+public class ModuleSuiteListener implements TestLifecycleListener {
+
+    private static final String PARENT_SUITE = "Kinotic Java";
+    private static final String MODULE_PROPERTY = "kinotic.allure.module";
+
+    @Override
+    public void beforeTestStop(TestResult result) {
+        String module = System.getProperty(MODULE_PROPERTY);
+        if (module == null || module.isBlank()) {
+            return;
+        }
+
+        List<Label> labels = result.getLabels();
+
+        // allure-junit5 fixes the suite label to the fully qualified class name and never sets
+        // parentSuite/subSuite, so the class is the only suite-tree label present here. Capture it,
+        // drop the suite-tree labels, then rebuild the three levels we want.
+        String testClass = labels.stream()
+                                 .filter(label -> "suite".equals(label.getName()))
+                                 .map(Label::getValue)
+                                 .findFirst()
+                                 .orElse(null);
+
+        labels.removeIf(label -> {
+            String name = label.getName();
+            return "parentSuite".equals(name) || "suite".equals(name) || "subSuite".equals(name);
+        });
+
+        labels.add(new Label().setName("parentSuite").setValue(PARENT_SUITE));
+        labels.add(new Label().setName("suite").setValue(module));
+        if (testClass != null) {
+            labels.add(new Label().setName("subSuite").setValue(simpleClassName(testClass)));
+        }
+    }
+
+    private static String simpleClassName(String className) {
+        int lastDot = className.lastIndexOf('.');
+        return lastDot >= 0 ? className.substring(lastDot + 1) : className;
+    }
+}

--- a/gradle/allure-support/resources/META-INF/services/io.qameta.allure.listener.TestLifecycleListener
+++ b/gradle/allure-support/resources/META-INF/services/io.qameta.allure.listener.TestLifecycleListener
@@ -1,0 +1,1 @@
+org.kinotic.test.allure.ModuleSuiteListener

--- a/kinotic-core/src/test/resources/allure.properties
+++ b/kinotic-core/src/test/resources/allure.properties
@@ -1,1 +1,0 @@
-allure.label.parentSuite=Kinotic Core

--- a/kinotic-github/src/test/resources/allure.properties
+++ b/kinotic-github/src/test/resources/allure.properties
@@ -1,1 +1,0 @@
-allure.label.parentSuite=Kinotic GitHub

--- a/kinotic-idl/src/test/resources/allure.properties
+++ b/kinotic-idl/src/test/resources/allure.properties
@@ -1,1 +1,0 @@
-allure.label.parentSuite=Kinotic IDL

--- a/kinotic-migration/src/test/resources/allure.properties
+++ b/kinotic-migration/src/test/resources/allure.properties
@@ -1,1 +1,0 @@
-allure.label.parentSuite=Kinotic Migration

--- a/kinotic-sql/src/test/resources/allure.properties
+++ b/kinotic-sql/src/test/resources/allure.properties
@@ -1,1 +1,0 @@
-allure.label.parentSuite=Kinotic SQL

--- a/kinotic-test/src/test/resources/allure.properties
+++ b/kinotic-test/src/test/resources/allure.properties
@@ -1,1 +1,0 @@
-allure.label.parentSuite=Integration Tests


### PR DESCRIPTION
Replaces per-module `allure.properties` files with a shared `ModuleSuiteListener` that dynamically rewrites test suite labels during test execution.

## Summary

Test suite labels in Allure reports are now generated programmatically rather than statically configured. This centralizes the labeling logic, eliminates duplication across modules, and ensures consistent hierarchy: `Kinotic Java > <module> > <class>`.

## Changes

- **New `ModuleSuiteListener`** (`gradle/allure-support/java/org/kinotic/test/allure/ModuleSuiteListener.java`): Implements Allure's `TestLifecycleListener` to intercept test results before they're recorded. Extracts the fully qualified class name from the `suite` label (set by allure-junit5), removes all suite-tree labels, then rebuilds them as a three-level hierarchy using the module name from the `kinotic.allure.module` system property.

- **Service registration** (`gradle/allure-support/resources/META-INF/services/io.qameta.allure.listener.TestLifecycleListener`): Registers `ModuleSuiteListener` for automatic discovery by Allure's SPI.

- **Build integration** (`buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle`):
  - Adds `gradle/allure-support/java` and `gradle/allure-support/resources` to test source/resource sets so the listener is compiled and available in every module's test classpath.
  - Passes `kinotic.allure.module` system property (set to `project.name`) to the test task, supplying the module name at runtime.

- **Removed per-module configuration**: Deletes `allure.properties` from six modules (`kinotic-core`, `kinotic-github`, `kinotic-idl`, `kinotic-migration`, `kinotic-sql`, `kinotic-test`), which previously hardcoded static parent suite labels.

## Implementation Details

The listener operates in `beforeTestStop()`, after allure-junit5 has set the `suite` label to the fully qualified class name but before the result is persisted. It extracts and simplifies the class name (e.g., `com.example.MyTest` → `MyTest`), then constructs the three-level tree. If the `kinotic.allure.module` property is absent or blank, the listener is a no-op, leaving default labels untouched.

https://claude.ai/code/session_01XiWnUGcUoYzuGZLNwU9z7P