### PR TITLE
Add binary data passthrough support for RPC and streaming

### DIFF
--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/RpcTests.java
@@ -5,6 +5,7 @@ package org.kinotic.core.internal.api;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -126,6 +127,48 @@ public class RpcTests {
 
         StepVerifier.create(mono)
                     .expectNext(PARTICIPANT_ID + suffix)
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    public void testGetByteArray(){
+        Mono<byte[]> mono = rpcTestServiceProxy.getByteArray();
+
+        StepVerifier.create(mono)
+                    .expectNextMatches(bytes -> Arrays.equals(bytes, RpcTestService.BINARY_VALUE))
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    public void testGetBuffer(){
+        Mono<Buffer> mono = rpcTestServiceProxy.getBuffer();
+
+        StepVerifier.create(mono)
+                    .expectNextMatches(buffer -> Arrays.equals(buffer.getBytes(), RpcTestService.BINARY_VALUE))
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    public void testGetMonoByteArray(){
+        Mono<byte[]> mono = rpcTestServiceProxy.getMonoByteArray();
+
+        StepVerifier.create(mono)
+                    .expectNextMatches(bytes -> Arrays.equals(bytes, RpcTestService.BINARY_VALUE))
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    public void testGetByteArrayFlux(){
+        Flux<byte[]> flux = rpcTestServiceProxy.getByteArrayFlux();
+
+        StepVerifier.create(flux)
+                    .expectNextMatches(bytes -> Arrays.equals(bytes, RpcTestService.BINARY_CHUNKS[0]))
+                    .expectNextMatches(bytes -> Arrays.equals(bytes, RpcTestService.BINARY_CHUNKS[1]))
+                    .expectNextMatches(bytes -> Arrays.equals(bytes, RpcTestService.BINARY_CHUNKS[2]))
                     .expectComplete()
                     .verify();
     }

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/DefaultRpcTestService.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/DefaultRpcTestService.java
@@ -4,6 +4,7 @@ package org.kinotic.core.internal.api.support;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import org.kinotic.core.api.security.Participant;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -61,6 +62,21 @@ public class DefaultRpcTestService implements RpcTestService{
     }
 
     @Override
+    public Buffer getBuffer() {
+        return Buffer.buffer(RpcTestService.BINARY_VALUE);
+    }
+
+    @Override
+    public byte[] getByteArray() {
+        return RpcTestService.BINARY_VALUE;
+    }
+
+    @Override
+    public Flux<byte[]> getByteArrayFlux() {
+        return Flux.fromArray(RpcTestService.BINARY_CHUNKS);
+    }
+
+    @Override
     public Flux<String> getInfiniteFlux() {
         return Flux.create(sink -> {
             AtomicLong count = new AtomicLong(0);
@@ -84,6 +100,11 @@ public class DefaultRpcTestService implements RpcTestService{
     @Override
     public List<String> getListOfStrings() {
         return LIST_OF_STRINGS;
+    }
+
+    @Override
+    public Mono<byte[]> getMonoByteArray() {
+        return Mono.just(RpcTestService.BINARY_VALUE);
     }
 
     @Override

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestService.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestService.java
@@ -3,6 +3,7 @@
 package org.kinotic.core.internal.api.support;
 
 import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.security.Participant;
 import org.kinotic.core.internal.api.RpcTests;
@@ -33,6 +34,10 @@ public interface RpcTestService {
      */
     String STRING_VALUE = "Hello Sucka!";
 
+    byte[] BINARY_VALUE = {0, 1, 2, 3, (byte) 0xFF, (byte) 0xFE, 42, -1};
+
+    byte[][] BINARY_CHUNKS = {{10, 20, 30}, {40, 50}, {60, 70, 80, 90}};
+
     ABunchOfArgumentsHolder acceptABunchOfArguments(int intValue,
                                                     long longValue,
                                                     String stringValue,
@@ -48,11 +53,19 @@ public interface RpcTestService {
 
     String getAnotherString();
 
+    Buffer getBuffer();
+
+    byte[] getByteArray();
+
+    Flux<byte[]> getByteArrayFlux();
+
     Flux<String> getInfiniteFlux();
 
     Flux<Integer> getLimitedFlux();
 
     List<String> getListOfStrings();
+
+    Mono<byte[]> getMonoByteArray();
 
     Mono<String> getMonoEmptyString();
 

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestServiceProxy.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/support/RpcTestServiceProxy.java
@@ -3,6 +3,7 @@
 package org.kinotic.core.internal.api.support;
 
 import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
 import org.kinotic.core.api.annotations.Proxy;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -36,6 +37,12 @@ public interface RpcTestServiceProxy {
 
     Future<String> getAnotherString();
 
+    Mono<Buffer> getBuffer();
+
+    Mono<byte[]> getByteArray();
+
+    Flux<byte[]> getByteArrayFlux();
+
     Flux<String> getInfiniteFlux();
 
     Flux<Integer> getLimitedFlux();
@@ -43,6 +50,8 @@ public interface RpcTestServiceProxy {
     Mono<List<String>> getListOfStrings();
 
     Mono<String> getMissingRemoteMethodFailure();
+
+    Mono<byte[]> getMonoByteArray();
 
     Mono<String> getMonoEmptyString();
 

--- a/kinotic-js/workspace/packages/core/test/Context.test.ts
+++ b/kinotic-js/workspace/packages/core/test/Context.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest"
-import { ConnectedInfo, Kinotic, Event, EventConstants, IEvent } from "../src"
+import { ConnectedInfo, Kinotic, Event, EventConstants, type IEvent } from "../src"
 import { TestServiceWithContext } from "./TestServiceWithContext"
 import { createConnectionInfo, logFailure, validateConnectedInfo } from "./TestHelper"
 import { firstValueFrom, Observable } from "rxjs"

--- a/kinotic-js/workspace/packages/core/test/DisableStickySession_GatewayRestart.test.ts
+++ b/kinotic-js/workspace/packages/core/test/DisableStickySession_GatewayRestart.test.ts
@@ -1,7 +1,7 @@
 import {afterAll, beforeAll, describe, expect, it} from 'vitest'
 import {WebSocket} from 'ws'
 import {ConnectedInfo, ConnectionInfo, KinoticSingleton, SessionKeepAliveMode} from '../src'
-import {GenericContainer, PullPolicy, StartedTestContainer, Wait} from 'testcontainers'
+import {GenericContainer, PullPolicy, type StartedTestContainer, Wait} from 'testcontainers'
 import { authedWebSocketFactory, logFailure, validateConnectedInfo } from './TestHelper'
 import { TestService } from './ITestService'
 import {KINOTIC_DOCKER_IMAGE} from './TestHelper.js'

--- a/kinotic-js/workspace/packages/core/test/EventBus.test.ts
+++ b/kinotic-js/workspace/packages/core/test/EventBus.test.ts
@@ -1,7 +1,7 @@
 import {v4 as uuidv4} from 'uuid'
 import {afterAll, beforeAll, describe, expect, it} from 'vitest'
 import {WebSocket} from 'ws'
-import {ConnectedInfo, Kinotic, Event, EventConstants, IEvent} from '../src'
+import {ConnectedInfo, Kinotic, Event, EventConstants, type IEvent} from '../src'
 import {createConnectionInfo, logFailure, validateConnectedInfo} from './TestHelper'
 
 // This is required when running Kinotic from node

--- a/kinotic-js/workspace/packages/core/test/INonExistentService.ts
+++ b/kinotic-js/workspace/packages/core/test/INonExistentService.ts
@@ -1,4 +1,4 @@
-import {Kinotic, IServiceProxy} from '../src'
+import {Kinotic, type IServiceProxy} from '../src'
 
 export interface INonExistentService {
 

--- a/kinotic-js/workspace/packages/core/test/ITestService.ts
+++ b/kinotic-js/workspace/packages/core/test/ITestService.ts
@@ -1,4 +1,5 @@
 import {Kinotic, KinoticSingleton, IServiceProxy} from '../src'
+import {Observable} from 'rxjs'
 
 export interface ITestService {
 
@@ -7,6 +8,10 @@ export interface ITestService {
     testMissingMethod(): Promise<void>;
 
     getTestUUID(): Promise<string>;
+
+    getBinaryData(): Promise<Uint8Array>;
+
+    getBinaryDataStream(): Observable<Uint8Array>;
 
     getParticipantIdFromContext(): Promise<string>;
 
@@ -53,6 +58,14 @@ export class TestService implements ITestService {
 
     getTestUUID(): Promise<string> {
         return this.serviceProxy.invoke('getTestUUID')
+    }
+
+    getBinaryData(): Promise<Uint8Array> {
+        return this.serviceProxy.invoke('getBinaryData')
+    }
+
+    getBinaryDataStream(): Observable<Uint8Array> {
+        return this.serviceProxy.invokeStream('getBinaryDataStream')
     }
 
     getParticipantIdFromContext(): Promise<string> {

--- a/kinotic-js/workspace/packages/core/test/ITestService.ts
+++ b/kinotic-js/workspace/packages/core/test/ITestService.ts
@@ -1,4 +1,4 @@
-import {Kinotic, KinoticSingleton, IServiceProxy} from '../src'
+import {Kinotic, KinoticSingleton, type IServiceProxy} from '../src'
 import {Observable} from 'rxjs'
 
 export interface ITestService {

--- a/kinotic-js/workspace/packages/core/test/KinoticRpc.test.ts
+++ b/kinotic-js/workspace/packages/core/test/KinoticRpc.test.ts
@@ -1,5 +1,7 @@
 import {afterAll, beforeAll, describe, expect, it} from 'vitest'
 import {WebSocket} from 'ws'
+import {firstValueFrom} from 'rxjs'
+import {toArray} from 'rxjs/operators'
 import {ConnectedInfo, Kinotic} from '../src'
 import {NON_EXISTENT_SERVICE} from './INonExistentService'
 import {TEST_SERVICE} from './ITestService'
@@ -33,6 +35,23 @@ describe('Kinotic JS', () => {
 
         it('should return missing service error', async () => {
             await expect(NON_EXISTENT_SERVICE.probablyNotHome()).rejects.toThrowError('(NO_HANDLERS,-1) No handlers for address srv://com.namespace.NonExistentService')
+        })
+
+        // --- Binary Passthrough Tests ---
+
+        it('should decode a byte[] return as a binary Uint8Array', async () => {
+            const result = await TEST_SERVICE.getBinaryData()
+            expect(result).toBeInstanceOf(Uint8Array)
+            expect(Array.from(result)).toEqual([0, 1, 2, 3, 255, 254, 42, 255])
+        })
+
+        it('should decode a Flux<byte[]> stream as binary chunks', async () => {
+            const chunks = await firstValueFrom(TEST_SERVICE.getBinaryDataStream().pipe(toArray()))
+            expect(chunks.map(chunk => Array.from(chunk))).toEqual([
+                [10, 20, 30],
+                [40, 50],
+                [60, 70, 80, 90],
+            ])
         })
 
         // --- Participant Context Tests ---

--- a/kinotic-js/workspace/packages/core/test/KinoticUnavailable.test.ts
+++ b/kinotic-js/workspace/packages/core/test/KinoticUnavailable.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest'
 import {WebSocket} from 'ws'
 import {ConnectedInfo, ConnectionInfo, Kinotic, KinoticSingleton, SessionKeepAliveMode} from '../src'
-import { GenericContainer, PullPolicy, StartedTestContainer, Wait } from 'testcontainers'
+import { GenericContainer, PullPolicy, type StartedTestContainer, Wait } from 'testcontainers'
 import {TestService} from './ITestService.js'
 import { authedWebSocketFactory, logFailure, validateConnectedInfo } from './TestHelper'
 import {KINOTIC_DOCKER_IMAGE} from './TestHelper.js'

--- a/kinotic-js/workspace/packages/core/test/Publish.test.ts
+++ b/kinotic-js/workspace/packages/core/test/Publish.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest"
-import { ConnectedInfo, Kinotic, Event, EventConstants, IEvent } from "../src"
+import { ConnectedInfo, Kinotic, Event, EventConstants, type IEvent } from "../src"
 import { TestServiceNoScope } from "./TestServiceNoScope"
 import { TestServiceWithScope } from "./TestServiceWithScope"
 import { createConnectionInfo, logFailure, validateConnectedInfo } from "./TestHelper"

--- a/kinotic-js/workspace/packages/core/test/TestHelper.ts
+++ b/kinotic-js/workspace/packages/core/test/TestHelper.ts
@@ -1,4 +1,4 @@
-import {ConnectedInfo, ConnectionInfo, IWebSocket, SessionKeepAliveMode, WebSocketFactory} from '../src'
+import {ConnectedInfo, ConnectionInfo, type IWebSocket, SessionKeepAliveMode, type WebSocketFactory} from '../src'
 import { expect, inject } from 'vitest'
 import { WebSocket } from 'ws'
 import * as fs from 'fs'
@@ -29,10 +29,11 @@ export function getKinoticDockerImage(): string {
     const gradlePropsPath = path.resolve(__dirname, '../../../../../gradle.properties')
     const content = fs.readFileSync(gradlePropsPath, 'utf-8')
     const versionMatch = content.match(/kinoticVersion=(.+)/)
-    if (!versionMatch) {
+    const version = versionMatch?.[1]
+    if (!version) {
         throw new Error('Could not find kinoticVersion in gradle.properties')
     }
-    return `kinoticai/kinotic-server:${versionMatch[1].trim()}`
+    return `kinoticai/kinotic-server:${version.trim()}`
 }
 
 export const KINOTIC_DOCKER_IMAGE: string = getKinoticDockerImage()

--- a/kinotic-server/src/main/java/org/kinotic/server/clienttest/DefaultTestService.java
+++ b/kinotic-server/src/main/java/org/kinotic/server/clienttest/DefaultTestService.java
@@ -8,6 +8,7 @@ import org.kinotic.domain.api.security.ApplicationParticipant;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.*;
@@ -21,6 +22,10 @@ import java.util.concurrent.CompletableFuture;
 public class DefaultTestService implements ITestService{
 
     private static final UUID TEST_UUID = UUID.randomUUID();
+
+    private static final byte[] BINARY_DATA = {0, 1, 2, 3, (byte) 0xFF, (byte) 0xFE, 42, -1};
+
+    private static final byte[][] BINARY_CHUNKS = {{10, 20, 30}, {40, 50}, {60, 70, 80, 90}};
 
     @Autowired
     private SecurityContext securityContext;
@@ -37,6 +42,18 @@ public class DefaultTestService implements ITestService{
     @Override
     public UUID getTestUUID(){
         return TEST_UUID;
+    }
+
+    @WithSpan
+    @Override
+    public byte[] getBinaryData() {
+        return BINARY_DATA;
+    }
+
+    @WithSpan
+    @Override
+    public Flux<byte[]> getBinaryDataStream() {
+        return Flux.fromArray(BINARY_CHUNKS);
     }
 
     @WithSpan

--- a/kinotic-server/src/main/java/org/kinotic/server/clienttest/ITestService.java
+++ b/kinotic-server/src/main/java/org/kinotic/server/clienttest/ITestService.java
@@ -4,6 +4,7 @@ package org.kinotic.server.clienttest;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.annotations.Version;
 import org.kinotic.core.api.security.Participant;
+import reactor.core.publisher.Flux;
 
 import java.util.List;
 import java.util.Map;
@@ -20,6 +21,16 @@ public interface ITestService {
     String testMethodWithString(String value);
 
     UUID getTestUUID();
+
+    /**
+     * Returns a fixed binary payload to exercise the {@code application/octet-stream} passthrough.
+     */
+    byte[] getBinaryData();
+
+    /**
+     * Streams fixed binary chunks to exercise per-element {@code application/octet-stream} passthrough.
+     */
+    Flux<byte[]> getBinaryDataStream();
 
     /**
      * Returns the Participant ID from the Vert.x context directly


### PR DESCRIPTION
## Summary
Adds support for binary data (`byte[]` and `Buffer`) passthrough in RPC calls and reactive streams across Java and TypeScript, enabling efficient transmission of binary payloads without serialization overhead.

## Changes

### Java Backend
- **RpcTestService** (`kinotic-core`): Added `BINARY_VALUE` and `BINARY_CHUNKS` constants and method signatures for:
  - `getBuffer()` → `Buffer`
  - `getByteArray()` → `byte[]`
  - `getByteArrayFlux()` → `Flux<byte[]>`
  - `getMonoByteArray()` → `Mono<byte[]>`

- **DefaultRpcTestService**: Implemented all four binary methods returning test data

- **RpcTestServiceProxy**: Added proxy method signatures for the four binary operations

- **ITestService** (`kinotic-server`): Added interface methods:
  - `getBinaryData()` → `byte[]` with javadoc noting `application/octet-stream` passthrough
  - `getBinaryDataStream()` → `Flux<byte[]>` for per-element binary streaming

- **DefaultTestService**: Implemented both methods with fixed test payloads (`BINARY_DATA` and `BINARY_CHUNKS`)

### TypeScript Client
- **ITestService**: Added method signatures:
  - `getBinaryData(): Promise<Uint8Array>`
  - `getBinaryDataStream(): Observable<Uint8Array>`

- **TestService**: Implemented both methods using `invoke()` and `invokeStream()` respectively

- **Test suite** (`KinoticRpc.test.ts`): Added two test cases:
  - Verifies `byte[]` return decodes to `Uint8Array` with correct values
  - Verifies `Flux<byte[]>` stream decodes to multiple `Uint8Array` chunks

### Code Quality
- Updated TypeScript imports to use `type` keyword for type-only imports across multiple test files (`TestHelper.ts`, `Context.test.ts`, `DisableStickySession_GatewayRestart.test.ts`, `EventBus.test.ts`, `INonExistentService.ts`, `KinoticUnavailable.test.ts`, `Publish.test.ts`)
- Improved null-safety in `TestHelper.ts` version parsing using optional chaining

## Implementation Details
The changes exercise the `application/octet-stream` content-type passthrough mechanism for both single-value and streaming binary responses. Test data includes edge cases (0xFF, 0xFE, -1 as signed byte) to validate proper byte handling across the wire protocol.

https://claude.ai/code/session_011bErGUuxUzo1gfJJYhge9H