### PR TITLE
Cancel orphaned RPC streams to prevent server-side resource leaks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,8 @@ The split is about audience, not formatting. Javadoc is for **consumers** of the
 
 Keep comments concise — usually a single line. Spend more words only where the logic is genuinely not straightforward and the extra explanation earns its place: a subtle invariant, a non-obvious interaction, a reason that isn't visible in the code. A comment's length should track how hard the code is to follow, not how important the code is.
 
+Comment the code as it is now, not its history. Don't narrate what the code used to do or the edit you're making — no "before", "previously", "used to", "changed from", or "now does X instead" phrasing. The diff and git history record what changed; the comment describes the present state.
+
 Use standard programming vocabulary in comments — the terms from GoF, Fowler's Refactoring, and the JDK/framework docs: delegate, factory, guard clause, invariant, idempotent, race condition, callback, dispatch. Never literary metaphors or coined phrases ("prologue", "dance", "journey", "saga"). Reference the actual method and class names involved rather than describing them indirectly. State cause and effect directly.
 
 Never remove or alter an existing authorship comment — `Created by <name> on <date>`, `@author`, or similar attribution. Preserve it verbatim (name, accents, emoji, date, punctuation) when editing or refactoring a file, including when you rewrite the surrounding Javadoc/JSDoc, and carry it with the type if you move that type to another file.

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/DefaultServiceRegistry.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/DefaultServiceRegistry.java
@@ -119,6 +119,7 @@ public class DefaultServiceRegistry implements ServiceRegistry {
                                                   rpcReturnValueHandlerFactory,
                                                   eventBusService,
                                                   securityContext,
+                                                  vertx,
                                                   Thread.currentThread().getContextClassLoader());
     }
 
@@ -134,6 +135,7 @@ public class DefaultServiceRegistry implements ServiceRegistry {
                                                   rpcReturnValueHandlerFactory,
                                                   eventBusService,
                                                   securityContext,
+                                                  vertx,
                                                   Thread.currentThread().getContextClassLoader());
     }
 

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/DefaultRpcServiceProxyHandle.java
@@ -3,6 +3,7 @@
 
 package org.kinotic.core.internal.api.service.rpc;
 
+import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.eventbus.ReplyFailure;
@@ -27,6 +28,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -49,6 +51,7 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
     private final RpcReturnValueHandlerFactory rpcReturnValueHandlerFactory;
     private final EventBusService eventBusService;
     private final SecurityContext securityContext;
+    private final Vertx vertx;
 
     private final Map<Method, Integer> methodsWithScopeAnnotation = new HashMap<>();
     private final EventConsumer replyEventConsumer;
@@ -56,6 +59,9 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
     private final AtomicBoolean released = new AtomicBoolean(false);
 
     private final ConcurrentHashMap<String, RpcReturnValueHandler> responseMap = new ConcurrentHashMap<>();
+    // correlationIds we recently sent a cancel for, to debounce the in-flight burst before the server stops
+    private final Set<String> recentlyReaped = ConcurrentHashMap.newKeySet();
+    private static final long REAP_DEBOUNCE_MS = 5000;
 
     public DefaultRpcServiceProxyHandle(ServiceIdentifier serviceIdentifier,
                                         String nodeName,
@@ -64,6 +70,7 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
                                         RpcReturnValueHandlerFactory rpcReturnValueHandlerFactory,
                                         EventBusService eventBusService,
                                         SecurityContext securityContext,
+                                        Vertx vertx,
                                         ClassLoader classLoader) {
 
         Validate.notNull(serviceIdentifier, "serviceIdentifier must not be null");
@@ -73,6 +80,7 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
         Validate.notNull(rpcReturnValueHandlerFactory, "returnValueHandlerFactory must not be null");
         Validate.notNull(eventBusService, "eventBusService must not be null");
         Validate.notNull(securityContext, "securityContext must not be null");
+        Validate.notNull(vertx, "vertx must not be null");
         Validate.notNull(classLoader, "classLoader must not be null");
 
         this.serviceIdentifier = serviceIdentifier;
@@ -83,6 +91,7 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
         this.rpcReturnValueHandlerFactory = rpcReturnValueHandlerFactory;
         this.eventBusService = eventBusService;
         this.securityContext = securityContext;
+        this.vertx = vertx;
 
         this.handlerCRI = CRI.create(EventConstants.REPLY_DESTINATION_SCHEME, encodedNodeName + ":" + UUID.randomUUID(), KinoticUtil.safeEncodeURI(serviceClass.getName())+"RpcProxyResponseHandler");
 
@@ -124,7 +133,7 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
                                 release();
                             }
                         }else{
-                            log.error("Received Message for correlationId: {} but no response handler is set", correlationId);
+                            reapOrphanedStream(event, correlationId);
                         }
 
                     }else{
@@ -147,6 +156,30 @@ public class DefaultRpcServiceProxyHandle<T> implements RpcServiceProxyHandle<T>
 
             responseMap.forEach((s, returnValueHandler) -> returnValueHandler.cancel(serviceClass.getSimpleName() + " released. No further responses will be processed"));
             responseMap.clear();
+            recentlyReaped.clear();
+        }
+    }
+
+    /**
+     * Handles a reply for a correlationId this proxy no longer tracks by cancelling the orphaned stream.
+     * The server can't detect such an abandoned stream itself, since all of this proxy's requests share one
+     * reply destination, so we route a cancel to the origin CRI the server sends on stream replies.
+     */
+    private void reapOrphanedStream(Event<byte[]> event, String correlationId){
+        String originCri = event.metadata().get(EventConstants.ORIGIN_CRI_HEADER);
+        if(originCri == null){
+            log.error("Received Message for correlationId: {} but no response handler is set", correlationId);
+            return;
+        }
+        // recentlyReaped debounces the burst of in-flight values that arrive before the server stops; the
+        // timer expires the entry so a lost cancel self-heals on the next stray value.
+        if(recentlyReaped.add(correlationId)){
+            vertx.setTimer(REAP_DEBOUNCE_MS, _ -> recentlyReaped.remove(correlationId));
+
+            Metadata metadata = Metadata.create();
+            metadata.put(EventConstants.CONTROL_HEADER, EventConstants.CONTROL_VALUE_CANCEL);
+            metadata.put(EventConstants.CORRELATION_ID_HEADER, correlationId);
+            eventBusService.send(Event.create(CRI.create(originCri), metadata, null));
         }
     }
 


### PR DESCRIPTION
When an RPC proxy releases or a response handler is removed before the server finishes streaming replies, the server continues sending messages to a reply destination that no longer has a handler. This change detects such orphaned streams and sends a cancel control message back to the origin, allowing the server to clean up resources.

**Changes:**

- Add `Vertx` instance to `DefaultRpcServiceProxyHandle` to enable timer-based debouncing
- Replace error log for missing response handlers with `reapOrphanedStream()` method that:
  - Extracts the origin CRI from the reply message metadata
  - Tracks recently-cancelled correlationIds in `recentlyReaped` set to debounce the burst of in-flight messages that arrive before the server stops
  - Sends a cancel control message back to the origin CRI with a 5-second debounce window
- Update `DefaultServiceRegistry` to pass `vertx` when constructing proxy handles
- Update CLAUDE.md to clarify that comments should describe code as it is now, not its history

The debounce mechanism prevents a flood of duplicate cancel messages when multiple stray replies arrive in quick succession before the server detects the stream is abandoned.

https://claude.ai/code/session_011bErGUuxUzo1gfJJYhge9H