### PR TITLE
Resolve CRI scope and resourceName without URI host validation

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
@@ -17,8 +17,14 @@ class DefaultCRI implements CRI {
     private final URI uri;
 
     public DefaultCRI(String scheme, String scope, String resourceName, String path, String version) {
+        // Assemble the authority ourselves and use the authority-form URI constructor rather than
+        // the (userInfo, host, port) form: that form validates the host as an RFC-2396 hostname and
+        // rejects the underscores zone labels use (os_api, app_api, slugified ids like org_kinotic_x).
+        String authority = resourceName != null
+                ? (scope != null ? scope + "@" : "") + resourceName
+                : null;
         try {
-            uri = new URI(scheme, scope,  resourceName, -1, path,null, version);
+            uri = new URI(scheme, authority, path, null, version);
         } catch (URISyntaxException x) {
             throw new IllegalArgumentException(x.getMessage(), x);
         }
@@ -40,17 +46,31 @@ class DefaultCRI implements CRI {
 
     @Override
     public String scope() {
-        return uri.getRawUserInfo();
+        // Split off the raw authority rather than using getRawUserInfo()/getHost(): java.net.URI
+        // only populates those for a valid RFC-2396 server-based authority, and a zone label's
+        // underscore makes the authority registry-based, nulling them. scope is the part before
+        // '@' (null when absent); resourceName is the remainder.
+        String authority = uri.getRawAuthority();
+        if (authority == null) {
+            return null;
+        }
+        int at = authority.indexOf('@');
+        return at >= 0 ? authority.substring(0, at) : null;
     }
 
     @Override
     public boolean hasScope() {
-        return uri.getRawUserInfo() != null;
+        return scope() != null;
     }
 
     @Override
     public String resourceName() {
-        return uri.getHost();
+        String authority = uri.getRawAuthority();
+        if (authority == null) {
+            return null;
+        }
+        int at = authority.indexOf('@');
+        return at >= 0 ? authority.substring(at + 1) : authority;
     }
 
     @Override

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
@@ -7,8 +7,13 @@ import org.kinotic.core.api.event.EventConstants;
 import org.apache.commons.lang3.Validate;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 /**
- * CRI's internally are implemented using the Java URI class, so we don't need to verify the logic there.
+ * CRIs are backed by {@link java.net.URI}, whose server-based authority parsing rejects the
+ * underscores zone labels use (os_api, app_api, slugified ids), so these tests pin that CRIs
+ * resolve their scope and resourceName from such addresses regardless.
  * Created by navid on 1/23/20
  */
 public class CRITests {
@@ -30,6 +35,9 @@ public class CRITests {
                                                         + "#"
                                                         + SERVICE_VERSION;
 
+    // A zone label carries an underscore, which java.net.URI will not accept as a hostname
+    private static final String ZONED_NAME = "os_api.org.kinotic.server.clienttest.ITestService";
+
     @Test
     public void testRawCRI1(){
         validateCRI(CRI.create(SERVICE_LITERAL1), false);
@@ -40,8 +48,44 @@ public class CRITests {
         validateCRI(CRI.create(SERVICE_LITERAL2), true);
     }
 
+    @Test
+    public void parsesZonedResourceNameWithUnderscore(){
+        CRI cri = CRI.create("srv://" + ZONED_NAME + "/testMethodWithString#1.0.0");
 
+        assertEquals(ZONED_NAME, cri.resourceName());
+        assertEquals("srv://" + ZONED_NAME, cri.baseResource());
+        assertEquals("/testMethodWithString", cri.path());
+        assertEquals("1.0.0", cri.version());
+        assertNull(cri.scope());
+    }
 
+    @Test
+    public void parsesScopedZonedResourceNameWithUnderscore(){
+        CRI cri = CRI.create("srv://node1@" + ZONED_NAME + "/save#1.0.0");
+
+        assertEquals("node1", cri.scope());
+        assertEquals(ZONED_NAME, cri.resourceName());
+        assertEquals("srv://node1@" + ZONED_NAME, cri.baseResource());
+    }
+
+    @Test
+    public void buildsZonedResourceNameFromComponents(){
+        CRI cri = CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, null, ZONED_NAME, "/save", "1.0.0");
+
+        assertEquals(ZONED_NAME, cri.resourceName());
+        assertEquals("srv://" + ZONED_NAME, cri.baseResource());
+        // The raw form round-trips back to a CRI that resolves the same resourceName
+        assertEquals(ZONED_NAME, CRI.create(cri.raw()).resourceName());
+    }
+
+    @Test
+    public void buildsScopedZonedResourceNameFromComponents(){
+        CRI cri = CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, "node1", ZONED_NAME, "/save", "1.0.0");
+
+        assertEquals("node1", cri.scope());
+        assertEquals(ZONED_NAME, cri.resourceName());
+        assertEquals("srv://node1@" + ZONED_NAME, cri.baseResource());
+    }
 
     private void validateCRI(CRI cri, boolean checkScope){
         Validate.isTrue(cri.resourceName().equals(SERVICE_NAME), "CRI resourceName does not match expected got "+ cri.resourceName());


### PR DESCRIPTION
## The bug

Every zoned service call fails server-side with:

```
(NO_HANDLERS,-1) No handlers for address srv://null
```

This is what has kept the `@kinotic-ai/core` workspace RPC tests (and e2e) red on develop since the zone work (#286) merged — the `continue-on-error` JS test steps let Java publish anyway, so it wasn't blocking, but the suites never passed.

## Root cause

`DefaultCRI` is backed by `java.net.URI`:

```java
public String resourceName() { return uri.getHost(); }        // ← null on underscore
public String scope()        { return uri.getRawUserInfo(); } // ← null on underscore
```

`java.net.URI` only populates `getHost()` / `getUserInfo()` for a valid RFC-2396 **server-based** authority. An underscore is illegal in a hostname, so an authority like `os_api.org.kinotic.server.clienttest.ITestService` is parsed as **registry-based**, and both accessors return `null` (verified with a JDK 21 probe). The zone prefixes `os_api` / `app_api` and slugified ids (`org_kinotic_sample`) all contain underscores; pre-zone resourceNames were dotted only, which is why it broke exactly at #286.

The chain:

```
resourceName() → null
  → baseResource() = "srv://" + null = "srv://null"
    → DefaultEventBusService.sendWithAck() requests "srv://null" on the Vert.x bus
      → NO_HANDLERS
```

The component constructor had the mirror-image fault: `new URI(scheme, userInfo, host, port, …)` **throws** `Illegal character in hostname` on an underscore host, so building a zoned CRI from parts (as `ServiceIdentifier.cris()` does when registering a zoned service) failed outright.

## Fix

Both paths now go through the raw authority, which `java.net.URI` preserves verbatim regardless of underscores:

```java
// parse: split scope / resourceName off getRawAuthority()
String authority = uri.getRawAuthority();
int at = authority.indexOf('@');
scope        = at >= 0 ? authority.substring(0, at) : null;
resourceName = at >= 0 ? authority.substring(at + 1) : authority;

// build: authority-form URI constructor performs no host validation
uri = new URI(scheme, (scope != null ? scope + "@" : "") + resourceName, path, null, version);
```

The TypeScript client is unaffected — its `DefaultCRI.parseRaw` uses a regex (`([^\/#]+)` for resourceName) that already accepts underscores.

## Testing

- `CRITests` extended with four underscore-zone cases (parse + build, scoped + unscoped) that reproduce the exact defect: pre-fix, `baseResource()` returns `srv://null`; post-fix, `srv://os_api.…`. All 6 pass.
- Full `kinotic-core` and `kinotic-api-gateway` suites green — no regression (the two original dotted-name CRI tests still pass, confirming backward compatibility).
- The end-to-end workspace-core RPC suite needs Docker (not available in my environment); CI runs it against a server built from this fix once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx)_