### PR TITLE
Add the application name column to the kinotic_application mapping

### DIFF
--- a/kinotic-migration/src/main/resources/migrations/V1__init.sql
+++ b/kinotic-migration/src/main/resources/migrations/V1__init.sql
@@ -2,6 +2,7 @@
 CREATE TABLE IF NOT EXISTS kinotic_application (
     id KEYWORD,
     organizationId KEYWORD,
+    name KEYWORD,
     description TEXT,
     oidcConfigurationIds KEYWORD,
     tenantPerUser BOOLEAN,


### PR DESCRIPTION
## Problem

PR #287 added the `name` field to the `Application` entity and made `beforeSave` write it on every save, but the `kinotic_application` Elasticsearch index has a **strict** mapping with no `name` column. Every application write now fails:

```
[es/index] failed: [strict_dynamic_mapping_exception] mapping set to strict,
dynamic introduction of [name] within [_doc] is not allowed
```

This breaks far more than application CRUD: any test or flow that reaches `TestDataService.createApplicationIfNotExist(...)` (which the sample-data setup does) fails, so the `kinotic-test` suite goes red across `ApplicationTests`, `EntityCrudTests`, `BulkUpdateTests`, and others — 17 failures in CI.

## Fix

```sql
CREATE TABLE IF NOT EXISTS kinotic_application (
    id KEYWORD,
    organizationId KEYWORD,
    name KEYWORD,          -- added
    description TEXT,
    oidcConfigurationIds KEYWORD,
    tenantPerUser BOOLEAN,
    updated DATE
);
```

These migrations have not shipped with data yet, so the column is added to the original `V1__init.sql` `CREATE TABLE` rather than as a follow-up `ALTER TABLE`. The column is placed after `organizationId` to match the entity's field order (`id, organizationId, name, description`).

## Testing

The failing tests are ES-backed (`kinotic-test`, via the Testcontainers compose stack) and can't run in this environment without Docker; CI rebuilds the migration image with this change before running `kinotic-test`, exercising the fix end-to-end. Locally verified the diff is the single column addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx)_