### PR TITLE
Clarify EntityDefinition id format and participant type hierarchy

### DIFF
--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractOrganizationScopedService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/AbstractOrganizationScopedService.java
@@ -120,9 +120,9 @@ public abstract class AbstractOrganizationScopedService<T extends OrganizationSc
     }
 
     /**
-     * Ensures the current participant carries an {@code organizationId} — either an
-     * {@link OrganizationParticipant} or its {@link ApplicationParticipant} subtype — and
-     * returns that id.
+     * Returns the {@code organizationId} of the current {@link OrganizationParticipant}.
+     * {@link ApplicationParticipant} is a sibling type, not a subtype, so application-scoped
+     * callers are rejected — this check is what keeps org-scoped services closed to applications.
      *
      * @throws IllegalStateException if no participant is bound to the current context
      * @throws AuthorizationException if the participant is not an {@code OrganizationParticipant}

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/model/EntityDefinition.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/model/EntityDefinition.java
@@ -25,6 +25,9 @@ import java.util.List;
 @NoArgsConstructor
 public class EntityDefinition implements ProjectScoped<String> {
 
+    /**
+     * System-assigned id of the shape {@code <organizationId>.<applicationId>.<name>}, lowercased.
+     */
     private String id = null; // do not ever set, system managed
 
     private String name = null;

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/utils/PersistenceUtil.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/utils/PersistenceUtil.java
@@ -15,11 +15,13 @@ public class PersistenceUtil {
     private static final Pattern EntityDefinitionNamePattern = Pattern.compile("^[A-Za-z_][A-Za-z0-9_]*$");
 
     /**
-     * Function will convert a {@link EntityDefinition} applicationId and name to a valid
-     * @param organizationId to converty
-     * @param applicationId to convert
-     * @param entityDefinitionName to convert
-     * @return a valid {@link EntityDefinition} id
+     * Builds an {@link EntityDefinition} id of the shape
+     * {@code <organizationId>.<applicationId>.<entityDefinitionName>}, lowercased.
+     *
+     * @param organizationId of the Organization the definition belongs to
+     * @param applicationId of the Application the definition belongs to
+     * @param entityDefinitionName the definition's name
+     * @return the {@link EntityDefinition} id
      */
     public static String createEntityDefinitionId(String organizationId, String applicationId, String entityDefinitionName){
         return (organizationId + "." + applicationId + "." + entityDefinitionName).toLowerCase();


### PR DESCRIPTION
Improves documentation accuracy across three files to clarify the shape and ownership of EntityDefinition ids, and corrects a misconception about the participant type hierarchy.

**Changes:**

- **PersistenceUtil.createEntityDefinitionId()** — Rewrote javadoc to explicitly document the id format as `<organizationId>.<applicationId>.<entityDefinitionName>`, lowercased, and corrected parameter descriptions from "to convert" to meaningful ownership statements.

- **EntityDefinition.id field** — Added javadoc documenting that the id is system-assigned and follows the `<organizationId>.<applicationId>.<name>` format, lowercased.

- **AbstractOrganizationScopedService.getOrganizationIdFromContext()** — Corrected javadoc that incorrectly stated ApplicationParticipant is a subtype of OrganizationParticipant. Clarified that they are sibling types, and explained that the rejection of application-scoped callers is the mechanism that keeps org-scoped services closed to applications.

These changes align documentation with the actual code behavior and correct a type hierarchy misunderstanding that could mislead future maintainers.

https://claude.ai/code/session_018g9d2MznsJtjmyLQDqMTRJ