### PR TITLE
Silence Rolldown INVALID_ANNOTATION warnings from pre-bundled deps

### DIFF
--- a/kinotic-frontend/components.d.ts
+++ b/kinotic-frontend/components.d.ts
@@ -14,7 +14,6 @@ declare module 'vue' {
     Button: typeof import('primevue/button')['default']
     CascadeSelect: typeof import('primevue/cascadeselect')['default']
     Confirm: typeof import('./src/components/Confirm.vue')['default']
-    CrudEntityAddEdit: typeof import('./src/components/CrudEntityAddEdit.vue')['default']
     CrudTable: typeof import('./src/components/CrudTable.vue')['default']
     DashboardWidgetCard: typeof import('./src/components/DashboardWidgetCard.vue')['default']
     Dialog: typeof import('primevue/dialog')['default']

--- a/kinotic-frontend/vite.config.ts
+++ b/kinotic-frontend/vite.config.ts
@@ -60,6 +60,10 @@ export default defineConfig(
         build: {
             sourcemap: true,
             rollupOptions: {
+                // Pre-bundled deps (e.g. @vueuse/core) ship /* #__PURE__ */ annotations in
+                // positions Rolldown cannot attach to an expression; we never author these
+                // annotations ourselves, so silencing the check only quiets third-party noise.
+                checks: { invalidAnnotation: false },
                 output: {
                     sourcemapExcludeSources: false
                 }


### PR DESCRIPTION
## Problem

Every frontend build (Vite 8 / Rolldown) prints warnings like:

```
[INVALID_ANNOTATION] A comment "/* #__PURE__ */" in ".../@vueuse/core/dist/index.js"
contains an annotation that Rolldown cannot interpret due to the position of the comment.
```

`@vueuse/core@14.3.0`'s pre-bundled `dist/index.js` places `/* #__PURE__ */` after an opening paren (`const defaultState = (/* #__PURE__ */ {…})`), where Rolldown can't attach it to an expression, so it ignores that one tree-shaking hint and warns. It's a missed micro-optimization in a dependency — the build still succeeds — but it's noise on every build.

## Fix

```ts
build: {
    rollupOptions: {
        checks: { invalidAnnotation: false },
        ...
    }
}
```

`checks.invalidAnnotation` (default `true`) is Rolldown's purpose-built toggle for this exact warning code, reachable through `build.rollupOptions` in Vite 8. We never author `/* #__PURE__ */` annotations in our own source, so the only source of these warnings is pre-bundled third-party `dist` files — disabling the check quiets that noise without hiding anything actionable in our code.

## Testing

Before/after `pnpm vite build` in `kinotic-frontend`:

| | INVALID_ANNOTATION warnings | build |
| --- | --- | --- |
| without fix | 2 | ✓ succeeds |
| with fix | 0 | ✓ succeeds |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx)_