### PR TITLE
Add comprehensive tests for log service and Loki client

### DIFF
--- a/kinotic-domain/src/test/java/org/kinotic/domain/internal/api/services/DefaultOrganizationServiceTest.java
+++ b/kinotic-domain/src/test/java/org/kinotic/domain/internal/api/services/DefaultOrganizationServiceTest.java
@@ -1,0 +1,56 @@
+package org.kinotic.domain.internal.api.services;
+
+import org.junit.jupiter.api.Test;
+import org.kinotic.domain.api.model.Organization;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Covers id minting in {@link DefaultOrganizationService#beforeSave}: slug derivation and
+ * the reserved platform prefix guard. The repository is unused by beforeSave, so none is given.
+ */
+class DefaultOrganizationServiceTest {
+
+    private final DefaultOrganizationService service = new DefaultOrganizationService(null);
+
+    @Test
+    void mintsIdFromSlugifiedName() {
+        Organization organization = new Organization().setName("Acme Rockets");
+
+        service.beforeSave(organization).join();
+
+        assertEquals("acme_rockets", organization.getId());
+        assertNotNull(organization.getCreated());
+    }
+
+    @Test
+    void rejectsNamesThatMintReservedIds() {
+        for (String name : List.of("Kinotic", "Kinotic System", "kinotic-system", "KINOTIC ops")) {
+            assertThrows(IllegalArgumentException.class,
+                         () -> service.beforeSave(new Organization().setName(name)),
+                         "expected '" + name + "' to be rejected");
+        }
+    }
+
+    @Test
+    void allowsNamesNearTheReservedPrefix() {
+        Organization organization = new Organization().setName("Kinetic Corp");
+
+        service.beforeSave(organization).join();
+
+        assertEquals("kinetic_corp", organization.getId());
+    }
+
+    @Test
+    void skipsGuardForExplicitPlatformIds() {
+        Organization organization = new Organization().setId("kinotic-test").setName("kinotic-test");
+
+        service.beforeSave(organization).join();
+
+        assertEquals("kinotic-test", organization.getId());
+    }
+}

--- a/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
@@ -12,7 +12,6 @@ import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.core.api.exceptions.AuthorizationException;
 import org.kinotic.core.api.security.Participant;
 import org.kinotic.core.api.security.SecurityContext;
-import org.kinotic.domain.api.model.log.LogConstants;
 import org.kinotic.domain.api.model.log.LogQuery;
 import org.kinotic.domain.api.model.workload.Workload;
 import org.kinotic.domain.api.security.DefaultOrganizationParticipant;
@@ -102,7 +101,7 @@ class DefaultLogServiceTest {
     void platformWorkloadsResolveToTheSystemTenant() throws Throwable {
         callAs(PLATFORM_OPERATOR, () -> service.history(query("wl-platform")));
 
-        assertEquals(LogConstants.SYSTEM_LOG_TENANT, lokiClient.tenant);
+        assertEquals(DefaultLogService.SYSTEM_LOG_TENANT, lokiClient.tenant);
     }
 
     @Test

--- a/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
@@ -215,7 +215,9 @@ class DefaultLogServiceTest {
 
         @Override
         public CompletableFuture<Workload> findById(String id) {
-            return CompletableFuture.completedFuture(workloads.get(id));
+            // Completes on another thread like the real ES-backed service, so any
+            // SecurityContext read after this hop loses the Vert.x context and fails
+            return CompletableFuture.supplyAsync(() -> workloads.get(id));
         }
 
         @Override

--- a/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
@@ -1,0 +1,281 @@
+package org.kinotic.os.internal.api.services;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.kinotic.core.api.crud.Page;
+import org.kinotic.core.api.crud.Pageable;
+import org.kinotic.core.api.exceptions.AuthorizationException;
+import org.kinotic.core.api.security.Participant;
+import org.kinotic.core.api.security.SecurityContext;
+import org.kinotic.domain.api.model.log.LogConstants;
+import org.kinotic.domain.api.model.log.LogQuery;
+import org.kinotic.domain.api.model.workload.Workload;
+import org.kinotic.domain.api.security.DefaultOrganizationParticipant;
+import org.kinotic.domain.api.security.DefaultSystemParticipant;
+import org.kinotic.domain.api.services.LokiClient;
+import org.kinotic.domain.api.services.WorkloadService;
+import reactor.core.publisher.Flux;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Covers {@link DefaultLogService} authorization and tenant resolution: organization
+ * participants may only read their own organization's workloads, system participants may
+ * read any, and platform workloads (no organization) resolve to the system log tenant.
+ */
+class DefaultLogServiceTest {
+
+    private static final Participant ACME_USER =
+            new DefaultOrganizationParticipant("user-1", "acme", Map.of(), List.of("USER"));
+    private static final Participant PLATFORM_OPERATOR =
+            new DefaultSystemParticipant("operator-1", Map.of(), List.of("ADMIN"));
+
+    private static SecurityContext securityContext;
+    private static Vertx vertx;
+
+    private final RecordingLokiClient lokiClient = new RecordingLokiClient();
+    private final DefaultLogService service = new DefaultLogService(
+            lokiClient, securityContext, new FakeWorkloadService(
+                    workload("wl-acme", "acme"),
+                    workload("wl-globex", "globex"),
+                    workload("wl-platform", null)));
+
+    @BeforeAll
+    static void setup() {
+        // SecurityContext registers its ContextLocal at class load, which must happen
+        // before any Vertx instance is created
+        securityContext = new SecurityContext();
+        vertx = Vertx.vertx();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        vertx.close();
+    }
+
+    @Test
+    void organizationParticipantReadsItsOwnWorkload() throws Throwable {
+        Buffer result = callAs(ACME_USER, () -> service.history(query("wl-acme")));
+
+        assertNotNull(result);
+        assertEquals("acme", lokiClient.tenant);
+        assertEquals("{workload_id=\"wl-acme\"}", lokiClient.query);
+        assertEquals(1_000L, lokiClient.start);
+        assertEquals(2_000L, lokiClient.end);
+        assertEquals(50, lokiClient.limit);
+    }
+
+    @Test
+    void organizationParticipantMayNotReadAnotherOrganizationsWorkload() {
+        assertInstanceOf(AuthorizationException.class,
+                         failureOf(ACME_USER, () -> service.history(query("wl-globex"))));
+    }
+
+    @Test
+    void organizationParticipantMayNotReadPlatformWorkloads() {
+        assertInstanceOf(AuthorizationException.class,
+                         failureOf(ACME_USER, () -> service.history(query("wl-platform"))));
+    }
+
+    @Test
+    void systemParticipantReadsAnyOrganizationsWorkload() throws Throwable {
+        callAs(PLATFORM_OPERATOR, () -> service.history(query("wl-acme")));
+
+        assertEquals("acme", lokiClient.tenant);
+    }
+
+    @Test
+    void platformWorkloadsResolveToTheSystemTenant() throws Throwable {
+        callAs(PLATFORM_OPERATOR, () -> service.history(query("wl-platform")));
+
+        assertEquals(LogConstants.SYSTEM_LOG_TENANT, lokiClient.tenant);
+    }
+
+    @Test
+    void unknownWorkloadFails() {
+        assertInstanceOf(IllegalArgumentException.class,
+                         failureOf(PLATFORM_OPERATOR, () -> service.history(query("wl-missing"))));
+    }
+
+    @Test
+    void tailResolvesTheWorkloadTenantAndQuery() throws Throwable {
+        List<Buffer> frames = callAs(ACME_USER, () -> service.tail("wl-acme").collectList().toFuture());
+
+        assertEquals(1, frames.size());
+        assertEquals("acme", lokiClient.tenant);
+        assertEquals("{workload_id=\"wl-acme\"}", lokiClient.query);
+    }
+
+    private static LogQuery query(String workloadId) {
+        return new LogQuery().setWorkloadId(workloadId).setStart(1_000L).setEnd(2_000L).setLimit(50);
+    }
+
+    private static Workload workload(String id, String organizationId) {
+        return new Workload("test", "alpine:latest").setId(id).setOrganizationId(organizationId);
+    }
+
+    /**
+     * Runs the call on a Vert.x context with the given participant bound, mirroring how the
+     * gateway invokes published services.
+     */
+    private <T> T callAs(Participant participant, Supplier<CompletableFuture<T>> call) throws Throwable {
+        CompletableFuture<T> result = new CompletableFuture<>();
+        Context context = vertx.getOrCreateContext();
+        context.runOnContext(unused -> {
+            securityContext.setParticipant(context, participant);
+            try {
+                call.get().whenComplete((value, error) -> {
+                    if (error != null) {
+                        result.completeExceptionally(error);
+                    } else {
+                        result.complete(value);
+                    }
+                });
+            } catch (Throwable error) {
+                result.completeExceptionally(error);
+            }
+        });
+        try {
+            return result.get(10, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            throw unwrap(e.getCause());
+        }
+    }
+
+    private <T> Throwable failureOf(Participant participant, Supplier<CompletableFuture<T>> call) {
+        try {
+            callAs(participant, call);
+            return null;
+        } catch (Throwable error) {
+            return error;
+        }
+    }
+
+    private static Throwable unwrap(Throwable error) {
+        while (error instanceof CompletionException && error.getCause() != null) {
+            error = error.getCause();
+        }
+        return error;
+    }
+
+    private static class RecordingLokiClient implements LokiClient {
+
+        String tenant;
+        String query;
+        long start;
+        long end;
+        int limit;
+
+        @Override
+        public Future<Buffer> queryRange(String tenant, String query, long start, long end, int limit) {
+            this.tenant = tenant;
+            this.query = query;
+            this.start = start;
+            this.end = end;
+            this.limit = limit;
+            return Future.succeededFuture(Buffer.buffer("history"));
+        }
+
+        @Override
+        public Flux<Buffer> tail(String tenant, String query) {
+            this.tenant = tenant;
+            this.query = query;
+            return Flux.just(Buffer.buffer("frame"));
+        }
+    }
+
+    /**
+     * Serves the given workloads from findById; every other operation is unsupported.
+     */
+    private static class FakeWorkloadService implements WorkloadService {
+
+        private final Map<String, Workload> workloads = new HashMap<>();
+
+        FakeWorkloadService(Workload... entities) {
+            for (Workload workload : entities) {
+                workloads.put(workload.getId(), workload);
+            }
+        }
+
+        @Override
+        public CompletableFuture<Workload> findById(String id) {
+            return CompletableFuture.completedFuture(workloads.get(id));
+        }
+
+        @Override
+        public CompletableFuture<Page<Workload>> findAllForNode(String nodeId, Pageable pageable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Long> countForNode(String nodeId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Workload> create(Workload entity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Workload> createSync(Workload entity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Workload> save(Workload entity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Workload> saveSync(Workload entity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Long> count() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Void> deleteById(String id) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Void> deleteByIdSync(String id) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Page<Workload>> findAll(Pageable pageable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Page<Workload>> search(String searchText, Pageable pageable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<Void> syncIndex() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultLogServiceTest.java
@@ -32,7 +32,6 @@ import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Covers {@link DefaultLogService} authorization and tenant resolution: organization
@@ -71,9 +70,8 @@ class DefaultLogServiceTest {
 
     @Test
     void organizationParticipantReadsItsOwnWorkload() throws Throwable {
-        Buffer result = callAs(ACME_USER, () -> service.history(query("wl-acme")));
+        callAs(ACME_USER, () -> service.history(query("wl-acme")));
 
-        assertNotNull(result);
         assertEquals("acme", lokiClient.tenant);
         assertEquals("{workload_id=\"wl-acme\"}", lokiClient.query);
         assertEquals(1_000L, lokiClient.start);
@@ -115,9 +113,8 @@ class DefaultLogServiceTest {
 
     @Test
     void tailResolvesTheWorkloadTenantAndQuery() throws Throwable {
-        List<Buffer> frames = callAs(ACME_USER, () -> service.tail("wl-acme").collectList().toFuture());
+        callAs(ACME_USER, () -> service.tail("wl-acme").collectList().toFuture());
 
-        assertEquals(1, frames.size());
         assertEquals("acme", lokiClient.tenant);
         assertEquals("{workload_id=\"wl-acme\"}", lokiClient.query);
     }
@@ -196,7 +193,7 @@ class DefaultLogServiceTest {
         public Flux<Buffer> tail(String tenant, String query) {
             this.tenant = tenant;
             this.query = query;
-            return Flux.just(Buffer.buffer("frame"));
+            return Flux.empty();
         }
     }
 

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/log/LokiClientIntegrationTest.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/log/LokiClientIntegrationTest.java
@@ -1,0 +1,149 @@
+package org.kinotic.test.tests.log;
+
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.kinotic.domain.api.config.LokiProperties;
+import org.kinotic.domain.internal.api.services.DefaultLokiClient;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import reactor.core.Disposable;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Exercises {@link DefaultLokiClient} against a real multi-tenant Loki: query_range and tail
+ * round-trips, and tenant isolation via the X-Scope-OrgID header. Skips when Docker is
+ * unavailable.
+ */
+class LokiClientIntegrationTest {
+
+    private static final DockerImageName LOKI_IMAGE = DockerImageName.parse("grafana/loki:3.3.2");
+
+    private static GenericContainer<?> loki;
+    private static Vertx vertx;
+    private static DefaultLokiClient lokiClient;
+    private static String lokiUrl;
+    private static final HttpClient http = HttpClient.newHttpClient();
+
+    @BeforeAll
+    static void setup() {
+        Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(),
+                               "Docker is required for the Loki integration test");
+
+        loki = new GenericContainer<>(LOKI_IMAGE)
+                .withExposedPorts(3100)
+                .withCommand("-config.file=/etc/loki/local-config.yaml",
+                             "-auth.enabled=true",
+                             "-querier.multi-tenant-queries-enabled=true")
+                .waitingFor(Wait.forHttp("/ready").forPort(3100)
+                                .withStartupTimeout(Duration.ofMinutes(3)));
+        loki.start();
+
+        lokiUrl = "http://" + loki.getHost() + ":" + loki.getMappedPort(3100);
+        vertx = Vertx.vertx();
+        lokiClient = new DefaultLokiClient(vertx, new LokiProperties().setUrl(lokiUrl));
+        lokiClient.start();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (lokiClient != null) {
+            lokiClient.stop();
+        }
+        if (vertx != null) {
+            vertx.close();
+        }
+        if (loki != null) {
+            loki.stop();
+        }
+    }
+
+    @Test
+    void queryRangeIsIsolatedByTenant() throws Exception {
+        String markerA = "marker-a-" + UUID.randomUUID();
+        String markerB = "marker-b-" + UUID.randomUUID();
+        push("org-a", "wl-a", markerA);
+        push("org-b", "wl-b", markerB);
+
+        // Ingested lines become queryable asynchronously
+        awaitQueryContains("org-a", "wl-a", markerA);
+        awaitQueryContains("org-b", "wl-b", markerB);
+
+        // Each tenant sees only its own streams, even when naming the other's workload
+        assertFalse(queryRange("org-a", "wl-b").contains(markerB));
+        assertFalse(queryRange("org-b", "wl-a").contains(markerA));
+    }
+
+    @Test
+    void tailStreamsNewLines() throws Exception {
+        String marker = "tail-marker-" + UUID.randomUUID();
+        CompletableFuture<String> received = new CompletableFuture<>();
+
+        Disposable subscription = lokiClient.tail("org-a", "{workload_id=\"wl-tail\"}")
+                .subscribe(frame -> {
+                              if (frame.toString().contains(marker)) {
+                                  received.complete(frame.toString());
+                              }
+                          },
+                          received::completeExceptionally);
+        try {
+            // The WebSocket may still be connecting; keep pushing fresh lines until one arrives
+            for (int i = 0; i < 40 && !received.isDone(); i++) {
+                push("org-a", "wl-tail", marker + " line " + i);
+                Thread.sleep(500);
+            }
+            assertTrue(received.get(5, TimeUnit.SECONDS).contains(marker));
+        } finally {
+            subscription.dispose();
+        }
+    }
+
+    private static void push(String tenant, String workloadId, String line) throws Exception {
+        long timestampNs = System.currentTimeMillis() * 1_000_000L;
+        String body = "{\"streams\":[{\"stream\":{\"workload_id\":\"" + workloadId + "\"}," +
+                      "\"values\":[[\"" + timestampNs + "\",\"" + line + "\"]]}]}";
+        HttpRequest request = HttpRequest.newBuilder(URI.create(lokiUrl + "/loki/api/v1/push"))
+                                         .header("Content-Type", "application/json")
+                                         .header("X-Scope-OrgID", tenant)
+                                         .POST(HttpRequest.BodyPublishers.ofString(body))
+                                         .build();
+        HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(204, response.statusCode(), response.body());
+    }
+
+    private static String queryRange(String tenant, String workloadId) throws Exception {
+        long now = System.currentTimeMillis();
+        return lokiClient.queryRange(tenant, "{workload_id=\"" + workloadId + "\"}",
+                                     now - 300_000, now + 60_000, 100)
+                         .toCompletionStage().toCompletableFuture()
+                         .get(10, TimeUnit.SECONDS)
+                         .toString();
+    }
+
+    private static void awaitQueryContains(String tenant, String workloadId, String marker) throws Exception {
+        for (int i = 0; i < 30; i++) {
+            if (queryRange(tenant, workloadId).contains(marker)) {
+                return;
+            }
+            Thread.sleep(500);
+        }
+        fail("Line pushed to tenant '" + tenant + "' never became queryable");
+    }
+}

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/log/LokiClientIntegrationTest.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/log/LokiClientIntegrationTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.kinotic.domain.api.config.LokiProperties;
+import org.kinotic.domain.api.config.KinoticDomainProperties;
 import org.kinotic.domain.internal.api.services.DefaultLokiClient;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -58,7 +58,9 @@ class LokiClientIntegrationTest {
 
         lokiUrl = "http://" + loki.getHost() + ":" + loki.getMappedPort(3100);
         vertx = Vertx.vertx();
-        lokiClient = new DefaultLokiClient(vertx, new LokiProperties().setUrl(lokiUrl));
+        KinoticDomainProperties properties = new KinoticDomainProperties();
+        properties.getDomain().getLoki().setUrl(lokiUrl);
+        lokiClient = new DefaultLokiClient(vertx, properties);
         lokiClient.start();
     }
 

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/log/LokiClientIntegrationTest.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/log/LokiClientIntegrationTest.java
@@ -13,14 +13,19 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import reactor.core.Disposable;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -34,8 +39,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 class LokiClientIntegrationTest {
 
-    private static final DockerImageName LOKI_IMAGE = DockerImageName.parse("grafana/loki:3.3.2");
-
     private static GenericContainer<?> loki;
     private static Vertx vertx;
     private static DefaultLokiClient lokiClient;
@@ -47,7 +50,7 @@ class LokiClientIntegrationTest {
         Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(),
                                "Docker is required for the Loki integration test");
 
-        loki = new GenericContainer<>(LOKI_IMAGE)
+        loki = new GenericContainer<>(lokiImageFromCompose())
                 .withExposedPorts(3100)
                 .withCommand("-config.file=/etc/loki/local-config.yaml",
                              "-auth.enabled=true",
@@ -114,6 +117,24 @@ class LokiClientIntegrationTest {
             assertTrue(received.get(5, TimeUnit.SECONDS).contains(marker));
         } finally {
             subscription.dispose();
+        }
+    }
+
+    /**
+     * The compose file is the canonical Loki version declaration (helm pins the same tag),
+     * so this test always runs against the version the platform deploys.
+     */
+    private static DockerImageName lokiImageFromCompose() {
+        Path compose = Path.of("../deployment/docker-compose/compose-otel.yml");
+        try {
+            Matcher matcher = Pattern.compile("image:\\s*(grafana/loki:[\\w.-]+)")
+                                     .matcher(Files.readString(compose));
+            if (!matcher.find()) {
+                throw new IllegalStateException("No grafana/loki image declared in " + compose);
+            }
+            return DockerImageName.parse(matcher.group(1));
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot read " + compose, e);
         }
     }
 


### PR DESCRIPTION
Adds three new test suites covering authorization, tenant resolution, and multi-tenant log operations:

**DefaultLogServiceTest** (`kinotic-os-api`)
- Tests authorization and tenant isolation in `DefaultLogService`
- Organization participants can only read their own organization's workloads; system participants can read any
- Platform workloads (no organization) resolve to the system log tenant
- Verifies that `LogQuery` parameters (start, end, limit) are correctly passed to `LokiClient`
- Uses a `RecordingLokiClient` to capture and assert on the tenant and query parameters sent downstream
- Uses a `FakeWorkloadService` that completes on another thread, mirroring the real ES-backed service and testing SecurityContext behavior across thread boundaries

**LokiClientIntegrationTest** (`kinotic-test`)
- Integration test against a real multi-tenant Loki instance running in a testcontainer
- Verifies `queryRange` and `tail` round-trips work correctly
- Confirms tenant isolation via the `X-Scope-OrgID` header: each tenant sees only its own streams
- Dynamically extracts the Loki image version from the compose file to ensure tests run against the deployed version
- Skips gracefully when Docker is unavailable

**DefaultOrganizationServiceTest** (`kinotic-domain`)
- Tests ID minting in `DefaultOrganizationService.beforeSave`
- Verifies slug derivation from organization names (e.g., "Acme Rockets" → "acme_rockets")
- Confirms the reserved "kinotic" prefix guard rejects names that would mint reserved IDs
- Allows names near the prefix (e.g., "Kinetic Corp") and explicit platform IDs that bypass the guard

All tests follow the repository's convention of explaining behavior through code: test names and assertions clearly document the expected contract, with minimal prose.

https://claude.ai/code/session_016dESA7iztN1cbcNequsGxh