### PR TITLE
Bump @kinotic-ai/core to 1.9.1 and cascade peer floors

### DIFF
--- a/kinotic-js/workspace/bun.lock
+++ b/kinotic-js/workspace/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/core": {
       "name": "@kinotic-ai/core",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
@@ -64,7 +64,7 @@
     },
     "packages/os-api": {
       "name": "@kinotic-ai/os-api",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "dependencies": {
         "@kinotic-ai/idl": "workspace:*",
         "@kinotic-ai/persistence": "workspace:*",
@@ -77,12 +77,12 @@
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
-        "@kinotic-ai/core": ">=1.9.0",
+        "@kinotic-ai/core": ">=1.9.1",
       },
     },
     "packages/persistence": {
       "name": "@kinotic-ai/persistence",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@kinotic-ai/idl": "workspace:*",
         "reflect-metadata": "^0.2.2",
@@ -95,7 +95,7 @@
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
-        "@kinotic-ai/core": ">=1.9.0",
+        "@kinotic-ai/core": ">=1.9.1",
       },
     },
     "packages/spawn": {
@@ -114,7 +114,7 @@
     },
     "packages/vm-manager": {
       "name": "@kinotic-ai/vm-manager",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "dependencies": {
         "@boxlite-ai/boxlite": "^0.8.2",
         "@kinotic-ai/core": "workspace:*",
@@ -125,7 +125,7 @@
         "typescript": "^5.9.3",
       },
       "peerDependencies": {
-        "@kinotic-ai/core": ">=1.9.0",
+        "@kinotic-ai/core": ">=1.9.1",
         "@kinotic-ai/os-api": ">=1.14.0",
       },
     },

--- a/kinotic-js/workspace/packages/core/package.json
+++ b/kinotic-js/workspace/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/core",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "files": [
     "dist"

--- a/kinotic-js/workspace/packages/os-api/package.json
+++ b/kinotic-js/workspace/packages/os-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/os-api",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "type": "module",
   "files": [
     "dist"
@@ -32,7 +32,7 @@
     "coverage": "bun test --coverage --pass-with-no-tests"
   },
   "peerDependencies": {
-    "@kinotic-ai/core": ">=1.9.0"
+    "@kinotic-ai/core": ">=1.9.1"
   },
   "dependencies": {
     "@kinotic-ai/idl": "workspace:*",

--- a/kinotic-js/workspace/packages/persistence/package.json
+++ b/kinotic-js/workspace/packages/persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/persistence",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "files": [
     "dist"
@@ -32,7 +32,7 @@
     "coverage": "bun test --coverage --pass-with-no-tests"
   },
   "peerDependencies": {
-    "@kinotic-ai/core": ">=1.9.0"
+    "@kinotic-ai/core": ">=1.9.1"
   },
   "dependencies": {
     "@kinotic-ai/idl": "workspace:*",

--- a/kinotic-js/workspace/packages/vm-manager/package.json
+++ b/kinotic-js/workspace/packages/vm-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/vm-manager",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "type": "module",
   "files": [
     "bin",
@@ -31,7 +31,7 @@
     "coverage": "bun test --coverage --pass-with-no-tests"
   },
   "peerDependencies": {
-    "@kinotic-ai/core": ">=1.9.0",
+    "@kinotic-ai/core": ">=1.9.1",
     "@kinotic-ai/os-api": ">=1.14.0"
   },
   "dependencies": {


### PR DESCRIPTION
The `application/octet-stream` decode added to core's `ServiceRegistry` shipped in source (PR #263) without a version bump, so registry consumers still resolve `@kinotic-ai/core@1.9.0` — which throws `Content Type application/octet-stream is not supported` on binary responses. This publishes that decode.

**Changes**

| package | version | core peer floor |
|---|---|---|
| `@kinotic-ai/core` | `1.9.0` → `1.9.1` | — |
| `@kinotic-ai/os-api` | `1.14.1` → `1.14.2` | `>=1.9.0` → `>=1.9.1` |
| `@kinotic-ai/persistence` | `1.5.1` → `1.5.2` | `>=1.9.0` → `>=1.9.1` |
| `@kinotic-ai/vm-manager` | `1.0.10` → `1.0.11` | `>=1.9.0` → `>=1.9.1` |

Per the workspace versioning rule (`kinotic-js/workspace/CLAUDE.md`): bumping core raises the `@kinotic-ai/core` peerDependency floor to `>=1.9.1` in every package that declares it, and bumps each dependent's own version so the new floor actually ships. `bun.lock` is regenerated via `bun install` so the workspace versions and peer floors match the manifests.

Patch bump (rather than minor) per the call that this completes protocol support rather than adding a new feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bErGUuxUzo1gfJJYhge9H

---
_Generated by [Claude Code](https://claude.ai/code/session_011bErGUuxUzo1gfJJYhge9H)_