### PR TITLE
Single zone per service, and dashes so CRIs stay valid URIs

### DIFF
--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
@@ -23,8 +23,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * Creates STOMP authorizers using the gateway's current participant routing rules.
  *
  * A participant may only address zones its type allows: application participants reach the
- * {@code app_api} data plane and their own {@code app.<organizationId>.<applicationId>} zone and
- * may host services only inside their own zone, organization participants reach the {@code os_api}
+ * {@code app-api} data plane and their own {@code app.<organizationId>.<applicationId>} zone and
+ * may host services only inside their own zone, organization participants reach the {@code os-api}
  * management surface and host nothing, and system participants reach everything and host in the
  * platform zones.
  */

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
@@ -58,15 +58,15 @@ public class StompAuthorizerFactoryTest {
     public void applicationParticipantSendRules() {
         StompAuthorizer authorizer = applicationAuthorizer("acme-org", "orders-app");
 
-        // the app_api data plane and the app's own zone, including app declared sub zones
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app_api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
+        // the app-api data plane and the app's own zone, including app declared sub zones
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService/create#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.billing.InvoiceService/pay#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app.OrderEvents")));
 
         // the organization management surface, other applications, other organizations, the
         // platform internals, and legacy un-zoned addresses
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://os_api.org.kinotic.os.api.services.iam.MemberService/inviteMember#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://os-api.org.kinotic.os.api.services.iam.MemberService/inviteMember#1.0.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.other-app.OrderService/create#1.0.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("srv://app.other-org.orders-app.OrderService/create#1.0.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("srv://system.org.kinotic.orchestrator.api.workload.WorkloadOrchestrationService/startWorkload#0.1.0")));
@@ -75,11 +75,11 @@ public class StompAuthorizerFactoryTest {
 
     @Test
     public void slugifiedIdsWithUnderscoresFormValidZones() {
-        StompAuthorizer authorizer = applicationAuthorizer("acme_corp", "orders_app");
+        StompAuthorizer authorizer = applicationAuthorizer("acme-corp", "orders-app");
 
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme_corp.orders_app.OrderService/create#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme_corp.orders_app.OrderService#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme_corp.other_app.OrderService/create#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-corp.orders-app.OrderService/create#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-corp.orders-app.OrderService#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-corp.other_app.OrderService/create#1.0.0")));
     }
 
     @Test
@@ -100,8 +100,8 @@ public class StompAuthorizerFactoryTest {
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://node1@app.acme-org.orders-app.OrderService#1.0.0")));
         assertTrue(authorizer.subscribeAllowed(CRI.create("stream://app.acme-org.orders-app.OrderEvents")));
 
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app_api.org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os_api.org.kinotic.os.api.services.iam.MemberService#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os-api.org.kinotic.os.api.services.iam.MemberService#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://system.kinotic-ai.vm-manager.VmManager#0.1.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.other-app.OrderService#1.0.0")));
     }
@@ -111,15 +111,15 @@ public class StompAuthorizerFactoryTest {
         StompAuthorizer authorizer = organizationAuthorizer("acme-org");
 
         // the management surface and the data plane
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://os_api.org.kinotic.persistence.api.services.EntityDefinitionService/publish#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://os_api.org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app_api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api.org.kinotic.persistence.api.services.EntityDefinitionService/publish#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api.org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
 
         // not an application's own services, the platform internals, and hosts nothing
         assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService/create#1.0.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("srv://system.org.kinotic.os.api.services.LogManager/query#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os_api.org.kinotic.os.api.services.iam.MemberService#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app_api.org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os-api.org.kinotic.os.api.services.iam.MemberService#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService#1.0.0")));
     }
 
@@ -127,8 +127,8 @@ public class StompAuthorizerFactoryTest {
     public void systemParticipantSendsAnywhereAndHostsPlatformZones() {
         StompAuthorizer authorizer = systemAuthorizer();
 
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://os_api.org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app_api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api.org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://system.org.kinotic.orchestrator.api.workload.WorkloadOrchestrationService/startWorkload#0.1.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService/create#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://node1@system.kinotic-ai.vm-manager.VmManager/startWorkload#0.1.0")));
@@ -136,8 +136,8 @@ public class StompAuthorizerFactoryTest {
 
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://system.kinotic-ai.vm-manager.VmManager#0.1.0")));
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://node1@system.kinotic-ai.vm-manager.VmManager#0.1.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://os_api.org.kinotic.some.PlatformService#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app_api.org.kinotic.some.DataService#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://os-api.org.kinotic.some.PlatformService#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app-api.org.kinotic.some.DataService#1.0.0")));
 
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService#1.0.0")));
     }
@@ -162,7 +162,7 @@ public class StompAuthorizerFactoryTest {
         // the raw string with its own allowed zone and target another app after the '@'. Zone
         // authorization must run against the resource the message actually routes to, not the scope.
         assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.x@app.acme-org.other-app.OrderService/create#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app@os_api.org.kinotic.os.api.services.iam.MemberService/inviteMember#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app@os-api.org.kinotic.os.api.services.iam.MemberService/inviteMember#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.x@app.acme-org.other-app.OrderService#1.0.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app.x@app.acme-org.other-app.OrderEvents")));
     }

--- a/kinotic-core/src/main/java/org/kinotic/core/api/annotations/Zone.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/annotations/Zone.java
@@ -7,9 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * {@link Zones} declares the zones a {@link Publish}ed service is addressable in, or the zone a
- * {@link Proxy} targets. A zone is the validated leading portion of the service CRI's resourceName;
- * a service declaring multiple zones registers one address per zone.
+ * {@link Zone} declares the zone a {@link Publish}ed service is addressable in, or the zone a
+ * {@link Proxy} targets. A zone is the validated leading portion of the service CRI's resourceName.
  *
  * May be placed on the service type or on a package via package-info.java to apply to every
  * {@link Publish}ed interface in that package. A type-level declaration overrides the package's.
@@ -18,12 +17,12 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.PACKAGE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface Zones {
+public @interface Zone {
 
     /**
-     * The zones the service registers under. Each zone is one or more dot separated labels of
+     * The zone the service registers under. A zone is one or more dot separated labels of
      * lowercase letters, digits, and interior dashes, e.g. {@code api} or {@code api.admin}
      */
-    String[] value();
+    String value();
 
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
@@ -18,8 +18,8 @@ class DefaultCRI implements CRI {
 
     public DefaultCRI(String scheme, String scope, String resourceName, String path, String version) {
         // Assemble the authority ourselves and use the authority-form URI constructor rather than
-        // the (userInfo, host, port) form: that form validates the host as an RFC-2396 hostname and
-        // rejects underscores; a zone label never has one, but a namespace segment can.
+        // the (userInfo, host, port) form, which reparses and validates the host: scope and
+        // resourceName are already the two halves of the authority, split on '@'.
         String authority = resourceName != null
                 ? (scope != null ? scope + "@" : "") + resourceName
                 : null;
@@ -46,10 +46,9 @@ class DefaultCRI implements CRI {
 
     @Override
     public String scope() {
-        // Split off the raw authority rather than using getRawUserInfo()/getHost(): java.net.URI
-        // only populates those for a valid RFC-2396 server-based authority, and a zone label's
-        // underscore makes the authority registry-based, nulling them. scope is the part before
-        // '@' (null when absent); resourceName is the remainder.
+        // Split the raw authority rather than using getRawUserInfo()/getHost(): java.net.URI only
+        // populates those for a server-based authority, so splitting on '@' keeps parsing correct
+        // for any resourceName. scope is the part before '@' (null when absent), resourceName the rest.
         String authority = uri.getRawAuthority();
         if (authority == null) {
             return null;

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
@@ -19,7 +19,7 @@ class DefaultCRI implements CRI {
     public DefaultCRI(String scheme, String scope, String resourceName, String path, String version) {
         // Assemble the authority ourselves and use the authority-form URI constructor rather than
         // the (userInfo, host, port) form: that form validates the host as an RFC-2396 hostname and
-        // rejects the underscores zone labels use (os_api, app_api, slugified ids like org_kinotic_x).
+        // rejects underscores; a zone label never has one, but a namespace segment can.
         String authority = resourceName != null
                 ? (scope != null ? scope + "@" : "") + resourceName
                 : null;

--- a/kinotic-core/src/main/java/org/kinotic/core/api/service/ServiceIdentifier.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/service/ServiceIdentifier.java
@@ -9,16 +9,13 @@ import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 /**
  * The {@link ServiceIdentifier} identifies a {@link ServiceDescriptor}
  * Created by Navíd Mitchell 🤪 on 8/18/21.
  */
 public class ServiceIdentifier {
 
-    private final List<String> zones;
+    private final String zone;
 
     private final String namespace;
 
@@ -29,9 +26,9 @@ public class ServiceIdentifier {
 
     private final String version;
 
-    private final List<CRI> cris;
+    private final CRI cri;
 
-    public ServiceIdentifier(List<String> zones,
+    public ServiceIdentifier(String zone,
                              String namespace,
                              String name,
                              String scope,
@@ -41,26 +38,24 @@ public class ServiceIdentifier {
         // The name is the final dot separated label of the address, so a dot inside it would
         // change where the zone and namespace end when the address is parsed or pattern matched
         Validate.isTrue(!name.contains("."), "The name must not contain '.' but was '%s'", name);
-        this.zones = zones != null ? List.copyOf(zones) : List.of();
-        this.zones.forEach(ZoneUtil::validateZone);
+        if (zone != null) {
+            ZoneUtil.validateZone(zone);
+        }
+        this.zone = zone;
         this.namespace = namespace;
         this.name = name;
         this.scope = scope;
         this.version = version;
 
-        cris = this.zones.isEmpty()
-                ? List.of(CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, scope, qualifiedName(null), null, version))
-                : this.zones.stream()
-                            .map(zone -> CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, scope, qualifiedName(zone), null, version))
-                            .toList();
+        cri = CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, scope, qualifiedName(), null, version);
     }
 
     /**
-     * The zones this {@link ServiceIdentifier} is addressable in
-     * @return the zones, empty if un-zoned
+     * The zone this {@link ServiceIdentifier} is addressable in
+     * @return the zone, or null if un-zoned
      */
-    public List<String> zones() {
-        return zones;
+    public String zone() {
+        return zone;
     }
 
     /**
@@ -102,38 +97,18 @@ public class ServiceIdentifier {
      * Returns the fully qualified name this {@link ServiceIdentifier} is addressed by
      * This is the zone.namespace.name, omitting any part that is not set
      * @return string containing the qualified name
-     * @throws IllegalStateException if this {@link ServiceIdentifier} has more than one zone and
-     *         therefore more than one qualified name
      */
     public String qualifiedName(){
-        Validate.validState(zones.size() <= 1,
-                            "ServiceIdentifier has %s zones so there is no single qualifiedName", zones.size());
-        return qualifiedName(zones.isEmpty() ? null : zones.getFirst());
-    }
-
-    private String qualifiedName(String zone) {
         String name = (namespace != null && !namespace.isEmpty() ? namespace + "." : "") + this.name;
         return zone != null ? zone + "." + name : name;
     }
 
     /**
-     * The {@link CRI}s this {@link ServiceIdentifier} is addressable by, one per zone
-     * @return the cris for this {@link ServiceIdentifier}, never empty
-     */
-    public List<CRI> cris(){
-        return cris;
-    }
-
-    /**
      * The {@link CRI} that represents this {@link ServiceIdentifier}
      * @return the cri for this {@link ServiceIdentifier}
-     * @throws IllegalStateException if this {@link ServiceIdentifier} has more than one zone and
-     *         therefore more than one cri
      */
     public CRI cri(){
-        Validate.validState(cris.size() == 1,
-                            "ServiceIdentifier has %s cris so there is no single cri", cris.size());
-        return cris.getFirst();
+        return cri;
     }
 
 
@@ -145,7 +120,7 @@ public class ServiceIdentifier {
 
         ServiceIdentifier that = (ServiceIdentifier) o;
 
-        return new EqualsBuilder().append(zones, that.zones())
+        return new EqualsBuilder().append(zone, that.zone())
                                   .append(namespace, that.namespace())
                                   .append(name, that.name())
                                   .append(scope, that.scope())
@@ -155,11 +130,11 @@ public class ServiceIdentifier {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(17, 37).append(zones).append(namespace).append(name).append(scope).append(version).toHashCode();
+        return new HashCodeBuilder(17, 37).append(zone).append(namespace).append(name).append(scope).append(version).toHashCode();
     }
 
     @Override
     public String toString() {
-        return cris.stream().map(CRI::raw).collect(Collectors.joining(", "));
+        return cri.raw();
     }
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/api/service/ServiceIdentifier.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/service/ServiceIdentifier.java
@@ -38,6 +38,10 @@ public class ServiceIdentifier {
         // The name is the final dot separated label of the address, so a dot inside it would
         // change where the zone and namespace end when the address is parsed or pattern matched
         Validate.isTrue(!name.contains("."), "The name must not contain '.' but was '%s'", name);
+        // The namespace forms interior labels of the address; an underscore is illegal in a URI
+        // host, so a segment carrying one would make the CRI an invalid URI
+        Validate.isTrue(namespace == null || !namespace.contains("_"),
+                        "The namespace must not contain '_' but was '%s'", namespace);
         if (zone != null) {
             ZoneUtil.validateZone(zone);
         }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
@@ -105,11 +105,11 @@ public class ServiceRegistrationBeanPostProcessor implements DestructionAwareBea
                                 throw new FatalBeanException("Version must be specified on the Published interface " + inter.getName() + " or an ancestor package.");
                             }
 
-                            // A service is addressable in each declared zone; with no declaration
+                            // A service is addressable in its declared zone; with no declaration
                             // it registers a single un-zoned address, whose reachability is
                             // whatever the gateway's routing rules allow
-                            String[] zones = MetaUtil.getZones(inter);
-                            ServiceIdentifier serviceIdentifier = new ServiceIdentifier(zones != null ? List.of(zones) : null,
+                            String zone = MetaUtil.getZone(inter);
+                            ServiceIdentifier serviceIdentifier = new ServiceIdentifier(zone,
                                                                                         namespace,
                                                                                         name,
                                                                                         scope,

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/DefaultServiceRegistry.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/DefaultServiceRegistry.java
@@ -28,7 +28,6 @@ import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MimeTypeUtils;
 
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -149,14 +148,10 @@ public class DefaultServiceRegistry implements ServiceRegistry {
         String name = proxyAnnotation.name().isEmpty() ? serviceInterface.getSimpleName() : proxyAnnotation.name();
         String version = MetaUtil.getVersion(serviceInterface);
 
-        // A proxy targets one address, so unlike a published service it must resolve to at most
-        // one zone; with no declaration it targets the un-zoned address
-        String[] zones = MetaUtil.getZones(serviceInterface);
-        Validate.isTrue(zones == null || zones.length <= 1,
-                        "The @Proxy interface %s must resolve to at most one zone but declares %s",
-                        serviceInterface.getName(), zones != null ? zones.length : 0);
+        // A proxy targets one address; with no declaration it targets the un-zoned address
+        String zone = MetaUtil.getZone(serviceInterface);
 
-        ServiceIdentifier serviceIdentifier = new ServiceIdentifier(zones != null ? List.of(zones) : null,
+        ServiceIdentifier serviceIdentifier = new ServiceIdentifier(zone,
                                                                     namespace,
                                                                     name,
                                                                     null,

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
@@ -102,13 +102,9 @@ public class ServiceInvocationSupervisor {
      */
     public Future<Void> start(){
         if(active.compareAndSet(false, true)){
-            // begin listening on the event bus for service invocation requests, one consumer
-            // per zone address, all dispatching to the same invocation machinery
-            methodInvocationEventConsumers = serviceDescriptor.serviceIdentifier()
-                                                              .cris()
-                                                              .stream()
-                                                              .map(eventBusService::listen)
-                                                              .toList();
+            // begin listening on the event bus for service invocation requests at the service's
+            // zone address
+            methodInvocationEventConsumers = List.of(eventBusService.listen(serviceDescriptor.serviceIdentifier().cri()));
 
             for (EventConsumer eventConsumer : methodInvocationEventConsumers) {
                 eventConsumer

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/utils/MetaUtil.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/utils/MetaUtil.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.kinotic.core.api.annotations.Scope;
 import org.kinotic.core.api.annotations.Version;
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.BridgeMethodResolver;
 import org.springframework.core.MethodParameter;
@@ -184,22 +184,22 @@ public class MetaUtil {
     }
 
     /**
-     * Gets the zones for the class by searching for a {@link Zones} annotation.
-     * If the class contains the annotation, those zones are returned; otherwise it returns the zones from the package-info.java file annotation if found.
-     * @param clazz to search for zones
-     * @return the zones or null if not found
+     * Gets the zone for the class by searching for a {@link Zone} annotation.
+     * If the class contains the annotation, that zone is returned; otherwise it returns the zone from the package-info.java file annotation if found.
+     * @param clazz to search for a zone
+     * @return the zone or null if not found
      */
-    public static String[] getZones(Class<?> clazz){
-        String[] ret = null;
-        Zones zones = AnnotationUtils.findAnnotation(clazz, Zones.class);
-        if(zones == null){
+    public static String getZone(Class<?> clazz){
+        String ret = null;
+        Zone zone = AnnotationUtils.findAnnotation(clazz, Zone.class);
+        if(zone == null){
             Package pkg = clazz.getPackage();
             if(pkg != null){
-                zones = AnnotationUtils.findAnnotation(pkg, Zones.class);
+                zone = AnnotationUtils.findAnnotation(pkg, Zone.class);
             }
         }
-        if(zones != null){
-            ret = zones.value();
+        if(zone != null){
+            ret = zone.value();
         }
         return ret;
     }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/utils/ZoneUtil.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/utils/ZoneUtil.java
@@ -11,10 +11,11 @@ import java.util.regex.Pattern;
  */
 public final class ZoneUtil {
 
-    // DNS-style label rule (plus interior underscores, which slugified ids use), so a zone can
-    // never contain characters that would break CRI parsing, dot-boundary prefix matching, or
-    // wildcard patterns. A zone is dot separated labels — both patterns are views of the one grammar.
-    private static final String LABEL = "[a-z0-9]([a-z0-9_-]*[a-z0-9])?";
+    // DNS-style label rule, so a zone is always a valid URI authority (CRIs are valid URIs by
+    // convention) and can never contain characters that would break CRI parsing, dot-boundary
+    // prefix matching, or wildcard patterns. A zone is dot separated labels — both patterns are
+    // views of the one grammar. Underscores are excluded because they are illegal in a URI host.
+    private static final String LABEL = "[a-z0-9]([a-z0-9-]*[a-z0-9])?";
     private static final Pattern LABEL_PATTERN = Pattern.compile("^" + LABEL + "$");
     private static final Pattern ZONE_PATTERN = Pattern.compile("^" + LABEL + "(\\." + LABEL + ")*$");
 
@@ -25,12 +26,12 @@ public final class ZoneUtil {
      *
      * @param zone the zone to validate
      * @throws IllegalArgumentException if the zone is empty or contains anything other than
-     *         dot separated labels of lowercase letters, digits, and interior dashes or underscores
+     *         dot separated labels of lowercase letters, digits, and interior dashes
      */
     public static void validateZone(String zone) {
         Validate.notEmpty(zone, "The zone must not be empty");
         Validate.isTrue(ZONE_PATTERN.matcher(zone).matches(),
-                        "Invalid zone '%s'. Zones must be dot separated labels of lowercase letters, digits, and interior dashes or underscores",
+                        "Invalid zone '%s'. Zones must be dot separated labels of lowercase letters, digits, and interior dashes",
                         zone);
     }
 
@@ -39,12 +40,12 @@ public final class ZoneUtil {
      *
      * @param label the label to validate
      * @throws IllegalArgumentException if the label is empty or is not a single label of
-     *         lowercase letters, digits, and interior dashes or underscores
+     *         lowercase letters, digits, and interior dashes
      */
     public static void validateLabel(String label) {
         Validate.notEmpty(label, "The label must not be empty");
         Validate.isTrue(LABEL_PATTERN.matcher(label).matches(),
-                        "Invalid zone label '%s'. Labels must be lowercase letters, digits, and interior dashes or underscores",
+                        "Invalid zone label '%s'. Labels must be lowercase letters, digits, and interior dashes",
                         label);
     }
 

--- a/kinotic-core/src/test/java/org/kinotic/core/api/service/ServiceIdentifierTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/api/service/ServiceIdentifierTest.java
@@ -19,10 +19,10 @@ public class ServiceIdentifierTest {
     }
 
     @Test
-    public void zoneWithUnderscoreAddresses() {
-        ServiceIdentifier identifier = new ServiceIdentifier("os_api", "com.example", "LogManager", null, "1.0.0");
-        assertEquals("os_api.com.example.LogManager", identifier.qualifiedName());
-        assertEquals("srv://os_api.com.example.LogManager#1.0.0", identifier.cri().raw());
+    public void platformZoneAddresses() {
+        ServiceIdentifier identifier = new ServiceIdentifier("os-api", "com.example", "LogManager", null, "1.0.0");
+        assertEquals("os-api.com.example.LogManager", identifier.qualifiedName());
+        assertEquals("srv://os-api.com.example.LogManager#1.0.0", identifier.cri().raw());
     }
 
     @Test

--- a/kinotic-core/src/test/java/org/kinotic/core/api/service/ServiceIdentifierTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/api/service/ServiceIdentifierTest.java
@@ -2,8 +2,6 @@ package org.kinotic.core.api.service;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -15,51 +13,45 @@ public class ServiceIdentifierTest {
 
     @Test
     public void qualifiedNameIsZonePrefixed() {
-        ServiceIdentifier identifier = new ServiceIdentifier(List.of("api"), "org.kinotic.os.api.services.iam", "MemberService", null, "1.0.0");
+        ServiceIdentifier identifier = new ServiceIdentifier("api", "org.kinotic.os.api.services.iam", "MemberService", null, "1.0.0");
         assertEquals("api.org.kinotic.os.api.services.iam.MemberService", identifier.qualifiedName());
         assertEquals("srv://api.org.kinotic.os.api.services.iam.MemberService#1.0.0", identifier.cri().raw());
     }
 
     @Test
-    public void multipleZonesProduceOneCriPerZone() {
-        ServiceIdentifier identifier = new ServiceIdentifier(List.of("api", "system"), "com.example", "LogManager", null, "1.0.0");
-        assertEquals(List.of("srv://api.com.example.LogManager#1.0.0",
-                             "srv://system.com.example.LogManager#1.0.0"),
-                     identifier.cris().stream().map(cri -> cri.raw()).toList());
-
-        // with more than one address there is no single cri or qualified name to return
-        assertThrows(IllegalStateException.class, identifier::cri);
-        assertThrows(IllegalStateException.class, identifier::qualifiedName);
+    public void zoneWithUnderscoreAddresses() {
+        ServiceIdentifier identifier = new ServiceIdentifier("os_api", "com.example", "LogManager", null, "1.0.0");
+        assertEquals("os_api.com.example.LogManager", identifier.qualifiedName());
+        assertEquals("srv://os_api.com.example.LogManager#1.0.0", identifier.cri().raw());
     }
 
     @Test
     public void scopeAndMissingNamespaceRoundTrip() {
-        ServiceIdentifier identifier = new ServiceIdentifier(List.of("system"), null, "VmManager", "node1", "0.1.0");
+        ServiceIdentifier identifier = new ServiceIdentifier("system", null, "VmManager", "node1", "0.1.0");
         assertEquals("system.VmManager", identifier.qualifiedName());
         assertEquals("srv://node1@system.VmManager#0.1.0", identifier.cri().raw());
     }
 
     @Test
-    public void noZonesMeansTheUnZonedAddress() {
+    public void noZoneMeansTheUnZonedAddress() {
         ServiceIdentifier identifier = new ServiceIdentifier(null, "com.example", "LegacyService", null, "1.0.0");
         assertEquals("com.example.LegacyService", identifier.qualifiedName());
         assertEquals("srv://com.example.LegacyService#1.0.0", identifier.cri().raw());
-        assertEquals(1, identifier.cris().size());
     }
 
     @Test
-    public void identityIncludesTheZones() {
-        ServiceIdentifier api = new ServiceIdentifier(List.of("api"), "com.example", "LogManager", null, "1.0.0");
-        ServiceIdentifier both = new ServiceIdentifier(List.of("api", "system"), "com.example", "LogManager", null, "1.0.0");
-        assertNotEquals(api, both);
-        assertEquals(api, new ServiceIdentifier(List.of("api"), "com.example", "LogManager", null, "1.0.0"));
+    public void identityIncludesTheZone() {
+        ServiceIdentifier api = new ServiceIdentifier("api", "com.example", "LogManager", null, "1.0.0");
+        ServiceIdentifier system = new ServiceIdentifier("system", "com.example", "LogManager", null, "1.0.0");
+        assertNotEquals(api, system);
+        assertEquals(api, new ServiceIdentifier("api", "com.example", "LogManager", null, "1.0.0"));
     }
 
     @Test
     public void invalidPartsAreRejected() {
-        assertThrows(IllegalArgumentException.class, () -> new ServiceIdentifier(List.of("Bad.Zone"), "com.example", "Svc", null, "1.0.0"));
+        assertThrows(IllegalArgumentException.class, () -> new ServiceIdentifier("Bad.Zone", "com.example", "Svc", null, "1.0.0"));
         // the name is the final label of the address, so it can never contain a dot
-        assertThrows(IllegalArgumentException.class, () -> new ServiceIdentifier(List.of("api"), "com.example", "Svc.Extra", null, "1.0.0"));
+        assertThrows(IllegalArgumentException.class, () -> new ServiceIdentifier("api", "com.example", "Svc.Extra", null, "1.0.0"));
     }
 
 }

--- a/kinotic-core/src/test/java/org/kinotic/core/api/service/ServiceIdentifierTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/api/service/ServiceIdentifierTest.java
@@ -52,6 +52,8 @@ public class ServiceIdentifierTest {
         assertThrows(IllegalArgumentException.class, () -> new ServiceIdentifier("Bad.Zone", "com.example", "Svc", null, "1.0.0"));
         // the name is the final label of the address, so it can never contain a dot
         assertThrows(IllegalArgumentException.class, () -> new ServiceIdentifier("api", "com.example", "Svc.Extra", null, "1.0.0"));
+        // an underscore in a namespace segment would make the CRI an invalid URI
+        assertThrows(IllegalArgumentException.class, () -> new ServiceIdentifier("api", "com.my_example", "Svc", null, "1.0.0"));
     }
 
 }

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
@@ -11,9 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
- * CRIs are backed by {@link java.net.URI}, whose server-based authority parsing rejects the
- * underscores zone labels use (os_api, app_api, slugified ids), so these tests pin that CRIs
- * resolve their scope and resourceName from such addresses regardless.
+ * CRIs are backed by {@link java.net.URI}, whose server-based authority parsing rejects
+ * underscores. Zone labels never carry one (the grammar forbids it), but a namespace segment
+ * still can, so these tests pin that CRIs resolve their scope and resourceName from an
+ * underscore-bearing address regardless.
  * Created by navid on 1/23/20
  */
 public class CRITests {
@@ -35,8 +36,8 @@ public class CRITests {
                                                         + "#"
                                                         + SERVICE_VERSION;
 
-    // A zone label carries an underscore, which java.net.URI will not accept as a hostname
-    private static final String ZONED_NAME = "os_api.org.kinotic.server.clienttest.ITestService";
+    // A namespace segment carries an underscore, which java.net.URI will not accept as a hostname
+    private static final String ZONED_NAME = "os-api.org.kinotic.my_service.ITestService";
 
     @Test
     public void testRawCRI1(){

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/utils/MetaUtilZonesTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/utils/MetaUtilZonesTest.java
@@ -4,28 +4,28 @@ import org.junit.jupiter.api.Test;
 import org.kinotic.core.internal.utils.zonefixtures.PackageZonedService;
 import org.kinotic.core.internal.utils.zonefixtures.TypeZonedService;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
- * Verifies zone resolution precedence: type level {@code @Zones}, then the package-info
+ * Verifies zone resolution precedence: type level {@code @Zone}, then the package-info
  * declaration, then nothing (callers apply the system default).
  */
 public class MetaUtilZonesTest {
 
     @Test
-    public void typeLevelZonesWinOverThePackage() {
-        assertArrayEquals(new String[]{"billing", "system"}, MetaUtil.getZones(TypeZonedService.class));
+    public void typeLevelZoneWinsOverThePackage() {
+        assertEquals("billing", MetaUtil.getZone(TypeZonedService.class));
     }
 
     @Test
-    public void packageInfoZonesApplyWhenTheTypeHasNone() {
-        assertArrayEquals(new String[]{"api"}, MetaUtil.getZones(PackageZonedService.class));
+    public void packageInfoZoneAppliesWhenTheTypeHasNone() {
+        assertEquals("api", MetaUtil.getZone(PackageZonedService.class));
     }
 
     @Test
     public void noDeclarationAnywhereResolvesToNull() {
-        assertNull(MetaUtil.getZones(MetaUtilZonesTest.class));
+        assertNull(MetaUtil.getZone(MetaUtilZonesTest.class));
     }
 
 }

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/utils/ZoneUtilTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/utils/ZoneUtilTest.java
@@ -12,12 +12,12 @@ public class ZoneUtilTest {
 
     @Test
     public void validZones() {
-        assertDoesNotThrow(() -> ZoneUtil.validateZone("os_api"));
-        assertDoesNotThrow(() -> ZoneUtil.validateZone("app_api"));
+        assertDoesNotThrow(() -> ZoneUtil.validateZone("os-api"));
+        assertDoesNotThrow(() -> ZoneUtil.validateZone("app-api"));
         assertDoesNotThrow(() -> ZoneUtil.validateZone("system"));
         assertDoesNotThrow(() -> ZoneUtil.validateZone("billing"));
         assertDoesNotThrow(() -> ZoneUtil.validateZone("api.admin"));
-        assertDoesNotThrow(() -> ZoneUtil.validateZone("app.acme_corp.orders_app"));
+        assertDoesNotThrow(() -> ZoneUtil.validateZone("app.acme-corp.orders-app"));
         assertDoesNotThrow(() -> ZoneUtil.validateZone("zone2.with-dash.x9"));
     }
 
@@ -33,6 +33,8 @@ public class ZoneUtilTest {
         assertThrows(IllegalArgumentException.class, () -> ZoneUtil.validateZone("api."));
         assertThrows(IllegalArgumentException.class, () -> ZoneUtil.validateZone("-api"));
         assertThrows(IllegalArgumentException.class, () -> ZoneUtil.validateZone("api-"));
+        // underscores are excluded so a zone is always a valid URI host
+        assertThrows(IllegalArgumentException.class, () -> ZoneUtil.validateZone("os_api"));
         assertThrows(IllegalArgumentException.class, () -> ZoneUtil.validateZone("_api"));
         assertThrows(IllegalArgumentException.class, () -> ZoneUtil.validateZone("api_"));
         assertThrows(IllegalArgumentException.class, () -> ZoneUtil.validateZone("a pi"));
@@ -45,12 +47,12 @@ public class ZoneUtilTest {
     public void labelsMustBeSingleAndDotFree() {
         assertDoesNotThrow(() -> ZoneUtil.validateLabel("acme-org"));
         assertDoesNotThrow(() -> ZoneUtil.validateLabel("orders-app"));
-        // slugified ids use underscore separators
-        assertDoesNotThrow(() -> ZoneUtil.validateLabel("acme_corp"));
 
         assertThrows(IllegalArgumentException.class, () -> ZoneUtil.validateLabel("acme.org"));
         assertThrows(IllegalArgumentException.class, () -> ZoneUtil.validateLabel("orders.*"));
         assertThrows(IllegalArgumentException.class, () -> ZoneUtil.validateLabel("Acme-Org"));
+        // slugified ids no longer use underscores, so an underscore label is rejected
+        assertThrows(IllegalArgumentException.class, () -> ZoneUtil.validateLabel("acme_corp"));
     }
 
 }

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/utils/zonefixtures/TypeZonedService.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/utils/zonefixtures/TypeZonedService.java
@@ -1,10 +1,10 @@
 package org.kinotic.core.internal.utils.zonefixtures;
 
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 
 /**
  * The type level declaration overrides the package-info declaration.
  */
-@Zones({"billing", "system"})
+@Zone("billing")
 public interface TypeZonedService {
 }

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/utils/zonefixtures/package-info.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/utils/zonefixtures/package-info.java
@@ -1,4 +1,4 @@
-@Zones("api")
+@Zone("api")
 package org.kinotic.core.internal.utils.zonefixtures;
 
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/utils/DomainUtil.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/utils/DomainUtil.java
@@ -32,13 +32,13 @@ public class DomainUtil {
      * The zone for platform services organizations use to manage the system, such as member,
      * application, and entity definition management
      */
-    public static final String OS_API_ZONE = "os_api";
+    public static final String OS_API_ZONE = "os-api";
 
     /**
      * The zone for the platform's application facing data services, such as entity persistence
      * and named query execution
      */
-    public static final String APP_API_ZONE = "app_api";
+    public static final String APP_API_ZONE = "app-api";
 
     /**
      * The zone for services internal to the platform, only reachable by system participants
@@ -52,14 +52,16 @@ public class DomainUtil {
 
     // Project ids may start with a digit because they embed application ids, which may
     // themselves start with a digit
-    private static final Pattern ProjectIdPattern = Pattern.compile("^[a-z0-9][a-z0-9._-]*$");
+    private static final Pattern ProjectIdPattern = Pattern.compile("^[a-z0-9][a-z0-9.-]*$");
     private static final BCryptPasswordEncoder PASSWORD_ENCODER = new BCryptPasswordEncoder();
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
-    private static final Slugify SLUGIFY = Slugify.builder().underscoreSeparator(true).build();
+    // Dash separator, not underscore: slugified ids become zone labels, and underscores are
+    // illegal in a URI host (CRIs are valid URIs by convention)
+    private static final Slugify SLUGIFY = Slugify.builder().build();
 
     /**
      * Validates that the given application id contains only lowercase letters, digits, and
-     * interior dashes or underscores.
+     * interior dashes.
      *
      * @param applicationId to validate
      * @throws IllegalArgumentException if the application id is null or invalid
@@ -77,13 +79,13 @@ public class DomainUtil {
         }
         if (!ProjectIdPattern.matcher(projectId).matches()){
             throw new IllegalArgumentException("Kinotic Project Id Invalid, first character must be a " +
-                                                       "letter or number. And contain only letters, numbers, periods, underscores or dashes. Got "+ projectId);
+                                                       "letter or number. And contain only letters, numbers, periods or dashes. Got "+ projectId);
         }
     }
 
     /**
      * Derives an id from the given text, slugified to lowercase letters, digits, and interior
-     * dashes or underscores.
+     * dashes.
      *
      * @param text to derive the id from
      * @return the derived id
@@ -91,12 +93,12 @@ public class DomainUtil {
      */
     public static String slugifyId(String text) {
         Validate.notBlank(text, "Cannot derive an id from a blank value");
-        // Slugify keeps separators it produced at the edges ("Acme Inc." -> "acme_inc_"), but
+        // Slugify keeps separators it produced at the edges ("Acme Inc." -> "acme-inc-"), but
         // the id must start and end alphanumeric
-        String id = StringUtils.strip(SLUGIFY.slugify(text), "-_");
+        String id = StringUtils.strip(SLUGIFY.slugify(text), "-");
         Validate.notEmpty(id, "Cannot derive an id from '%s', it has no usable characters", text);
         // Guards against a Slugify behavior change; the version in use only emits lowercase
-        // letters, digits, dashes, and underscores
+        // letters, digits, and dashes
         ZoneUtil.validateLabel(id);
         return id;
     }

--- a/kinotic-domain/src/test/java/org/kinotic/domain/internal/api/services/DefaultOrganizationServiceTest.java
+++ b/kinotic-domain/src/test/java/org/kinotic/domain/internal/api/services/DefaultOrganizationServiceTest.java
@@ -23,7 +23,7 @@ class DefaultOrganizationServiceTest {
 
         service.beforeSave(organization).join();
 
-        assertEquals("acme_rockets", organization.getId());
+        assertEquals("acme-rockets", organization.getId());
         assertNotNull(organization.getCreated());
     }
 
@@ -33,7 +33,7 @@ class DefaultOrganizationServiceTest {
 
         service.beforeSave(organization).join();
 
-        assertEquals("acme_inc", organization.getId());
+        assertEquals("acme-inc", organization.getId());
     }
 
     @Test
@@ -51,7 +51,7 @@ class DefaultOrganizationServiceTest {
 
         service.beforeSave(organization).join();
 
-        assertEquals("kinetic_corp", organization.getId());
+        assertEquals("kinetic-corp", organization.getId());
     }
 
     @Test

--- a/kinotic-github/src/main/java/org/kinotic/github/api/services/package-info.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/api/services/package-info.java
@@ -1,7 +1,7 @@
 @Version("1.0.0")
-@Zones(DomainUtil.OS_API_ZONE)
+@Zone(DomainUtil.OS_API_ZONE)
 package org.kinotic.github.api.services;
 
 import org.kinotic.core.api.annotations.Version;
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.internal.utils.DomainUtil;

--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisioner.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisioner.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class GitHubProjectRepoProvisioner implements ProjectRepoProvisioner {
 
-    private static final Slugify SLUGIFY = Slugify.builder().underscoreSeparator(true).build();
+    private static final Slugify SLUGIFY = Slugify.builder().build();
     private static final int GITHUB_REPO_NAME_MAX = 100;
     private static final int TARBALL_MAX_ATTEMPTS = 10;
     private static final Duration TARBALL_RETRY_DELAY = Duration.ofSeconds(2);

--- a/kinotic-js/workspace/CLAUDE.md
+++ b/kinotic-js/workspace/CLAUDE.md
@@ -33,7 +33,7 @@ export class YourService {
 }
 ```
 
-The `@Publish` decorator takes an optional `namespace` and optional `name` (defaults to the class name). Related decorators include `@Scope` on a getter or method (for routing to specific service instances), `@Version` (for semantic versioning), and `@Zones` (declares the zones a service is addressable in, appended to `Kinotic.zonePrefix`; without a declaration, `Kinotic.defaultZones` from the project package.json `kinotic.zones` field applies).
+The `@Publish` decorator takes an optional `namespace` and optional `name` (defaults to the class name). Related decorators include `@Scope` on a getter or method (for routing to specific service instances), `@Version` (for semantic versioning), and `@Zone` (declares the zone a service is addressable in, appended to `Kinotic.zonePrefix`; without a declaration, `Kinotic.defaultZone` from the project package.json `kinotic.zone` field applies).
 
 
 ## Vitest and TC39 decorators

--- a/kinotic-js/workspace/packages/core/package.json
+++ b/kinotic-js/workspace/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/core",
-  "version": "4.0.0",
+  "version": "3.1.0",
   "type": "module",
   "files": [
     "dist"

--- a/kinotic-js/workspace/packages/core/package.json
+++ b/kinotic-js/workspace/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/core",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "type": "module",
   "files": [
     "dist"

--- a/kinotic-js/workspace/packages/core/src/api/Kinotic.ts
+++ b/kinotic-js/workspace/packages/core/src/api/Kinotic.ts
@@ -26,10 +26,10 @@ export interface IKinotic {
     zonePrefix: string | null
 
     /**
-     * The zones applied to published services that carry no {@link Zones} declaration of their
-     * own, typically loaded from the project package.json `kinotic.zones` field.
+     * The zone applied to published services that carry no {@link Zone} declaration of their
+     * own, typically loaded from the project package.json `kinotic.zone` field.
      */
-    defaultZones: string[] | null
+    defaultZone: string | null
 
     /**
      * Requests a connection to the given Stomp url
@@ -78,7 +78,7 @@ export class KinoticSingleton implements IKinotic {
 
     public zonePrefix: string | null = null
 
-    public defaultZones: string[] | null = null
+    public defaultZone: string | null = null
 
     constructor() {
         this._eventBus = new EventBus()

--- a/kinotic-js/workspace/packages/core/src/api/KinoticDecorators.ts
+++ b/kinotic-js/workspace/packages/core/src/api/KinoticDecorators.ts
@@ -11,7 +11,7 @@ import { validateZone } from '@/api/ZoneUtil'
  */
 const scopeFunctions = new WeakSet<Function>()
 const versionRegistry = new WeakMap<Function, string>()
-const zonesRegistry = new WeakMap<Function, string[]>()
+const zonesRegistry = new WeakMap<Function, string>()
 const contextMarkedFunctions = new WeakSet<Function>()
 
 // A Version above @Publish stamps the replacement class while one below it stamps the
@@ -73,20 +73,18 @@ export function Version(version: string) {
 }
 
 /**
- * Declares the zones a service is addressable in, relative to this client's trust context: the
- * declared zones are appended to {@link KinoticSingleton#zonePrefix}, so an application's service
- * can never leave its own `app.<organizationId>.<applicationId>` zone. A service declaring
- * multiple zones registers one address per zone. When absent, {@link KinoticSingleton#defaultZones}
- * (typically loaded from the project package.json `kinotic.zones` field) applies.
- * @param zones each zone is one or more dot separated labels of lowercase letters, digits, and
- *        interior dashes, e.g. `billing` or `billing.internal`
+ * Declares the zone a service is addressable in, relative to this client's trust context: the
+ * declared zone is appended to {@link KinoticSingleton#zonePrefix}, so an application's service
+ * can never leave its own `app.<organizationId>.<applicationId>` zone. When absent,
+ * {@link KinoticSingleton#defaultZone} (typically loaded from the project package.json
+ * `kinotic.zone` field) applies.
+ * @param zone one or more dot separated labels of lowercase letters, digits, and interior
+ *        dashes, e.g. `billing` or `billing.internal`
  */
-export function Zones(zones: string[]) {
-    for (const zone of zones) {
-        validateZone(zone)
-    }
+export function Zone(zone: string) {
+    validateZone(zone)
     return function (value: Function, _context: ClassDecoratorContext<any>): void {
-        zonesRegistry.set(value, zones)
+        zonesRegistry.set(value, zone)
     }
 }
 
@@ -111,30 +109,30 @@ export function receivesContext(serviceInstance: object, methodName: string): bo
     return typeof method === 'function' && contextMarkedFunctions.has(method)
 }
 
-// Effective zones = zonePrefix . declaredZone. The prefix comes from the client's static
+// Effective zone = zonePrefix . declaredZone. The prefix comes from the client's static
 // configuration (never from the service itself), so a wrong declaration can only route nowhere,
 // not into another application's zone — the gateway validates the prefix on every send/subscribe.
-// An empty result means the service registers at its un-zoned legacy address.
-function resolveEffectiveZones(constructor: Function): string[] {
-    const declaredZones = findInConstructorChain(zonesRegistry, constructor) ?? Kinotic.defaultZones ?? []
+// A null result means the service registers at its un-zoned legacy address.
+function resolveEffectiveZone(constructor: Function): string | null {
+    const declaredZone = findInConstructorChain(zonesRegistry, constructor) ?? Kinotic.defaultZone
     const prefix = Kinotic.zonePrefix
-    let effectiveZones: string[]
-    if (prefix != null && declaredZones.length > 0) {
-        effectiveZones = declaredZones.map(zone => `${prefix}.${zone}`)
+    let effectiveZone: string | null
+    if (prefix != null && declaredZone != null) {
+        effectiveZone = `${prefix}.${declaredZone}`
     } else if (prefix != null) {
-        effectiveZones = [prefix]
+        effectiveZone = prefix
     } else {
-        effectiveZones = [...declaredZones]
+        effectiveZone = declaredZone ?? null
     }
-    for (const zone of effectiveZones) {
-        validateZone(zone)
+    if (effectiveZone != null) {
+        validateZone(effectiveZone)
     }
-    return effectiveZones
+    return effectiveZone
 }
 
 /**
  * Registers each instance of the decorated class with the Kinotic ServiceRegistry.
- * The service name defaults to the class name; {@link Version}, {@link Scope}, and {@link Zones}
+ * The service name defaults to the class name; {@link Version}, {@link Scope}, and {@link Zone}
  * on the same class refine the registration.
  * @param namespace the optional namespace the service is published under
  * @param name the service name, defaults to the class name
@@ -145,10 +143,10 @@ export function Publish(namespace?: string | null, name?: string) {
             constructor(...args: any[]) {
                 super(...args)
 
-                const zones = resolveEffectiveZones(this.constructor)
+                const zone = resolveEffectiveZone(this.constructor)
                 const serviceIdentifier = new ServiceIdentifier(namespace ?? null,
                                                                 name || value.name,
-                                                                zones.length > 0 ? zones : undefined)
+                                                                zone ?? undefined)
 
                 const version = findInConstructorChain(versionRegistry, this.constructor)
                 if (version) {

--- a/kinotic-js/workspace/packages/core/src/api/ServiceIdentifier.ts
+++ b/kinotic-js/workspace/packages/core/src/api/ServiceIdentifier.ts
@@ -12,6 +12,16 @@ export class ServiceIdentifier {
 
 
     constructor(namespace: string | null, name: string, zone?: string) {
+        // The name is the final dot separated label of the address, so a dot inside it would
+        // change where the zone and namespace end when the address is parsed or pattern matched
+        if (name.includes('.')) {
+            throw new Error(`The name must not contain '.' but was '${name}'`)
+        }
+        // The namespace forms interior labels of the address; an underscore is illegal in a URI
+        // host, so a segment carrying one would make the CRI an invalid URI
+        if (namespace != null && namespace.includes('_')) {
+            throw new Error(`The namespace must not contain '_' but was '${namespace}'`)
+        }
         this.namespace = namespace
         this.name = name
         this.zone = zone

--- a/kinotic-js/workspace/packages/core/src/api/ServiceIdentifier.ts
+++ b/kinotic-js/workspace/packages/core/src/api/ServiceIdentifier.ts
@@ -5,67 +5,42 @@ export class ServiceIdentifier {
 
     public namespace: string | null
     public name: string
-    public zones?: string[]
+    public zone?: string
     public scope?: string
     public version?: string
-    private _cris: CRI[] | null = null
+    private _cri: CRI | null = null
 
 
-    constructor(namespace: string | null, name: string, zones?: string[]) {
+    constructor(namespace: string | null, name: string, zone?: string) {
         this.namespace = namespace
         this.name = name
-        this.zones = zones
+        this.zone = zone
     }
 
     /**
      * Returns the fully qualified name this {@link ServiceIdentifier} is addressed by
      * This is the zone.namespace.name, omitting any part that is not set
      * @return string containing the qualified name
-     * @throws if this {@link ServiceIdentifier} has more than one zone and therefore more than
-     *         one qualified name
      */
     public qualifiedName(): string {
-        if (this.zones && this.zones.length > 1) {
-            throw new Error(`ServiceIdentifier has ${this.zones.length} zones so there is no single qualifiedName`)
-        }
-        return this.qualifiedNameFor(this.zones?.[0])
-    }
-
-    /**
-     * The {@link CRI}s this {@link ServiceIdentifier} is addressable by, one per zone
-     * @return the cris for this {@link ServiceIdentifier}, never empty
-     */
-    public cris(): CRI[] {
-        if (this._cris == null) {
-            const zones: (string | undefined)[] = this.zones && this.zones.length > 0 ? this.zones : [undefined]
-            this._cris = zones.map(zone => createCRI(
-                EventConstants.SERVICE_DESTINATION_SCHEME, // scheme
-                this.scope || null,                       // scope
-                this.qualifiedNameFor(zone),              // resourceName
-                null,                                     // path
-                this.version || null                      // version
-            ))
-        }
-        return this._cris
+        const name = this.namespace ? this.namespace + "." + this.name : this.name
+        return this.zone ? this.zone + "." + name : name
     }
 
     /**
      * The {@link CRI} that represents this {@link ServiceIdentifier}
      * @return the cri for this {@link ServiceIdentifier}
-     * @throws if this {@link ServiceIdentifier} has more than one zone and therefore more than
-     *         one cri
      */
     public cri(): CRI {
-        const cris = this.cris()
-        const cri = cris[0]
-        if (cris.length !== 1 || !cri) {
-            throw new Error(`ServiceIdentifier has ${cris.length} cris so there is no single cri`)
+        if (this._cri == null) {
+            this._cri = createCRI(
+                EventConstants.SERVICE_DESTINATION_SCHEME, // scheme
+                this.scope || null,                       // scope
+                this.qualifiedName(),                     // resourceName
+                null,                                     // path
+                this.version || null                      // version
+            )
         }
-        return cri
-    }
-
-    private qualifiedNameFor(zone: string | undefined): string {
-        const name = this.namespace ? this.namespace + "." + this.name : this.name
-        return zone ? zone + "." + name : name
+        return this._cri
     }
 }

--- a/kinotic-js/workspace/packages/core/src/api/ServiceRegistry.ts
+++ b/kinotic-js/workspace/packages/core/src/api/ServiceRegistry.ts
@@ -83,7 +83,7 @@ export class ServiceRegistry implements IServiceRegistry {
     }
 
     public register(serviceIdentifier: ServiceIdentifier, service: any): void {
-        const criString = serviceIdentifier.cris().map(cri => cri.raw()).join(', ')
+        const criString = serviceIdentifier.cri().raw()
         if (!this.supervisors.has(criString)) {
             this.debugLogger(`Registering service for CRI: ${criString}`)
             const supervisor = new ServiceInvocationSupervisor(
@@ -98,7 +98,7 @@ export class ServiceRegistry implements IServiceRegistry {
     }
 
     public unRegister(serviceIdentifier: ServiceIdentifier): void {
-        const criString = serviceIdentifier.cris().map(cri => cri.raw()).join(', ')
+        const criString = serviceIdentifier.cri().raw()
         const supervisor = this.supervisors.get(criString)
         if (supervisor) {
             this.debugLogger(`Unregistering service for CRI: ${criString}`)

--- a/kinotic-js/workspace/packages/core/src/api/ZoneUtil.ts
+++ b/kinotic-js/workspace/packages/core/src/api/ZoneUtil.ts
@@ -4,10 +4,11 @@
  * guarantees the shape.
  */
 
-// DNS-style label rule (plus interior underscores, which slugified ids use), so a zone can
-// never contain characters that would break CRI parsing, dot-boundary prefix matching, or
-// wildcard patterns. A zone is dot separated labels — both patterns are views of the one grammar.
-const LABEL = '[a-z0-9]([a-z0-9_-]*[a-z0-9])?'
+// DNS-style label rule, so a zone is always a valid URI authority (CRIs are valid URIs by
+// convention) and can never contain characters that would break CRI parsing, dot-boundary
+// prefix matching, or wildcard patterns. A zone is dot separated labels — both patterns are
+// views of the one grammar. Underscores are excluded because they are illegal in a URI host.
+const LABEL = '[a-z0-9]([a-z0-9-]*[a-z0-9])?'
 const LABEL_PATTERN = new RegExp(`^${LABEL}$`)
 const ZONE_PATTERN = new RegExp(`^${LABEL}(\\.${LABEL})*$`)
 
@@ -15,11 +16,11 @@ const ZONE_PATTERN = new RegExp(`^${LABEL}(\\.${LABEL})*$`)
  * Validates that the given zone satisfies the zone grammar
  * @param zone the zone to validate
  * @throws if the zone is empty or contains anything other than dot separated labels of
- *         lowercase letters, digits, and interior dashes or underscores
+ *         lowercase letters, digits, and interior dashes
  */
 export function validateZone(zone: string): void {
     if (!zone || !ZONE_PATTERN.test(zone)) {
-        throw new Error(`Invalid zone '${zone}'. Zones must be dot separated labels of lowercase letters, digits, and interior dashes or underscores`)
+        throw new Error(`Invalid zone '${zone}'. Zones must be dot separated labels of lowercase letters, digits, and interior dashes`)
     }
 }
 
@@ -27,10 +28,10 @@ export function validateZone(zone: string): void {
  * Validates that the given value is a single zone label
  * @param label the label to validate
  * @throws if the label is empty or is not a single label of lowercase letters, digits, and
- *         interior dashes or underscores
+ *         interior dashes
  */
 export function validateLabel(label: string): void {
     if (!label || !LABEL_PATTERN.test(label)) {
-        throw new Error(`Invalid zone label '${label}'. Labels must be lowercase letters, digits, and interior dashes or underscores`)
+        throw new Error(`Invalid zone label '${label}'. Labels must be lowercase letters, digits, and interior dashes`)
     }
 }

--- a/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
@@ -81,27 +81,25 @@ export class ServiceInvocationSupervisor {
         }
         this.active = true
 
-        // One subscription per zone address, all dispatching to the same invocation machinery
-        for (const cri of this.serviceIdentifier.cris()) {
-            const criBase = cri.baseResource()
-            this.methodSubscriptions.push(this._eventBus
-                                              .observe(criBase)
-                                              .subscribe({
-                                                             next: async (event: IEvent) => {
-                                                                 await this.processEvent(event);
-                                                             },
-                                                             error: (error: Error) => {
-                                                                 this.log.error("Event listener error", error)
-                                                                 this.active = false
-                                                             },
-                                                             complete: () => {
-                                                                 this.log.error("Event listener stopped unexpectedly. Setting supervisor inactive.")
-                                                                 this.active = false
-                                                             },
-                                                         }))
+        // Subscribe at the service's zone address, dispatching to the invocation machinery
+        const criBase = this.serviceIdentifier.cri().baseResource()
+        this.methodSubscriptions.push(this._eventBus
+                                          .observe(criBase)
+                                          .subscribe({
+                                                         next: async (event: IEvent) => {
+                                                             await this.processEvent(event);
+                                                         },
+                                                         error: (error: Error) => {
+                                                             this.log.error("Event listener error", error)
+                                                             this.active = false
+                                                         },
+                                                         complete: () => {
+                                                             this.log.error("Event listener stopped unexpectedly. Setting supervisor inactive.")
+                                                             this.active = false
+                                                         },
+                                                     }))
 
-            this.log.info(`ServiceInvocationSupervisor started for ${criBase}`)
-        }
+        this.log.info(`ServiceInvocationSupervisor started for ${criBase}`)
     }
 
     public stop(): void {

--- a/kinotic-js/workspace/packages/core/test/EventBus.test.ts
+++ b/kinotic-js/workspace/packages/core/test/EventBus.test.ts
@@ -24,7 +24,7 @@ describe('Kinotic JS', () => {
         it('should fail invalid service request', async () => {
             // Target a zone this organization participant may send to, so the request reaches
             // reply-to validation (the behavior under test) rather than being denied by zone rules
-            const toSend: IEvent = new Event('srv://os_api.org.kinotic.server.clienttest.ITestService/testMethodWithString')
+            const toSend: IEvent = new Event('srv://os-api.org.kinotic.server.clienttest.ITestService/testMethodWithString')
             toSend.setHeader(EventConstants.REPLY_TO_HEADER, '')
             toSend.setHeader(EventConstants.CONTENT_TYPE_HEADER, EventConstants.CONTENT_JSON)
             const correlationId = uuidv4()

--- a/kinotic-js/workspace/packages/core/test/ITestService.ts
+++ b/kinotic-js/workspace/packages/core/test/ITestService.ts
@@ -45,7 +45,7 @@ export class TestService implements ITestService {
 
     constructor(continuum?: KinoticSingleton) {
         let toUse = continuum || Kinotic
-        this.serviceProxy = toUse.serviceProxy('os_api.org.kinotic.server.clienttest.ITestService')
+        this.serviceProxy = toUse.serviceProxy('os-api.org.kinotic.server.clienttest.ITestService')
     }
 
     testMethodWithString(value: string): Promise<string> {

--- a/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
+++ b/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest"
+import { ServiceIdentifier } from "../src/api/ServiceIdentifier"
+
+// Pure construction guards, no gateway needed, so this runs regardless of USE_GATEWAY_DOCKER.
+describe('Kinotic JS', () => {
+  describe('packages/core', () => {
+    describe('ServiceIdentifier construction', () => {
+
+        it('builds a zone prefixed cri', () => {
+            const identifier = new ServiceIdentifier('org.kinotic.os.api.services.iam', 'MemberService', 'os-api')
+            identifier.version = '1.0.0'
+            expect(identifier.qualifiedName()).toBe('os-api.org.kinotic.os.api.services.iam.MemberService')
+            expect(identifier.cri().raw()).toBe('srv://os-api.org.kinotic.os.api.services.iam.MemberService#1.0.0')
+        })
+
+        it('rejects a name containing a dot', () => {
+            expect(() => new ServiceIdentifier('com.example', 'Svc.Extra', 'api')).toThrow()
+        })
+
+        it('rejects a namespace containing an underscore', () => {
+            expect(() => new ServiceIdentifier('com.my_example', 'Svc', 'api')).toThrow()
+        })
+    })
+  })
+})

--- a/kinotic-js/workspace/packages/os-api/package.json
+++ b/kinotic-js/workspace/packages/os-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/os-api",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "type": "module",
   "files": [
     "dist"
@@ -32,7 +32,7 @@
     "coverage": "bun test --coverage --pass-with-no-tests"
   },
   "peerDependencies": {
-    "@kinotic-ai/core": ">=3.0.0"
+    "@kinotic-ai/core": ">=4.0.0"
   },
   "dependencies": {
     "@kinotic-ai/idl": "workspace:*",

--- a/kinotic-js/workspace/packages/os-api/package.json
+++ b/kinotic-js/workspace/packages/os-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/os-api",
-  "version": "4.0.0",
+  "version": "3.1.0",
   "type": "module",
   "files": [
     "dist"
@@ -32,7 +32,7 @@
     "coverage": "bun test --coverage --pass-with-no-tests"
   },
   "peerDependencies": {
-    "@kinotic-ai/core": ">=4.0.0"
+    "@kinotic-ai/core": ">=3.1.0"
   },
   "dependencies": {
     "@kinotic-ai/idl": "workspace:*",

--- a/kinotic-js/workspace/packages/os-api/src/api/PlatformZones.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/PlatformZones.ts
@@ -2,8 +2,8 @@ import { validateLabel } from '@kinotic-ai/core'
 
 /**
  * The zones the Kinotic platform partitions the event bus address space into:
- * `app.<organizationId>.<applicationId>` addresses belong to a single application, `app_api`
- * contains the platform's data plane for applications, `os_api` contains the platform services
+ * `app.<organizationId>.<applicationId>` addresses belong to a single application, `app-api`
+ * contains the platform's data plane for applications, `os-api` contains the platform services
  * organizations manage the system through, and `system` addresses are internal to the platform.
  * The gateway enforces which zones a participant may address on every send and subscribe.
  */
@@ -16,7 +16,7 @@ export { APP_API_ZONE } from '@kinotic-ai/persistence'
  * The zone for platform services organizations use to manage the system, such as member,
  * application, and entity definition management
  */
-export const OS_API_ZONE = 'os_api'
+export const OS_API_ZONE = 'os-api'
 
 /**
  * The zone for services internal to the platform, only reachable by system participants

--- a/kinotic-js/workspace/packages/persistence/package.json
+++ b/kinotic-js/workspace/packages/persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/persistence",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "type": "module",
   "files": [
     "dist"
@@ -32,7 +32,7 @@
     "coverage": "bun test --coverage --pass-with-no-tests"
   },
   "peerDependencies": {
-    "@kinotic-ai/core": ">=3.0.0"
+    "@kinotic-ai/core": ">=4.0.0"
   },
   "dependencies": {
     "@kinotic-ai/idl": "workspace:*",

--- a/kinotic-js/workspace/packages/persistence/package.json
+++ b/kinotic-js/workspace/packages/persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/persistence",
-  "version": "4.0.0",
+  "version": "3.1.0",
   "type": "module",
   "files": [
     "dist"
@@ -32,7 +32,7 @@
     "coverage": "bun test --coverage --pass-with-no-tests"
   },
   "peerDependencies": {
-    "@kinotic-ai/core": ">=4.0.0"
+    "@kinotic-ai/core": ">=3.1.0"
   },
   "dependencies": {
     "@kinotic-ai/idl": "workspace:*",

--- a/kinotic-js/workspace/packages/persistence/src/api/IEntitiesRepository.ts
+++ b/kinotic-js/workspace/packages/persistence/src/api/IEntitiesRepository.ts
@@ -12,7 +12,7 @@ import {
  * The zone for the platform's application facing data services, such as entity persistence
  * and named query execution — where the services backing these repositories are hosted.
  */
-export const APP_API_ZONE = 'app_api'
+export const APP_API_ZONE = 'app-api'
 
 export interface IEntitiesRepository {
 

--- a/kinotic-js/workspace/packages/vm-manager/package.json
+++ b/kinotic-js/workspace/packages/vm-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/vm-manager",
-  "version": "4.0.0",
+  "version": "3.1.0",
   "type": "module",
   "files": [
     "bin",
@@ -34,7 +34,7 @@
     "coverage": "bun test --coverage --pass-with-no-tests"
   },
   "peerDependencies": {
-    "@kinotic-ai/core": ">=4.0.0",
+    "@kinotic-ai/core": ">=3.1.0",
     "@kinotic-ai/os-api": ">=3.0.0"
   },
   "dependencies": {

--- a/kinotic-js/workspace/packages/vm-manager/package.json
+++ b/kinotic-js/workspace/packages/vm-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/vm-manager",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "type": "module",
   "files": [
     "bin",
@@ -34,7 +34,7 @@
     "coverage": "bun test --coverage --pass-with-no-tests"
   },
   "peerDependencies": {
-    "@kinotic-ai/core": ">=3.0.0",
+    "@kinotic-ai/core": ">=4.0.0",
     "@kinotic-ai/os-api": ">=3.0.0"
   },
   "dependencies": {

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/workload/package-info.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/workload/package-info.java
@@ -2,9 +2,9 @@
  * Workload orchestration API and proxy interfaces.
  */
 @Version("1.0.0")
-@Zones(DomainUtil.SYSTEM_ZONE)
+@Zone(DomainUtil.SYSTEM_ZONE)
 package org.kinotic.orchestrator.api.workload;
 
 import org.kinotic.core.api.annotations.Version;
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.internal.utils.DomainUtil;

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/ApplicationService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/ApplicationService.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Manages {@link Application}s. An application's id is derived from its slugified name at
- * creation: lowercase letters, digits, and interior dashes or underscores.
+ * creation: lowercase letters, digits, and interior dashes.
  */
 // FIXME: add an OrganizationScopedServiceInterface
 @Publish

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/iam/package-info.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/iam/package-info.java
@@ -1,7 +1,7 @@
 @Version("1.0.0")
-@Zones(DomainUtil.OS_API_ZONE)
+@Zone(DomainUtil.OS_API_ZONE)
 package org.kinotic.os.api.services.iam;
 
 import org.kinotic.core.api.annotations.Version;
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.internal.utils.DomainUtil;

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/package-info.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/package-info.java
@@ -2,9 +2,9 @@
  * Created by Navíd Mitchell 🤪 on 3/30/23.
  */
 @Version("1.0.0")
-@Zones(DomainUtil.OS_API_ZONE)
+@Zone(DomainUtil.OS_API_ZONE)
 package org.kinotic.os.api.services;
 
 import org.kinotic.core.api.annotations.Version;
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.internal.utils.DomainUtil;

--- a/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultProjectService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/internal/api/services/DefaultProjectService.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 @Component
 public class DefaultProjectService extends AbstractApplicationScopedService<Project> implements ProjectService {
 
-    final Slugify slg = Slugify.builder().underscoreSeparator(true).build();
+    final Slugify slg = Slugify.builder().build();
 
     private final ProjectRepository projectRepository;
     private final ProjectRepoProvisioner repoProvisioner;
@@ -112,7 +112,7 @@ public class DefaultProjectService extends AbstractApplicationScopedService<Proj
     }
 
     private String deriveId(Project project) {
-        return (project.getApplicationId() + "_" + slg.slugify(project.getName())).toLowerCase();
+        return (project.getApplicationId() + "-" + slg.slugify(project.getName())).toLowerCase();
     }
 
 }

--- a/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultApplicationServiceTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/internal/api/services/DefaultApplicationServiceTest.java
@@ -11,8 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Covers id handling in {@link DefaultApplicationService#beforeSave}: minting the id from the
- * slugified name and rejecting ids that are not lowercase letters, digits, and interior dashes
- * or underscores. The collaborators are unused by beforeSave, so none are given.
+ * slugified name and rejecting ids that are not lowercase letters, digits, and interior
+ * dashes. The collaborators are unused by beforeSave, so none are given.
  */
 class DefaultApplicationServiceTest {
 
@@ -24,18 +24,18 @@ class DefaultApplicationServiceTest {
 
         service.beforeSave(application).join();
 
-        assertEquals("orders_app", application.getId());
+        assertEquals("orders-app", application.getId());
         assertNotNull(application.getUpdated());
     }
 
     @Test
     void keepsAnExistingId() {
         Application application = new Application("Orders App", "desc");
-        application.setId("orders-app_v2");
+        application.setId("orders-app-v2");
 
         service.beforeSave(application).join();
 
-        assertEquals("orders-app_v2", application.getId());
+        assertEquals("orders-app-v2", application.getId());
     }
 
     @Test

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/AdminJsonEntitiesRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/AdminJsonEntitiesRepository.java
@@ -6,7 +6,7 @@ import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.idl.api.schema.FunctionDefinition;
 import org.kinotic.persistence.api.model.*;
 import org.kinotic.core.api.annotations.Publish;
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.internal.utils.DomainUtil;
 import org.kinotic.domain.api.security.ApplicationParticipant;
 
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletableFuture;
  * Created by Nic Padilla 🤪on 6/18/23.
  */
 @Publish
-@Zones(DomainUtil.APP_API_ZONE)
+@Zone(DomainUtil.APP_API_ZONE)
 public interface AdminJsonEntitiesRepository {
 
     /**

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/JsonEntitiesRepository.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/JsonEntitiesRepository.java
@@ -8,7 +8,7 @@ import org.kinotic.persistence.api.model.QueryParameter;
 import org.kinotic.domain.api.model.RawJson;
 import org.kinotic.persistence.api.model.EntityDefinition;
 import org.kinotic.core.api.annotations.Publish;
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.internal.utils.DomainUtil;
 import org.kinotic.domain.api.security.ApplicationParticipant;
 import tools.jackson.databind.util.TokenBuffer;
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletableFuture;
  * Created by Nic Padilla 🤪on 6/18/23.
  */
 @Publish
-@Zones(DomainUtil.APP_API_ZONE)
+@Zone(DomainUtil.APP_API_ZONE)
 public interface JsonEntitiesRepository {
 
     /**

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/NamedQueriesService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/NamedQueriesService.java
@@ -1,7 +1,7 @@
 package org.kinotic.persistence.api.services;
 
 import org.kinotic.core.api.annotations.Publish;
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.internal.utils.DomainUtil;
 import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
@@ -17,7 +17,7 @@ import java.util.concurrent.CompletableFuture;
  * Created by Navíd Mitchell 🤪 on 4/23/24.
  */
 @Publish
-@Zones(DomainUtil.APP_API_ZONE)
+@Zone(DomainUtil.APP_API_ZONE)
 public interface NamedQueriesService {
 
     /**

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/insights/package-info.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/insights/package-info.java
@@ -2,9 +2,9 @@
  * Created by Navíd Mitchell 🤪 on 3/30/23.
  */
 @Version("1.0.0")
-@Zones(DomainUtil.OS_API_ZONE)
+@Zone(DomainUtil.OS_API_ZONE)
 package org.kinotic.persistence.api.services.insights;
 
 import org.kinotic.core.api.annotations.Version;
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.internal.utils.DomainUtil;

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/package-info.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/api/services/package-info.java
@@ -2,9 +2,9 @@
  * Created by Navíd Mitchell 🤪 on 3/30/23.
  */
 @Version("1.0.0")
-@Zones(DomainUtil.OS_API_ZONE)
+@Zone(DomainUtil.OS_API_ZONE)
 package org.kinotic.persistence.api.services;
 
 import org.kinotic.core.api.annotations.Version;
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.domain.internal.utils.DomainUtil;

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/insights/InsightsContextService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/api/services/insights/InsightsContextService.java
@@ -203,9 +203,9 @@ public class InsightsContextService {
                 this.attachShadow({ mode: 'open' });
                 this.currentDateRange = { startDate: null, endDate: null };
                 this.unsubscribe = null;
-                this.applicationId = 'org_kinotic_sample';
+                this.applicationId = 'org-kinotic-sample';
                 this.entityDefinitionName = 'sales_data';
-                this.entityDefinitionId = 'kinotic.org_kinotic_sample.sales_data';
+                this.entityDefinitionId = 'kinotic.org-kinotic-sample.sales_data';
                 this.dateField = 'orderDate'; // Hardcoded from schema analysis
               }
           
@@ -321,9 +321,9 @@ public class InsightsContextService {
               constructor() {
                 super();
                 this.attachShadow({ mode: 'open' });
-                this.applicationId = 'org_kinotic_sample';
+                this.applicationId = 'org-kinotic-sample';
                 this.entityDefinitionName = 'person_datainsightstest';
-                this.entityDefinitionId = 'kinotic.org_kinotic_sample.person_datainsightstest';
+                this.entityDefinitionId = 'kinotic.org-kinotic-sample.person_datainsightstest';
               }
               
               connectedCallback() {
@@ -387,7 +387,7 @@ public class InsightsContextService {
                 "name": "Customer Age Distribution",
                 "description": "Bar chart showing the distribution of customers across different age groups",
                 "rawHtml": "class CustomerAgeDistributionChart extends HTMLElement { ... }",
-                "applicationId": "org_kinotic_sample",
+                "applicationId": "org-kinotic-sample",
                 "modifiedAt": "2024-01-01T00:00:00Z",
                 "supportsDateRangeFiltering": false
               },
@@ -396,7 +396,7 @@ public class InsightsContextService {
                 "name": "Revenue Trend Analysis",
                 "description": "Line chart showing revenue trends over time",
                 "rawHtml": "class RevenueTrendChart extends HTMLElement { ... }",
-                "applicationId": "org_kinotic_sample",
+                "applicationId": "org-kinotic-sample",
                 "modifiedAt": "2024-01-01T00:00:00Z",
                 "supportsDateRangeFiltering": true
               }

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/sample/TestDataService.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/sample/TestDataService.java
@@ -40,12 +40,12 @@ public class TestDataService {
     /**
      * The id of the Application the sample {@link EntityDefinition}s are created under
      */
-    public static final String SAMPLE_APP_ID = "org_kinotic_sample";
+    public static final String SAMPLE_APP_ID = "org-kinotic-sample";
 
     /**
      * The id of the Project the sample {@link EntityDefinition}s are created under
      */
-    public static final String SAMPLE_PROJECT_ID = SAMPLE_APP_ID + "_default";
+    public static final String SAMPLE_PROJECT_ID = SAMPLE_APP_ID + "-default";
 
     private static final String PEOPLE_FILE = "classpath:people.json";
     private static final String PEOPLE_WITH_ID_FILE = "classpath:people-with-id.json";

--- a/kinotic-server/src/main/java/org/kinotic/server/clienttest/ITestService.java
+++ b/kinotic-server/src/main/java/org/kinotic/server/clienttest/ITestService.java
@@ -3,7 +3,7 @@ package org.kinotic.server.clienttest;
 
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.annotations.Version;
-import org.kinotic.core.api.annotations.Zones;
+import org.kinotic.core.api.annotations.Zone;
 import org.kinotic.core.api.security.Participant;
 import org.kinotic.domain.internal.utils.DomainUtil;
 import reactor.core.publisher.Flux;
@@ -18,7 +18,7 @@ import java.util.concurrent.CompletableFuture;
  */
 @Publish
 @Version("1.0.0")
-@Zones(DomainUtil.OS_API_ZONE)
+@Zone(DomainUtil.OS_API_ZONE)
 public interface ITestService {
 
     String testMethodWithString(String value);

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/ApplicationTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/ApplicationTests.java
@@ -23,7 +23,7 @@ public class ApplicationTests extends KinoticTestBase {
 		test.setOrganizationId(TEST_ORG_ID);
 
 		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> applicationService.save(test))))
-					.expectNextMatches(application -> application.getId().equals("test_app") && application.getUpdated() != null)
+					.expectNextMatches(application -> application.getId().equals("test-app") && application.getUpdated() != null)
 					.expectComplete()
 					.verify();
 
@@ -42,12 +42,12 @@ public class ApplicationTests extends KinoticTestBase {
 		test.setOrganizationId(TEST_ORG_ID);
 
 		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> applicationService.create(test))))
-					.expectNextMatches(application -> application.getId().equals("slugs_and_snails")
+					.expectNextMatches(application -> application.getId().equals("slugs-and-snails")
 							&& application.getName().equals("Slugs. And Snails!"))
 					.expectComplete()
 					.verify();
 
-		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> applicationService.deleteById("slugs_and_snails"))))
+		StepVerifier.create(Mono.fromFuture(runAsOrganization(() -> applicationService.deleteById("slugs-and-snails"))))
 					.expectComplete()
 					.verify();
 	}

--- a/website/content/1.apps/3.application-structure/2.applications-and-projects.md
+++ b/website/content/1.apps/3.application-structure/2.applications-and-projects.md
@@ -10,7 +10,7 @@ An application is the deployable unit in Kinotic. Projects are the building bloc
 Every application has:
 
 - **Name** -- A human-readable name (e.g., `Inventory App`).
-- **Id** -- Derived from the name at creation: the slugified name, made of lowercase letters, digits, and interior dashes or underscores (e.g., `inventory_app`). The id forms the final label of the application's [zone](/reference/cri-format).
+- **Id** -- Derived from the name at creation: the slugified name, made of lowercase letters, digits, and interior dashes (e.g., `inventory-app`). The id forms the final label of the application's [zone](/reference/cri-format).
 - **Description** -- A human-readable summary of what the application does.
 - **Optional API support** -- Applications can optionally expose a GraphQL and/or OpenAPI endpoint that aggregates the services published by their projects.
 
@@ -41,7 +41,7 @@ When you run `kinotic init`, a `.kinotic.json` file is created in your project r
 
 | Field | Description |
 | --- | --- |
-| `application` | The application id this project belongs to. Must match the application id registered with Kinotic OS: lowercase letters, digits, and interior dashes or underscores. |
+| `application` | The application id this project belongs to. Must match the application id registered with Kinotic OS: lowercase letters, digits, and interior dashes. |
 | `entitiesPaths` | An array of `EntitiesPathConfig` objects. Each object specifies `path` (the directory containing entity definitions), `repositoryPath` (where the CLI writes auto-generated repository classes), and `mirrorFolderStructure` (whether to replicate the entity directory structure in the output). The CLI scans these paths when you run `kinotic sync`. |
 
 ### Project Dependencies

--- a/website/content/1.apps/4.services/2.publishing-services.md
+++ b/website/content/1.apps/4.services/2.publishing-services.md
@@ -42,20 +42,20 @@ Kinotic.zonePrefix = appZone(config.organization, config.application)
 @Publish()                       // → srv://app.acme-org.orders-app.OrderService
 class OrderService { ... }
 
-@Zones(['billing'])              // → srv://app.acme-org.orders-app.billing.InvoiceService
+@Zone('billing')                 // → srv://app.acme-org.orders-app.billing.InvoiceService
 @Publish()
 class InvoiceService { ... }
 ```
 
-A default zone for every service in the project can also be declared in `package.json`; a class-level `@Zones` overrides it:
+A default zone for every service in the project can also be declared in `package.json`; a class-level `@Zone` overrides it:
 
 ```json
-{ "kinotic": { "zones": ["billing"] } }
+{ "kinotic": { "zone": "billing" } }
 ```
 
 ```typescript
 import pkg from './package.json' with { type: 'json' }
-Kinotic.defaultZones = pkg.kinotic?.zones ?? null
+Kinotic.defaultZone = pkg.kinotic?.zone ?? null
 ```
 
 The gateway rejects any send or subscribe outside the zones the authenticated participant may address, so a wrong or missing zone routes nowhere — it can never reach another application.
@@ -66,9 +66,9 @@ The gateway rejects any send or subscribe outside the zones the authenticated pa
 
 Marks a class for publication. The full service identifier becomes `namespace.ClassName`; both parts are optional (the name defaults to the class name).
 
-### @Zones(zones)
+### @Zone(zone)
 
-Declares the zones the service is addressable in, relative to the client's `zonePrefix`. A service declaring multiple zones registers one address per zone. Each zone is one or more dot-separated labels of lowercase letters, digits, and interior dashes.
+Declares the zone the service is addressable in, relative to the client's `zonePrefix`. The zone is one or more dot-separated labels of lowercase letters, digits, and interior dashes.
 
 ### @Version(version)
 

--- a/website/content/1.apps/4.services/3.service-proxies.md
+++ b/website/content/1.apps/4.services/3.service-proxies.md
@@ -31,7 +31,7 @@ export class NotificationService implements INotificationService {
 
     constructor(kinotic: IKinotic) {
         // A proxy targets the service's full address, including its zone (see CRI Format).
-        // A platform service is reached in os_api or app_api; an application's own service
+        // A platform service is reached in os-api or app-api; an application's own service
         // is reached in its app zone, e.g. app.acme-org.orders-app.com.example.NotificationService
         this.serviceProxy = kinotic.serviceProxy('app.acme-org.orders-app.com.example.NotificationService')
     }

--- a/website/content/3.reference/1.decorators.md
+++ b/website/content/3.reference/1.decorators.md
@@ -386,14 +386,14 @@ class MyService {
 - `namespace` — Optional service namespace (e.g., `'com.example'`)
 - `name` — Optional custom service name. Defaults to the class name.
 
-### `@Zones(zones)`
+### `@Zone(zone)`
 
-Declares the zones a service is addressable in, relative to the client's `Kinotic.zonePrefix`. A service declaring multiple zones registers one address per zone. When absent, `Kinotic.defaultZones` (typically loaded from the project `package.json` `kinotic.zones` field) applies. Each zone is one or more dot-separated labels of lowercase letters, digits, and interior dashes.
+Declares the zone a service is addressable in, relative to the client's `Kinotic.zonePrefix`. When absent, `Kinotic.defaultZone` (typically loaded from the project `package.json` `kinotic.zone` field) applies. The zone is one or more dot-separated labels of lowercase letters, digits, and interior dashes.
 
 ```typescript
-import { Publish, Zones } from '@kinotic-ai/core'
+import { Publish, Zone } from '@kinotic-ai/core'
 
-@Zones(['billing'])
+@Zone('billing')
 @Publish()
 class InvoiceService {
     // With zonePrefix app.acme-org.orders-app → srv://app.acme-org.orders-app.billing.InvoiceService

--- a/website/content/3.reference/4.cri-format.md
+++ b/website/content/3.reference/4.cri-format.md
@@ -41,29 +41,29 @@ stream://device-42@app.acme-org.orders-app.temperature/sensor-1
 
 ### Zone
 
-The leading portion of the resource name places the resource in a zone, the isolation boundary the gateway validates on every send and subscribe. A zone is one or more dot-separated labels of lowercase letters, digits, and interior dashes or underscores.
+The leading portion of the resource name places the resource in a zone, the isolation boundary the gateway validates on every send and subscribe. A zone is one or more dot-separated labels of lowercase letters, digits, and interior dashes.
 
 | Zone | Description |
 |------|-------------|
 | `app.<organizationId>.<applicationId>` | One application's services. Only that application (and system participants) can call them; only that application can host them. Applications may nest their own sub-zones, e.g. `app.acme-org.orders-app.billing`. |
-| `app_api` | The platform's data plane for applications, such as entity persistence and named query execution. Hosted in-process by the platform only. |
-| `os_api` | The platform services organizations manage the system through, such as member, application, and entity definition management. Hosted in-process by the platform only. |
+| `app-api` | The platform's data plane for applications, such as entity persistence and named query execution. Hosted in-process by the platform only. |
+| `os-api` | The platform services organizations manage the system through, such as member, application, and entity definition management. Hosted in-process by the platform only. |
 | `system` | Platform-internal services. Only system participants can call or host them. |
 
 Which zones a connection may address is determined by the authenticated participant:
 
 | Participant | May send to | May host in |
 |-------------|-------------|-------------|
-| APPLICATION (org, app) | `app_api.*`, `app.<org>.<app>.*` | `app.<org>.<app>.*` |
-| ORGANIZATION (org) | `os_api.*` | — |
-| SYSTEM | everything | `os_api.*`, `app_api.*`, `system.*` |
+| APPLICATION (org, app) | `app-api.*`, `app.<org>.<app>.*` | `app.<org>.<app>.*` |
+| ORGANIZATION (org) | `os-api.*` | — |
+| SYSTEM | everything | `os-api.*`, `app-api.*`, `system.*` |
 
 ### Resource Name
 
 The name of the resource being addressed. For services, this is the zone followed by the fully qualified service name. For streams, this is the zone followed by the event type name.
 
 ```
-srv://os_api.com.example.UserService
+srv://os-api.com.example.UserService
 stream://app.acme-org.orders-app.temperature
 ```
 
@@ -72,7 +72,7 @@ stream://app.acme-org.orders-app.temperature
 An optional path that identifies a specific part of the resource, such as a method name on a service.
 
 ```
-srv://os_api.com.example.UserService/findById
+srv://os-api.com.example.UserService/findById
 stream://app.acme-org.orders-app.temperature/sensor-1
 ```
 
@@ -81,8 +81,8 @@ stream://app.acme-org.orders-app.temperature/sensor-1
 An optional semantic version for the resource. Enables versioned service routing so multiple versions of a service can coexist.
 
 ```
-srv://os_api.com.example.UserService/findById#1.0.0
-srv://os_api.com.example.UserService#2.0.0
+srv://os-api.com.example.UserService/findById#1.0.0
+srv://os-api.com.example.UserService#2.0.0
 ```
 
 ## Factory Function
@@ -93,16 +93,16 @@ The `createCRI` function provides several overloads for constructing CRI instanc
 import { createCRI } from '@kinotic-ai/core'
 
 // From a raw string
-const cri1 = createCRI('srv://os_api.com.example.UserService/findById#1.0.0')
+const cri1 = createCRI('srv://os-api.com.example.UserService/findById#1.0.0')
 
 // From scheme and resource name
-const cri2 = createCRI('srv', 'os_api.com.example.UserService')
+const cri2 = createCRI('srv', 'os-api.com.example.UserService')
 
 // From scheme, scope, and resource name
 const cri3 = createCRI('stream', 'tenant-123', 'app.acme-org.orders-app.orders')
 
 // From all components
-const cri4 = createCRI('srv', null, 'os_api.com.example.UserService', 'findById', '1.0.0')
+const cri4 = createCRI('srv', null, 'os-api.com.example.UserService', 'findById', '1.0.0')
 ```
 
 ### CRI Interface
@@ -128,8 +128,8 @@ cri.raw()           // 'srv://tenant-123@app.acme-org.orders-app.OrderService/pl
 
 | CRI | Description |
 |-----|-------------|
-| `srv://os_api.org.kinotic.os.api.services.iam.MemberService` | A platform service in the `os_api` zone |
-| `srv://app_api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save` | A specific method on a platform service |
+| `srv://os-api.org.kinotic.os.api.services.iam.MemberService` | A platform service in the `os-api` zone |
+| `srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save` | A specific method on a platform service |
 | `srv://app.acme-org.orders-app.OrderService/create#1.0.0` | A versioned method on an application's own service |
 | `srv://app.acme-org.orders-app.billing.InvoiceService` | A service in an application-declared sub-zone |
 | `srv://system.org.kinotic.orchestrator.api.workload.WorkloadOrchestrationService` | A platform-internal service |

--- a/website/content/3.reference/5.sdk-packages.md
+++ b/website/content/3.reference/5.sdk-packages.md
@@ -43,7 +43,7 @@ Core connectivity, service proxying, events, and CRUD abstractions. This is the 
 | Decorator | Description |
 |-----------|-------------|
 | `@Publish(namespace?, name?)` | Publish a class as a remote service |
-| `@Zones(zones)` | Declare the zones a service is addressable in, relative to `Kinotic.zonePrefix` |
+| `@Zone(zone)` | Declare the zone a service is addressable in, relative to `Kinotic.zonePrefix` |
 | `@Version(version)` | Set semantic version for a service |
 | `@Scope` | Mark the getter or method providing the service scope |
 | `@Context` | Mark a method whose final parameter receives the request context |


### PR DESCRIPTION
Two related zone cleanups, both shipped as **3.1.0**.

## 1. One zone per service

The multi-zone *list* was unused — every service already resolved to exactly one zone (all 10 `@Zones` declare one; a type-level declaration replaces the package default, never stacks). So:

- **`@Zones` → `@Zone`** (`String value()`); `MetaUtil.getZones` → `getZone`.
- **`ServiceIdentifier`**: `List zones` → `String zone`, `cris()` → `cri()`, and the "throws if >1 zone" guards on `cri()`/`qualifiedName()` are deleted (Java + TS).
- `ServiceInvocationSupervisor` registers one consumer; the `@Proxy` "at most one zone" guard is gone.
- TS: `@Zone`, `ServiceIdentifier.zone`/`cri()`, `Kinotic.defaultZone` (from `package.json` `kinotic.zone`). An app developer still declares a per-service sub-zone that appends to the `app.<org>.<app>` prefix.

## 2. Dashes so CRIs are valid URIs

CRIs are valid URIs by convention, but `java.net.URI.getHost()` returns null on an underscore (illegal in an RFC-2396 host) — that's what produced the zoned `srv://null`. Rather than *only* rely on #290's robust `getRawAuthority` parser, the inputs are kept URI-valid:

- **Slugified ids use dashes** (`DomainUtil.slugifyId`, project ids, GitHub repo names) → `acme-inc`, `org-kinotic-sample`.
- **Platform zones** `os_api`/`app_api` → **`os-api`/`app-api`** (Java `DomainUtil` + TS `PlatformZones`/`IEntitiesRepository`).
- **Zone grammar** (`ZoneUtil` Java + TS) excludes `_`, so a zone is always a valid URI host — an underscore now fails loudly at `validateZone` instead of silently as `srv://null`.
- **Project ids** join with `-` (`applicationId-nameSlug`).

### Namespaces are URI-valid too

A namespace segment becomes an interior label of the CRI (`zone.namespace.name`), so an underscore there would make the CRI an invalid URI just as it did in a zone. Underscores are now rejected in the **`ServiceIdentifier` constructor** (Java + TS), where every registration path converges (package-derived, explicit `@Publish`, proxy, TS decorator). This is a URI-validity constraint, not an authorization one — the namespace sits inside the `**` wildcard tail *after* the authorized zone prefix, so it is never a security boundary; **dots** stay allowed as the natural package separator.

The #290 `getRawAuthority` parser stays as the robust parse regardless — the `DefaultCRI` comments no longer claim a namespace may carry an underscore.

## Versioning

Shipped as **3.1.0** across core + the peer-dependents (`os-api`, `persistence`, `vm-manager`), `>=3.1.0` peer floor.

## Testing

- Java tests pass across `kinotic-core`, `kinotic-domain`, `kinotic-os-api`, `kinotic-api-gateway` (`ZoneUtilTest`, `ServiceIdentifierTest` — now covering namespace-underscore rejection, `MetaUtilZonesTest`, `CRITests`, `DefaultOrganizationServiceTest`, `DefaultApplicationServiceTest`, `StompAuthorizerFactoryTest`); `kinotic-persistence`/`kinotic-github`/`kinotic-test` compile.
- TS workspace: new `ServiceIdentifier.test.ts` unit test (name-dot + namespace-underscore guards) passes; changed core files typecheck with no errors.

## Note on base

**#290** (the CRI `getRawAuthority` fix) is now merged into develop. This branch has been rebased onto the latest develop — the redundant local copy of #290 was dropped, so the diff is only the single-zone + dashes + namespace changes, and it merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx