### PR TITLE
Add workload log shipping to Loki with multi-tenant isolation

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -74,11 +74,13 @@ Keycloak and Grafana also read from the same TLS secret.
 
 Centralized log collection using Grafana's stack:
 
-- **Alloy** — DaemonSet on each node, collects pod logs, ships to Loki. Pipeline config in `helm/observability/alloy-config.alloy`.
-- **Loki** — Log storage. Filesystem in KinD, Azure Blob Storage in Azure.
-- **Grafana** — Query and dashboards. Local auth in KinD, Entra ID (Azure AD) in Azure.
+- **Alloy** — DaemonSet on each node, collects pod logs, ships to Loki under the `kinotic-system` tenant. Pipeline config in `helm/observability/alloy-config.alloy`.
+- **Loki** — Multi-tenant log storage (`auth_enabled: true`): one tenant per organization for workload logs, plus the reserved `kinotic-system` tenant for platform logs. Filesystem in KinD, Azure Blob Storage in Azure.
+- **Grafana** — Query and dashboards. The Loki datasource browses the `kinotic-system` tenant by default; multi-tenant queries accept pipe-separated ids (`acme|kinotic-system`). Local auth in KinD, Entra ID (Azure AD) in Azure.
 
-To add a new log source (e.g. Firecracker VM logs), add a `local.file_match` + `loki.source.file` block to the Alloy config and apply.
+Customer workload (micro VM) logs are shipped separately: each vm-manager node runs its own Alloy process that tails per-workload log directories and routes each stream to the workload organization's tenant. See the observability page on the website for the architecture.
+
+To add a new cluster log source, add a `local.file_match` + `loki.source.file` block to the Alloy config and apply.
 
 ## Quick Reference
 

--- a/kinotic-js/workspace/bun.lock
+++ b/kinotic-js/workspace/bun.lock
@@ -64,7 +64,7 @@
     },
     "packages/os-api": {
       "name": "@kinotic-ai/os-api",
-      "version": "1.14.2",
+      "version": "1.15.0",
       "dependencies": {
         "@kinotic-ai/idl": "workspace:*",
         "@kinotic-ai/persistence": "workspace:*",
@@ -114,7 +114,7 @@
     },
     "packages/vm-manager": {
       "name": "@kinotic-ai/vm-manager",
-      "version": "1.0.11",
+      "version": "1.1.0",
       "dependencies": {
         "@boxlite-ai/boxlite": "^0.8.2",
         "@kinotic-ai/core": "workspace:*",
@@ -126,7 +126,7 @@
       },
       "peerDependencies": {
         "@kinotic-ai/core": ">=1.9.1",
-        "@kinotic-ai/os-api": ">=1.14.0",
+        "@kinotic-ai/os-api": ">=1.15.0",
       },
     },
   },

--- a/kinotic-js/workspace/packages/os-api/package.json
+++ b/kinotic-js/workspace/packages/os-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/os-api",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "type": "module",
   "files": [
     "dist"

--- a/kinotic-js/workspace/packages/vm-manager/package.json
+++ b/kinotic-js/workspace/packages/vm-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/vm-manager",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "type": "module",
   "files": [
     "bin",
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "@kinotic-ai/core": ">=1.9.1",
-    "@kinotic-ai/os-api": ">=1.14.0"
+    "@kinotic-ai/os-api": ">=1.15.0"
   },
   "dependencies": {
     "@boxlite-ai/boxlite": "^0.8.2",

--- a/website/content/2.platform/3.configuration.md
+++ b/website/content/2.platform/3.configuration.md
@@ -25,6 +25,6 @@ The server reads workload logs from Grafana Loki (see [Observability](/platform/
 
 | Property | Environment variable | Helm value | Default |
 |---|---|---|---|
-| `kinotic.loki.url` | `KINOTIC_LOKI_URL` | `kinotic.loki.url` | `http://localhost:3100` |
+| `kinotic.domain.loki.url` | `KINOTIC_DOMAIN_LOKI_URL` | `kinotic.domain.loki.url` | `http://localhost:3100` |
 
 In docker-compose the server points at `http://loki:3100`; the Helm chart defaults to `http://loki.observability.svc:3100`.

--- a/website/content/2.platform/3.configuration.md
+++ b/website/content/2.platform/3.configuration.md
@@ -18,3 +18,13 @@ Kinotic OS is configured through a combination of application properties, enviro
 - **Authentication** — OIDC provider configuration, session management, and security policies
 - **Environment variables** — Runtime overrides for containerized deployments
 - **Helm values** — Kubernetes-specific configuration for resource limits, replicas, ingress, and TLS
+
+## Loki
+
+The server reads workload logs from Grafana Loki (see [Observability](/platform/observability#workload-logs)).
+
+| Property | Environment variable | Helm value | Default |
+|---|---|---|---|
+| `kinotic.loki.url` | `KINOTIC_LOKI_URL` | `kinotic.loki.url` | `http://localhost:3100` |
+
+In docker-compose the server points at `http://loki:3100`; the Helm chart defaults to `http://loki.observability.svc:3100`.

--- a/website/content/2.platform/6.observability.md
+++ b/website/content/2.platform/6.observability.md
@@ -54,27 +54,7 @@ Loki runs multi-tenant. A workload's logs are stored in its organization's tenan
 
 ### Reading workload logs
 
-The `LogService` streams and queries the logs of workloads the caller may view: an organization participant sees its own organization's workloads, a system participant sees any. Both methods return raw Loki response bytes for the caller to parse.
-
-```typescript
-import { Kinotic } from '@kinotic-ai/core'
-import { LogService } from '@kinotic-ai/os-api'
-
-const logService = new LogService(Kinotic)
-
-// Live tail — each emission is a raw Loki tail frame
-const subscription = logService.tail(workloadId).subscribe(frame => {
-    console.log(new TextDecoder().decode(frame))
-})
-
-// Historical logs — the raw Loki query_range response
-const history = await logService.history({
-    workloadId,
-    start: Date.now() - 3_600_000,
-    end: Date.now(),
-    limit: 500,
-})
-```
+The `LogService` (`@kinotic-ai/os-api`) streams (`tail`) and queries (`history`) the logs of workloads the caller may view: an organization participant sees its own organization's workloads, a system participant sees any. Both methods return raw Loki response bytes for the caller to parse.
 
 ### Configuration
 

--- a/website/content/2.platform/6.observability.md
+++ b/website/content/2.platform/6.observability.md
@@ -32,3 +32,55 @@ Track platform activity including:
 ## Application Logs
 
 View microservice logs directly from the dashboard with the ability to temporarily adjust logging levels for debugging. Increase verbosity on a running service to investigate an issue, then restore normal levels when done — no redeployment required.
+
+## Workload Logs
+
+Logs from micro VM workloads (builds, deploys, and application containers) are shipped to Grafana Loki and can be tailed live or queried historically, per workload.
+
+### Log shipping architecture
+
+Each vm-manager node mounts a per-workload host directory into the VM at `/var/log/kinotic`. Any `*.log` file the workload writes there is shipped — this is the logging contract for workload images. The node runs a managed [Grafana Alloy](https://grafana.com/docs/alloy/latest/) process whose pipeline is regenerated as workloads come and go; Alloy tails the log directories and pushes to Loki.
+
+Every log stream carries these labels:
+
+| Label | Value |
+|---|---|
+| `workload_id` | The workload's id |
+| `vm_id` | The micro VM (boxlite box) id |
+| `node_id` | The vm-manager node the workload runs on |
+| `application_id` | The workload's application, when it has one |
+
+Loki runs multi-tenant. A workload's logs are stored in its organization's tenant (`X-Scope-OrgID` = the organization id), so one organization's queries can never see another's streams. Platform workloads with no organization ship to the reserved `kinotic-system` tenant — organization ids beginning with `kinotic` are reserved for the platform. Platform operators can query across tenants with pipe-separated ids (for example `acme|kinotic-system`).
+
+### Reading workload logs
+
+The `LogService` streams and queries the logs of workloads the caller may view: an organization participant sees its own organization's workloads, a system participant sees any. Both methods return raw Loki response bytes for the caller to parse.
+
+```typescript
+import { Kinotic } from '@kinotic-ai/core'
+import { LogService } from '@kinotic-ai/os-api'
+
+const logService = new LogService(Kinotic)
+
+// Live tail — each emission is a raw Loki tail frame
+const subscription = logService.tail(workloadId).subscribe(frame => {
+    console.log(new TextDecoder().decode(frame))
+})
+
+// Historical logs — the raw Loki query_range response
+const history = await logService.history({
+    workloadId,
+    start: Date.now() - 3_600_000,
+    end: Date.now(),
+    limit: 500,
+})
+```
+
+### Configuration
+
+| Setting | Description |
+|---|---|
+| `kinotic.loki.url` / `KINOTIC_LOKI_URL` (server) | Loki HTTP API the server queries (default `http://localhost:3100`) |
+| `KINOTIC_LOKI_URL` (vm-manager) | Loki HTTP API the node's Alloy pushes to |
+| `KINOTIC_LOG_SHIPPING_ENABLED` (vm-manager) | Disable log shipping on a node (default `true`) |
+| `KINOTIC_ALLOY_PATH` / `KINOTIC_ALLOY_VERSION` (vm-manager) | Alloy binary to run; when unset, `alloy` on the PATH is used, else the pinned release is downloaded |

--- a/website/content/2.platform/6.observability.md
+++ b/website/content/2.platform/6.observability.md
@@ -80,7 +80,7 @@ const history = await logService.history({
 
 | Setting | Description |
 |---|---|
-| `kinotic.loki.url` / `KINOTIC_LOKI_URL` (server) | Loki HTTP API the server queries (default `http://localhost:3100`) |
+| `kinotic.domain.loki.url` / `KINOTIC_DOMAIN_LOKI_URL` (server) | Loki HTTP API the server queries (default `http://localhost:3100`) |
 | `KINOTIC_LOKI_URL` (vm-manager) | Loki HTTP API the node's Alloy pushes to |
 | `KINOTIC_LOG_SHIPPING_ENABLED` (vm-manager) | Disable log shipping on a node (default `true`) |
 | `KINOTIC_ALLOY_PATH` / `KINOTIC_ALLOY_VERSION` (vm-manager) | Alloy binary to run; when unset, `alloy` on the PATH is used, else the pinned release is downloaded |

--- a/website/content/2.platform/6.observability.md
+++ b/website/content/2.platform/6.observability.md
@@ -61,6 +61,6 @@ The `LogService` (`@kinotic-ai/os-api`) streams (`tail`) and queries (`history`)
 | Setting | Description |
 |---|---|
 | `kinotic.domain.loki.url` / `KINOTIC_DOMAIN_LOKI_URL` (server) | Loki HTTP API the server queries (default `http://localhost:3100`) |
-| `KINOTIC_LOKI_URL` (vm-manager) | Loki HTTP API the node's Alloy pushes to |
-| `KINOTIC_LOG_SHIPPING_ENABLED` (vm-manager) | Disable log shipping on a node (default `true`) |
-| `KINOTIC_ALLOY_PATH` / `KINOTIC_ALLOY_VERSION` (vm-manager) | Alloy binary to run; when unset, `alloy` on the PATH is used, else the pinned release is downloaded |
+| `KINOTIC_LOKI_URL` (vm-manager) | Loki HTTP API the node's Alloy pushes to; unset disables log shipping |
+
+The vm-manager resolves the Alloy binary from the `PATH`, downloading its pinned release on first use when none is found.


### PR DESCRIPTION
Adds workload (micro VM) log collection and shipping to Grafana Loki with per-organization tenant isolation, enabling live tailing and historical queries of build, deploy, and application container logs.

## Changes

- **Workload log architecture**: Each vm-manager node mounts per-workload host directories into VMs at `/var/log/kinotic`. Workloads write `*.log` files there; a managed Grafana Alloy process on each node tails these directories and ships logs to Loki with labels for `workload_id`, `vm_id`, `node_id`, and `application_id`.

- **Multi-tenant isolation**: Loki runs with `auth_enabled: true`. Workload logs are stored in organization-specific tenants (`X-Scope-OrgID` = organization id); platform workloads ship to the reserved `kinotic-system` tenant. Organization ids beginning with `kinotic` are reserved for the platform. Platform operators can query across tenants using pipe-separated ids (e.g., `acme|kinotic-system`).

- **LogService API**: New `LogService` in `@kinotic-ai/os-api` (v1.15.0) provides `tail()` and `history()` methods to stream and query workload logs. Both return raw Loki response bytes; callers see only logs for workloads they may view (organization participants see their org's workloads, system participants see any).

- **Configuration**: Added `kinotic.domain.loki.url` / `KINOTIC_DOMAIN_LOKI_URL` (server) to specify the Loki HTTP API endpoint (default `http://localhost:3100`). vm-manager reads `KINOTIC_LOKI_URL` to enable log shipping; unset disables it. The vm-manager resolves the Alloy binary from `PATH`, downloading its pinned release on first use.

- **Documentation**: Updated observability and configuration pages with workload log architecture, label definitions, tenant routing, and configuration reference. Updated deployment README to clarify platform logs ship to `kinotic-system` tenant and document the separate vm-manager Alloy process for workload logs.

- **Version bumps**: `@kinotic-ai/os-api` 1.14.2 → 1.15.0, `@kinotic-ai/vm-manager` 1.0.11 → 1.1.0 (requires `@kinotic-ai/os-api` ≥1.15.0).

https://claude.ai/code/session_016dESA7iztN1cbcNequsGxh