### PR TITLE
Build kinotic-js packages before running tests

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -97,6 +97,8 @@ jobs:
         run: |
           cd kinotic-js/workspace
           bun install --frozen-lockfile
+          # Cross-package imports resolve to each package's dist/, which bunup builds
+          bun run build
           bun run --filter '*' test
 
       - name: Run E2E Tests


### PR DESCRIPTION
Add `bun run build` step in the kinotic-js test workflow to ensure cross-package imports resolve correctly.

**Summary**

The kinotic-js workspace uses monorepo cross-package imports that resolve to each package's `dist/` directory. These built artifacts must exist before tests run, but the workflow was skipping the build step.

**Changes**

- Insert `bun run build` after `bun install --frozen-lockfile` and before `bun run --filter '*' test` in the gradle-build.yml workflow

This ensures all packages are built and their `dist/` outputs are available for import resolution during the test phase.

https://claude.ai/code/session_016dESA7iztN1cbcNequsGxh