### PR TITLE
Route origin CRI through streaming replies for cancel handling

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConstants.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/EventConstants.java
@@ -52,8 +52,7 @@ public class EventConstants {
     public static final String CORRELATION_ID_HEADER = "__correlation-id";
 
     /**
-     * Origin service CRI sent on stream replies so a client can address a cancel back to the service.
-     * The {@code __} prefix persists it across messages.
+     * Origin service CRI sent on stream replies so a client can route a cancel back to the service.
      */
     public static final String ORIGIN_CRI_HEADER = "__origin-cri";
 

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
@@ -161,11 +161,19 @@ public class ServiceInvocationSupervisor {
     }
 
     private void convertAndSend(Metadata incomingMetadata, HandlerMethod handlerMethod, Object result) {
+        convertAndSend(incomingMetadata, handlerMethod, result, null);
+    }
+
+    private void convertAndSend(Metadata incomingMetadata, HandlerMethod handlerMethod, Object result, String originCri) {
         try {
             Event<byte[]> resultEvent = returnValueConverter.convert(incomingMetadata,
                                                                      handlerMethod.getReturnType()
                                                                                   .getParameterType(),
                                                                      result);
+            // Set the origin CRI on the reply so a streaming client can route a cancel back to this service.
+            if (originCri != null) {
+                resultEvent.metadata().put(EventConstants.ORIGIN_CRI_HEADER, originCri);
+            }
             eventBusService.send(resultEvent);
         } catch (Exception e) {
             if(log.isDebugEnabled()){
@@ -302,9 +310,6 @@ public class ServiceInvocationSupervisor {
 
                 String correlationId = incomingEvent.metadata().get(EventConstants.CORRELATION_ID_HEADER);
 
-                // Send the origin CRI so a client can route a cancel back to this service.
-                incomingMetadata.put(EventConstants.ORIGIN_CRI_HEADER, incomingEvent.cri().raw());
-
                 activeStreamingResults.computeIfAbsent(correlationId, _ -> {
                     //  FIXME: logic error here clients like the js client will stay alive during multiple requests even though previous request was invalidated indirectly
                     Flux<?> flux = Flux.from(reactiveAdapter.toPublisher(result));
@@ -312,7 +317,7 @@ public class ServiceInvocationSupervisor {
                     CRI replyCRI = CRI.create(incomingEvent.metadata().get(EventConstants.REPLY_TO_HEADER));
                     Flux<ListenerStatus> replyListenerStatus = eventBusService.monitorListenerStatus(replyCRI);
 
-                    StreamSubscriber streamSubscriber = new StreamSubscriber(incomingMetadata, handlerMethod, replyListenerStatus);
+                    StreamSubscriber streamSubscriber = new StreamSubscriber(incomingMetadata, handlerMethod, replyListenerStatus, incomingEvent.cri().raw());
                     flux.subscribe(streamSubscriber);
                     return streamSubscriber;
                 });
@@ -442,14 +447,17 @@ public class ServiceInvocationSupervisor {
         private final HandlerMethod handlerMethod;
         private final Metadata incomingMetadata;
         private final Flux<ListenerStatus> replyListenerStatus;
+        private final String originCri;
         private ReplyListenerStatusSubscriber replyListenerStatusSubscriber;
 
         public StreamSubscriber(Metadata incomingMetadata,
                                 HandlerMethod handlerMethod,
-                                Flux<ListenerStatus> replyListenerStatus) {
+                                Flux<ListenerStatus> replyListenerStatus,
+                                String originCri) {
             this.incomingMetadata = incomingMetadata;
             this.handlerMethod = handlerMethod;
             this.replyListenerStatus = replyListenerStatus;
+            this.originCri = originCri;
         }
 
         public void processControlEvent(Event<byte[]> incomingEvent){
@@ -506,7 +514,7 @@ public class ServiceInvocationSupervisor {
             if(log.isTraceEnabled()){
                 log.trace("Next stream value {}", value);
             }
-            convertAndSend(incomingMetadata, handlerMethod, value);
+            convertAndSend(incomingMetadata, handlerMethod, value, originCri);
         }
 
         @Override

--- a/kinotic-js/workspace/packages/core/src/api/event/IEventBus.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/IEventBus.ts
@@ -187,8 +187,7 @@ export enum EventConstants {
     CORRELATION_ID_HEADER = '__correlation-id',
 
     /**
-     * Origin service CRI the server sends on stream replies so the client can address a cancel back to
-     * it. The __ prefix persists it across messages.
+     * Origin service CRI the server sends on stream replies so the client can route a cancel back to it.
      */
     ORIGIN_CRI_HEADER = '__origin-cri',
 


### PR DESCRIPTION
## Summary
Refactor how the origin service CRI is propagated through streaming event replies, enabling clients to route cancel messages back to the originating service.

## Changes

**ServiceInvocationSupervisor.java**
- Extract `convertAndSend(Metadata, HandlerMethod, Object)` into an overload that accepts an optional `originCri` parameter
- Pass `originCri` through to `convertAndSend()` calls in `StreamSubscriber.hookOnNext()` so each streamed value carries the origin service identifier
- Move origin CRI assignment from incoming metadata (line 305) to the result event metadata (line 314-316), ensuring it's set on replies rather than request state
- Update `StreamSubscriber` constructor to accept and store `originCri` from `incomingEvent.cri().raw()`

**EventConstants.java & IEventBus.ts**
- Clarify javadoc: change "address a cancel" to "route a cancel" for consistency and accuracy across Java and TypeScript definitions

## Implementation Details

The origin CRI now flows through the event reply chain:
1. Captured from the incoming event's CRI when `StreamSubscriber` is instantiated
2. Stored as an instance field in `StreamSubscriber`
3. Passed to `convertAndSend()` for each streamed value
4. Set on the result event's metadata with `EventConstants.ORIGIN_CRI_HEADER` key

This ensures streaming clients receive the service's own CRI on each reply, allowing them to construct cancel messages that route back to the correct service instance.

https://claude.ai/code/session_011bErGUuxUzo1gfJJYhge9H