### PR TITLE
Set content-length on outgoing STOMP frames for binary-safe framing

### DIFF
--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/GatewayUtils.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/GatewayUtils.java
@@ -38,7 +38,15 @@ public class GatewayUtils {
         // Make sure that internal headers are set properly now
         headers.put(Frame.DESTINATION, event.cri().raw());
 
-        return new Frame(Frame.Command.MESSAGE, headers, event.data() == null ? null : Buffer.buffer(event.data()));
+        byte[] data = event.data();
+        // STOMP delimits a body by content-length when present, otherwise by the NULL terminator. Without
+        // it a body containing 0x00 truncates at the first NULL, and back-to-back frame boundaries are
+        // ambiguous, so set it from the actual byte length to keep binary payloads intact.
+        if (data != null) {
+            headers.put(Frame.CONTENT_LENGTH, Integer.toString(data.length));
+        }
+
+        return new Frame(Frame.Command.MESSAGE, headers, data == null ? null : Buffer.buffer(data));
     }
 
 

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/GatewayUtils.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/GatewayUtils.java
@@ -39,9 +39,7 @@ public class GatewayUtils {
         headers.put(Frame.DESTINATION, event.cri().raw());
 
         byte[] data = event.data();
-        // STOMP delimits a body by content-length when present, otherwise by the NULL terminator. Without
-        // it a body containing 0x00 truncates at the first NULL, and back-to-back frame boundaries are
-        // ambiguous, so set it from the actual byte length to keep binary payloads intact.
+        // Without content-length STOMP delimits the body by the NULL terminator, truncating binary payloads at the first 0x00.
         if (data != null) {
             headers.put(Frame.CONTENT_LENGTH, Integer.toString(data.length));
         }


### PR DESCRIPTION
## Problem

The binary RPC tests added in #265 fail on the `develop` build, exposing a real gateway bug:

1. A single `byte[]` `{0,1,2,3,0xFF,0xFE,42,-1}` arrives **empty** on the JS client.
2. A `Flux<byte[]>` loses its **first** chunk `[10,20,30]`; `[40,50]` and `[60,70,80,90]` arrive intact.

## Root cause

`GatewayUtils.eventToStompFrame` builds the outgoing `MESSAGE` frame from the reply event's raw bytes but never sets `content-length`, and the stomp-lite `Frame.toBuffer()` does not add one. Per the STOMP spec, a body with **no** `content-length` is delimited by the `NUL` (`0x00`) terminator:

- The single value starts with `0x00`, so the body truncated to empty at the first `NUL`. The `Flux` chunks contain no `0x00`, which is why they survived.
- Back-to-back stream frames are then `NUL`-delimited with no length, making the first frame's boundary ambiguous (its body begins on `0x0A` `\n`), so the first chunk is dropped.

## Fix

Set `content-length` from the actual byte length on every reply frame that has a body, so the body is length-delimited rather than `NUL`-delimited:

```java
byte[] data = event.data();
if (data != null) {
    headers.put(Frame.CONTENT_LENGTH, Integer.toString(data.length));
}
return new Frame(Frame.Command.MESSAGE, headers, data == null ? null : Buffer.buffer(data));
```

This is the single client-facing reply path (`eventToStompFrame` → `StompSubscriptionEventSubscriber` → `connection.write`), covering both single `invoke` replies and stream replies. `@stomp/stompjs` honors `content-length` and reads exactly N bytes, preserving `0x00` and removing frame-boundary ambiguity. JSON/text replies are unaffected — `content-length` is the byte length of the already-encoded body.

## Validation

The gateway compiles. The end-to-end binary RPC tests (#265) run on the `develop` push, which rebuilds the `kinotic-server` image and reruns the JS suite against it — that is the validation for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bErGUuxUzo1gfJJYhge9H

---
_Generated by [Claude Code](https://claude.ai/code/session_011bErGUuxUzo1gfJJYhge9H)_