### PR TITLE
Silence javadoc doclint missing-comment warnings across all modules

### DIFF
--- a/buildSrc/src/cloud/groovy/org.kinotic.java-library-conventions.gradle
+++ b/buildSrc/src/cloud/groovy/org.kinotic.java-library-conventions.gradle
@@ -7,17 +7,3 @@ plugins {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-autoconfigure'
 }
-
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
-
-javadoc {
-    // suppress warnings
-    options.addStringOption('Xdoclint:none', '-quiet')
-
-    if(JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption('html5', true)
-    }
-}

--- a/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
@@ -16,6 +16,16 @@ java {
     withSourcesJar()
 }
 
+javadoc {
+    // Delombok generates the sources javadoc runs on, so the entities and test services it emits
+    // carry no doc comments; Xdoclint:none keeps those missing-comment notes off the build log
+    options.addStringOption('Xdoclint:none', '-quiet')
+
+    if (JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+}
+
 // Byte-identical archives for identical inputs, so CI can key "already published" checks
 // on a jar's hash and skip republishing images whose contents did not change
 tasks.withType(AbstractArchiveTask).configureEach {

--- a/buildSrc/src/publish/groovy/org.kinotic.java-library-conventions.gradle
+++ b/buildSrc/src/publish/groovy/org.kinotic.java-library-conventions.gradle
@@ -95,12 +95,3 @@ jreleaser {
         }
     }
 }
-
-javadoc {
-    // suppress warnings
-    options.addStringOption('Xdoclint:none', '-quiet')
-
-    if(JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption('html5', true)
-    }
-}


### PR DESCRIPTION
## What

`kinotic-server:javadoc` (and any application module) emitted a wall of doclint notes on every build:

```
ITestService.java:31: warning: no @return
    byte[] getBinaryData();
DefaultTestService.java:22: warning: use of default constructor, which does not provide a comment
KinoticServerApplication.java:9: warning: no comment
...
```

## Why

`withJavadocJar()` is enabled for **every** module in `java-common-conventions`, but the `Xdoclint:none` suppression lived only in the two `java-library-conventions` variants (`publish` + `cloud`). Application modules like `kinotic-server` use `java-application-conventions`, so they built a javadoc jar with doclint **on**, running it over delombok-generated sources whose entities and test services carry no doc comments.

## Change

Move the `javadoc { Xdoclint:none / html5 }` configuration to `java-common-conventions` — the single place `withJavadocJar()` is applied — so every module inherits it, and drop the now-duplicated blocks from the `publish` and `cloud` library conventions (the `cloud` variant's redundant `java { withJavadocJar(); withSourcesJar() }`, already provided by common, goes too).

```
buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle     | +10   ← single home
buildSrc/src/publish/groovy/org.kinotic.java-library-conventions.gradle |  -9   ← duplicate removed
buildSrc/src/cloud/groovy/org.kinotic.java-library-conventions.gradle   | -14   ← duplicate removed
```

One home for the config instead of three; application modules now inherit the same treatment library modules already had.

## Testing

`:kinotic-core:javadoc` builds clean with zero doclint missing-comment/param/return warnings. `kinotic-server` inherits the same shared convention (it couldn't be built in the sandbox — it depends on `:kinotic-frontend`, excluded in cloud-compile mode — but the fix is in the convention it applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx)_