### PR TITLE
Guard Allure support injection on presence of test sources

### DIFF
--- a/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
@@ -143,11 +143,13 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
 }
 
-// Shared Allure test support compiled into every module: ModuleSuiteListener (an Allure
-// TestLifecycleListener registered via META-INF/services) rewrites each test's suite labels to
-// Kinotic Java > <module> > <class>, grouping all Java module tests under one bucket.
-sourceSets.test.java.srcDir(rootProject.file('gradle/allure-support/java'))
-sourceSets.test.resources.srcDir(rootProject.file('gradle/allure-support/resources'))
+// ModuleSuiteListener (registered via META-INF/services) regroups each test's Allure suite labels
+// as Kinotic Java > <module> > <class>. Only inject it where tests exist: adding test source to a
+// test-less module trips Gradle's failOnNoDiscoveredTests.
+if (!fileTree('src/test/java').matching { include '**/*.java' }.isEmpty()) {
+    sourceSets.test.java.srcDir(rootProject.file('gradle/allure-support/java'))
+    sourceSets.test.resources.srcDir(rootProject.file('gradle/allure-support/resources'))
+}
 
 test {
     useJUnitPlatform()


### PR DESCRIPTION
Fixes a build failure in modules with no test sources. The Allure test support (ModuleSuiteListener) was unconditionally injected into every module's test sourceset, causing Gradle's `failOnNoDiscoveredTests` to fail when a module had test sources registered but no actual test classes.

**Changes:**
- Wrapped the Allure support source injection in a guard that checks for the presence of `.java` files in `src/test/java`
- Only injects the shared Allure listener and resources when the module actually has test sources
- Added clarifying comments explaining the guard's purpose

This allows modules without tests to skip the Allure support injection entirely, preventing the "test sources present but zero tests discovered" failure while maintaining the shared test listener for modules that do have tests.

https://claude.ai/code/session_01XiWnUGcUoYzuGZLNwU9z7P