### PR TITLE
Replace Class<?> with MethodParameter in ReturnValueConverter

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/BinaryReturnValueConverter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/BinaryReturnValueConverter.java
@@ -18,9 +18,9 @@ import org.springframework.util.MimeTypeUtils;
 import java.util.Map;
 
 /**
- * Sends {@code byte[]} and {@link Buffer} return values straight through as
- * {@code application/octet-stream}, skipping JSON serialization. For reactive returns the element
- * type decides, so a {@code Flux<byte[]>} streams raw bytes per element.
+ * Sends {@code byte[]} and {@link Buffer} return values straight through as {@code application/octet-stream},
+ * skipping JSON serialization — whether returned directly (e.g. {@code byte[] getArray()}) or as the element
+ * of a reactive type (e.g. {@code Flux<byte[]>}, which streams raw bytes per element).
  */
 @Component
 // Must be selected ahead of JacksonReturnValueConverter, which otherwise claims any return on a JSON request.

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/BinaryReturnValueConverter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/BinaryReturnValueConverter.java
@@ -19,8 +19,9 @@ import java.util.Map;
 
 /**
  * Sends {@code byte[]} and {@link Buffer} return values straight through as {@code application/octet-stream},
- * skipping JSON serialization — whether returned directly (e.g. {@code byte[] getArray()}) or as the element
- * of a reactive type (e.g. {@code Flux<byte[]>}, which streams raw bytes per element).
+ * skipping JSON serialization — whether returned directly (e.g. {@code byte[] getArray()}) or as the value of any
+ * reactive type the {@link ReactiveAdapterRegistry} recognizes (e.g. {@code Mono<byte[]>}, {@code Flux<byte[]>},
+ * {@code Future<byte[]>}).
  */
 @Component
 // Must be selected ahead of JacksonReturnValueConverter, which otherwise claims any return on a JSON request.
@@ -48,7 +49,8 @@ public class BinaryReturnValueConverter implements ReturnValueConverter {
     }
 
     /**
-     * The declared return type, or the element type for reactive returns (e.g. {@code Flux<byte[]>} to {@code byte[]}).
+     * The declared return type, or its value type when the return is a reactive type the
+     * {@link ReactiveAdapterRegistry} recognizes (e.g. {@code Flux<byte[]>} to {@code byte[]}).
      */
     private Class<?> resolveValueType(MethodParameter returnType) {
         Class<?> declaredType = returnType.getParameterType();

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/BinaryReturnValueConverter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/BinaryReturnValueConverter.java
@@ -25,11 +25,11 @@ import java.util.Map;
 @Component
 // Must be selected ahead of JacksonReturnValueConverter, which otherwise claims any return on a JSON request.
 @Order(Ordered.HIGHEST_PRECEDENCE)
-public class RawReturnValueConverter implements ReturnValueConverter {
+public class BinaryReturnValueConverter implements ReturnValueConverter {
 
     private final ReactiveAdapterRegistry reactiveAdapterRegistry;
 
-    public RawReturnValueConverter(ReactiveAdapterRegistry reactiveAdapterRegistry) {
+    public BinaryReturnValueConverter(ReactiveAdapterRegistry reactiveAdapterRegistry) {
         this.reactiveAdapterRegistry = reactiveAdapterRegistry;
     }
 

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/RawReturnValueConverter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/RawReturnValueConverter.java
@@ -7,10 +7,10 @@ import org.kinotic.core.api.event.Event;
 import org.kinotic.core.api.event.EventConstants;
 import org.kinotic.core.api.event.Metadata;
 import org.kinotic.core.internal.utils.EventUtil;
+import org.springframework.core.GenericTypeResolver;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.Ordered;
 import org.springframework.core.ReactiveAdapterRegistry;
-import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MimeTypeUtils;
@@ -53,7 +53,7 @@ public class RawReturnValueConverter implements ReturnValueConverter {
     private Class<?> resolveValueType(MethodParameter returnType) {
         Class<?> declaredType = returnType.getParameterType();
         if (reactiveAdapterRegistry.getAdapter(declaredType) != null) {
-            Class<?> elementType = ResolvableType.forMethodParameter(returnType).getGeneric(0).resolve();
+            Class<?> elementType = GenericTypeResolver.resolveReturnTypeArgument(returnType.getMethod(), declaredType);
             if (elementType != null) {
                 return elementType;
             }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/RawReturnValueConverter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/RawReturnValueConverter.java
@@ -1,0 +1,64 @@
+
+
+package org.kinotic.core.internal.api.service.invoker;
+
+import io.vertx.core.buffer.Buffer;
+import org.kinotic.core.api.event.Event;
+import org.kinotic.core.api.event.EventConstants;
+import org.kinotic.core.api.event.Metadata;
+import org.kinotic.core.internal.utils.EventUtil;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.Ordered;
+import org.springframework.core.ReactiveAdapterRegistry;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MimeTypeUtils;
+
+import java.util.Map;
+
+/**
+ * Sends {@code byte[]} and {@link Buffer} return values straight through as
+ * {@code application/octet-stream}, skipping JSON serialization. For reactive returns the element
+ * type decides, so a {@code Flux<byte[]>} streams raw bytes per element.
+ */
+@Component
+// Must be selected ahead of JacksonReturnValueConverter, which otherwise claims any return on a JSON request.
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RawReturnValueConverter implements ReturnValueConverter {
+
+    private final ReactiveAdapterRegistry reactiveAdapterRegistry;
+
+    public RawReturnValueConverter(ReactiveAdapterRegistry reactiveAdapterRegistry) {
+        this.reactiveAdapterRegistry = reactiveAdapterRegistry;
+    }
+
+    @Override
+    public boolean supports(Metadata incomingMetadata, MethodParameter returnType) {
+        Class<?> valueType = resolveValueType(returnType);
+        return byte[].class.isAssignableFrom(valueType) || Buffer.class.isAssignableFrom(valueType);
+    }
+
+    @Override
+    public Event<byte[]> convert(Metadata incomingMetadata, MethodParameter returnType, Object returnValue) {
+        byte[] bytes = returnValue instanceof Buffer buffer ? buffer.getBytes() : (byte[]) returnValue;
+        return EventUtil.createReplyEvent(incomingMetadata,
+                                          Map.of(EventConstants.CONTENT_TYPE_HEADER, MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE),
+                                          () -> bytes);
+    }
+
+    /**
+     * The declared return type, or the element type for reactive returns (e.g. {@code Flux<byte[]>} to {@code byte[]}).
+     */
+    private Class<?> resolveValueType(MethodParameter returnType) {
+        Class<?> declaredType = returnType.getParameterType();
+        if (reactiveAdapterRegistry.getAdapter(declaredType) != null) {
+            Class<?> elementType = ResolvableType.forMethodParameter(returnType).getGeneric(0).resolve();
+            if (elementType != null) {
+                return elementType;
+            }
+        }
+        return declaredType;
+    }
+
+}

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ReturnValueConverter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ReturnValueConverter.java
@@ -5,6 +5,7 @@ package org.kinotic.core.internal.api.service.invoker;
 import org.kinotic.core.api.event.Event;
 import org.kinotic.core.api.event.Metadata;
 import org.kinotic.core.api.event.EventBusService;
+import org.springframework.core.MethodParameter;
 
 /**
  * Converts the return value to a {@link Event} that can bes sent on the {@link EventBusService}
@@ -18,18 +19,18 @@ public interface ReturnValueConverter {
     /**
      * Converts the return value to an {@link Event} to send
      * @param incomingMetadata the original {@link Metadata} sent to the {@link ServiceInvocationSupervisor}
-     * @param returnType of the {@link java.lang.reflect.Method} that was invoked to get this return value
+     * @param returnType the {@link MethodParameter} describing the return type of the invoked method
      * @param returnValue that was returned by the invoked method
      * @return the {@link Event} containing the converted data
      */
-    Event<byte[]> convert(Metadata incomingMetadata, Class<?> returnType, Object returnValue);
+    Event<byte[]> convert(Metadata incomingMetadata, MethodParameter returnType, Object returnValue);
 
     /**
      * Checks it a given {@link ReturnValueConverter} supports the incoming {@link Event} by checking the data provided
      * @param incomingMetadata the original {@link Metadata} sent to the {@link ServiceInvocationSupervisor}
-     * @param returnType of the {@link java.lang.reflect.Method} that will be invoked
+     * @param returnType the {@link MethodParameter} describing the return type of the method that will be invoked
      * @return true if this converter can handle the data
      */
-    boolean supports(Metadata incomingMetadata, Class<?> returnType);
+    boolean supports(Metadata incomingMetadata, MethodParameter returnType);
 
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ReturnValueConverterComposite.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ReturnValueConverterComposite.java
@@ -4,6 +4,7 @@ package org.kinotic.core.internal.api.service.invoker;
 
 import org.kinotic.core.api.event.Event;
 import org.kinotic.core.api.event.Metadata;
+import org.springframework.core.MethodParameter;
 import org.springframework.util.Assert;
 
 import java.util.Collections;
@@ -38,18 +39,18 @@ public class ReturnValueConverterComposite implements ReturnValueConverter {
     }
 
     @Override
-    public Event<byte[]> convert(Metadata incomingMetadata, Class<?> returnType, Object returnValue) {
+    public Event<byte[]> convert(Metadata incomingMetadata, MethodParameter returnType, Object returnValue) {
         ReturnValueConverter converter = selectConverter(incomingMetadata, returnType);
         Assert.notNull(converter,"Unsupported Return Value no ReturnValueConverter can be found. Should call supports() first.");
         return converter.convert(incomingMetadata, returnType, returnValue);
     }
 
     @Override
-    public boolean supports(Metadata incomingMetadata, Class<?> returnType) {
+    public boolean supports(Metadata incomingMetadata, MethodParameter returnType) {
         return selectConverter(incomingMetadata, returnType) != null;
     }
 
-    private ReturnValueConverter selectConverter(Metadata incomingMetadata, Class<?> returnType){
+    private ReturnValueConverter selectConverter(Metadata incomingMetadata, MethodParameter returnType){
         ReturnValueConverter ret = null;
         for(ReturnValueConverter converter : converters){
             if(converter.supports(incomingMetadata, returnType)){

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
@@ -167,8 +167,7 @@ public class ServiceInvocationSupervisor {
     private void convertAndSend(Metadata incomingMetadata, HandlerMethod handlerMethod, Object result, String originCri) {
         try {
             Event<byte[]> resultEvent = returnValueConverter.convert(incomingMetadata,
-                                                                     handlerMethod.getReturnType()
-                                                                                  .getParameterType(),
+                                                                     handlerMethod.getReturnType(),
                                                                      result);
             // Set the origin CRI on the reply so a streaming client can route a cancel back to this service.
             if (originCri != null) {
@@ -249,7 +248,7 @@ public class ServiceInvocationSupervisor {
                 }
 
                 if (!returnValueConverter.supports(incomingEvent.metadata(),
-                                                   handlerMethod.getReturnType().getParameterType())) {
+                                                   handlerMethod.getReturnType())) {
                     throw new IllegalStateException("No compatible ReturnValueConverter found");
                 }
 

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/json/JacksonReturnValueConverter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/json/JacksonReturnValueConverter.java
@@ -9,6 +9,7 @@ import org.kinotic.core.api.event.Metadata;
 import org.kinotic.core.api.security.SecurityContext;
 import org.kinotic.core.internal.api.service.invoker.ReturnValueConverter;
 import org.kinotic.core.internal.api.service.json.AbstractJacksonSupport;
+import org.springframework.core.MethodParameter;
 import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MimeTypeUtils;
@@ -31,9 +32,9 @@ public class JacksonReturnValueConverter extends AbstractJacksonSupport implemen
     }
 
     @Override
-    public Event<byte[]> convert(Metadata incomingMetadata, Class<?> returnType, Object returnValue) {
+    public Event<byte[]> convert(Metadata incomingMetadata, MethodParameter returnType, Object returnValue) {
         // insure void return types are not mistakenly seen as null
-        if(Void.TYPE.isAssignableFrom(returnType)){
+        if(Void.TYPE.isAssignableFrom(returnType.getParameterType())){
             returnValue = Void.TYPE;
         }
         HashMap<String,String> headers = new HashMap<>(1);
@@ -43,7 +44,7 @@ public class JacksonReturnValueConverter extends AbstractJacksonSupport implemen
     }
 
     @Override
-    public boolean supports(Metadata incomingMetadata, Class<?> returnType) {
+    public boolean supports(Metadata incomingMetadata, MethodParameter returnType) {
         return containsJsonContent(incomingMetadata);
     }
 

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/converters/BinaryRpcResponseConverter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/converters/BinaryRpcResponseConverter.java
@@ -13,8 +13,8 @@ import org.springframework.util.MimeTypeUtils;
 
 /**
  * Decodes {@code application/octet-stream} responses into the {@code byte[]} or {@link Buffer} the caller
- * declared. The client-side counterpart of {@code BinaryReturnValueConverter}. Resolves the reactive
- * element type (e.g. {@code Flux<byte[]>} to {@code byte[]}) so streaming binary responses decode per element.
+ * declared — whether a direct return (e.g. {@code byte[] getArray()}) or a reactive element type
+ * (e.g. {@code Flux<byte[]>} decoded per element). The client-side counterpart of {@code BinaryReturnValueConverter}.
  */
 @Component
 public class BinaryRpcResponseConverter implements RpcResponseConverter {

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/converters/BinaryRpcResponseConverter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/converters/BinaryRpcResponseConverter.java
@@ -1,0 +1,55 @@
+
+
+package org.kinotic.core.internal.api.service.rpc.converters;
+
+import io.vertx.core.buffer.Buffer;
+import org.kinotic.core.api.event.Event;
+import org.kinotic.core.api.event.EventConstants;
+import org.kinotic.core.internal.api.service.rpc.RpcResponseConverter;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ReactiveAdapterRegistry;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MimeTypeUtils;
+
+/**
+ * Decodes {@code application/octet-stream} responses into the {@code byte[]} or {@link Buffer} the caller
+ * declared. The client-side counterpart of {@code BinaryReturnValueConverter}. Resolves the reactive
+ * element type (e.g. {@code Flux<byte[]>} to {@code byte[]}) so streaming binary responses decode per element.
+ */
+@Component
+public class BinaryRpcResponseConverter implements RpcResponseConverter {
+
+    private final ReactiveAdapterRegistry reactiveAdapterRegistry;
+
+    public BinaryRpcResponseConverter(ReactiveAdapterRegistry reactiveAdapterRegistry) {
+        this.reactiveAdapterRegistry = reactiveAdapterRegistry;
+    }
+
+    @Override
+    public boolean supports(Event<byte[]> responseEvent, MethodParameter methodParameter) {
+        String contentType = responseEvent.metadata().get(EventConstants.CONTENT_TYPE_HEADER);
+        if (!MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE.equals(contentType)) {
+            return false;
+        }
+        Class<?> valueType = resolveValueType(methodParameter);
+        return byte[].class.isAssignableFrom(valueType) || Buffer.class.isAssignableFrom(valueType);
+    }
+
+    @Override
+    public Object convert(Event<byte[]> responseEvent, MethodParameter methodParameter) {
+        byte[] data = responseEvent.data();
+        return Buffer.class.isAssignableFrom(resolveValueType(methodParameter)) ? Buffer.buffer(data) : data;
+    }
+
+    /**
+     * The declared type, or the element type for reactive returns (e.g. {@code Flux<byte[]>} to {@code byte[]}).
+     */
+    private Class<?> resolveValueType(MethodParameter methodParameter) {
+        MethodParameter parameter = methodParameter;
+        if (reactiveAdapterRegistry.getAdapter(parameter.getParameterType()) != null) {
+            parameter = parameter.nested();
+        }
+        return parameter.getNestedParameterType();
+    }
+
+}

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/converters/BinaryRpcResponseConverter.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/rpc/converters/BinaryRpcResponseConverter.java
@@ -12,9 +12,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.MimeTypeUtils;
 
 /**
- * Decodes {@code application/octet-stream} responses into the {@code byte[]} or {@link Buffer} the caller
- * declared — whether a direct return (e.g. {@code byte[] getArray()}) or a reactive element type
- * (e.g. {@code Flux<byte[]>} decoded per element). The client-side counterpart of {@code BinaryReturnValueConverter}.
+ * Decodes {@code application/octet-stream} responses into the {@code byte[]} or {@link Buffer} the caller declared
+ * — whether returned directly (e.g. {@code byte[] getArray()}) or as the value of any reactive type the
+ * {@link ReactiveAdapterRegistry} recognizes (e.g. {@code Mono<byte[]>}, {@code Flux<byte[]>}, {@code Future<byte[]>}).
+ * The client-side counterpart of {@code BinaryReturnValueConverter}.
  */
 @Component
 public class BinaryRpcResponseConverter implements RpcResponseConverter {
@@ -42,7 +43,8 @@ public class BinaryRpcResponseConverter implements RpcResponseConverter {
     }
 
     /**
-     * The declared type, or the element type for reactive returns (e.g. {@code Flux<byte[]>} to {@code byte[]}).
+     * The declared type, or its value type when the return is a reactive type the
+     * {@link ReactiveAdapterRegistry} recognizes (e.g. {@code Flux<byte[]>} to {@code byte[]}).
      */
     private Class<?> resolveValueType(MethodParameter methodParameter) {
         MethodParameter parameter = methodParameter;

--- a/kinotic-js/workspace/packages/core/src/api/ServiceRegistry.ts
+++ b/kinotic-js/workspace/packages/core/src/api/ServiceRegistry.ts
@@ -204,10 +204,12 @@ class ServiceProxy implements IServiceProxy {
                             .pipe(map<IEvent, any>((value: IEvent): any => {
                                 const contentType: string | undefined = value.getHeader(EventConstants.CONTENT_TYPE_HEADER)
                                 if (contentType !== undefined) {
-                                    if (contentType === 'application/json') {
+                                    if (contentType === EventConstants.CONTENT_JSON) {
                                         return JSON.parse(value.getDataString())
-                                    } else if (contentType === 'text/plain') {
+                                    } else if (contentType === EventConstants.CONTENT_TEXT) {
                                         return value.getDataString()
+                                    } else if (contentType === EventConstants.CONTENT_OCTET_STREAM) {
+                                        return value.data.orUndefined()
                                     } else {
                                         throw new Error('Content Type ' + contentType + ' is not supported')
                                     }

--- a/kinotic-js/workspace/packages/core/src/api/event/IEventBus.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/IEventBus.ts
@@ -226,6 +226,7 @@ export enum EventConstants {
 
     CONTENT_JSON = 'application/json',
     CONTENT_TEXT = 'text/plain',
+    CONTENT_OCTET_STREAM = 'application/octet-stream',
 
     /**
      * The traceparent HTTP header field identifies the incoming request in a tracing system. It has four fields:


### PR DESCRIPTION
Replace `Class<?>` return type parameter with Spring's `MethodParameter` across the `ReturnValueConverter` interface and its implementations. This provides richer type metadata beyond just the raw class, enabling converters to inspect generic type information and method annotations.

**Changes:**

- `ReturnValueConverter` interface: Updated `convert()` and `supports()` method signatures to accept `MethodParameter returnType` instead of `Class<?> returnType`
- `ReturnValueConverterComposite`: Updated method signatures and internal `selectConverter()` helper to use `MethodParameter`
- `JacksonReturnValueConverter`: Updated method signatures; changed `Void.TYPE.isAssignableFrom(returnType)` to `Void.TYPE.isAssignableFrom(returnType.getParameterType())` to extract the class from the parameter wrapper
- `ServiceInvocationSupervisor`: Simplified call sites by passing `handlerMethod.getReturnType()` directly instead of extracting `.getParameterType()` first — the conversion now happens inside the converter implementations where it's needed

This change centralizes type inspection logic and allows converters to access method-level metadata (generics, annotations) that a bare `Class<?>` cannot provide.

https://claude.ai/code/session_011bErGUuxUzo1gfJJYhge9H