### PR TITLE
Zone the non-existent-service test so it returns NO_HANDLERS instead of disconnecting

### DIFF
--- a/kinotic-js/workspace/packages/core/test/INonExistentService.ts
+++ b/kinotic-js/workspace/packages/core/test/INonExistentService.ts
@@ -11,7 +11,9 @@ class NonExistentService implements INonExistentService {
     private readonly serviceProxy: IServiceProxy
 
     constructor() {
-        this.serviceProxy = Kinotic.serviceProxy('com.namespace.NonExistentService')
+        // Zoned into os-api so the org participant is authorized to send here and routing returns
+        // NO_HANDLERS; an un-zoned address is denied at authorization and drops the connection.
+        this.serviceProxy = Kinotic.serviceProxy('os-api.com.namespace.NonExistentService')
     }
 
     probablyNotHome(): Promise<void> {

--- a/kinotic-js/workspace/packages/core/test/KinoticRpc.test.ts
+++ b/kinotic-js/workspace/packages/core/test/KinoticRpc.test.ts
@@ -34,7 +34,7 @@ describe('Kinotic JS', () => {
         })
 
         it('should return missing service error', async () => {
-            await expect(NON_EXISTENT_SERVICE.probablyNotHome()).rejects.toThrowError('(NO_HANDLERS,-1) No handlers for address srv://com.namespace.NonExistentService')
+            await expect(NON_EXISTENT_SERVICE.probablyNotHome()).rejects.toThrowError('(NO_HANDLERS,-1) No handlers for address srv://os-api.com.namespace.NonExistentService')
         })
 
         // --- Binary Passthrough Tests ---


### PR DESCRIPTION
## Symptom

`@kinotic-ai/core` CI: `KinoticRpc.test.ts` fails 17 tests. The first failure cascades into the rest:

```
× should return missing service error
  → expected [Function] to throw error including '(NO_HANDLERS,-1) No handlers for addr…'
    but got 'Connection disconnected'
× should decode a byte[] return … → You must call connect on the event bus before sending any request
× should get participant id from vert.x context → You must call connect …
  … (15 more, all "must call connect before sending")
```

## Root cause

The test connects via `createConnectionInfo()`, whose default auth headers set `organizationId: 'kinotic-test'` and **no** `applicationId` → the gateway authenticates an **`OrganizationParticipant`**. Per `StompAuthorizerFactory`, an org participant may send only to `os-api.**` and `app-api.**`:

```java
} else if (participant instanceof OrganizationParticipant) {
    addZone(sendPatterns, DomainUtil.OS_API_ZONE);   // srv://os-api.**
    addZone(sendPatterns, DomainUtil.APP_API_ZONE);  // srv://app-api.**
}
```

- `TEST_SERVICE` → `os-api.org.kinotic.server.clienttest.ITestService` → matches `os-api.**` ✓
- `NON_EXISTENT_SERVICE` → `com.namespace.NonExistentService` (**un-zoned**) → matches neither → the gateway **denies the send and drops the connection**, so every subsequent test in the file sends on a dead bus.

`ITestService` was zoned into `os-api` when the suite migrated to zones; `INonExistentService` was left un-zoned, so it now exercises an address the participant can't reach — an authorization drop instead of the intended routing miss.

## Fix

Zone the non-existent address into `os-api` (reachable by the org participant). The send is now authorized, routing runs, finds no registered handler, and returns `NO_HANDLERS` with the connection intact — the behavior the test asserts, matching the sibling `testMissingMethod` case.

```diff
- Kinotic.serviceProxy('com.namespace.NonExistentService')
+ Kinotic.serviceProxy('os-api.com.namespace.NonExistentService')
```

and the expected error address updates to `srv://os-api.com.namespace.NonExistentService`.

## Testing

These are integration tests against the server Docker image and can't run in the sandbox (no Docker) — CI is the verification. TEST_SERVICE already passing in the same run confirms the server image carries zone enforcement, so this is a client-test-only fix; no server rebuild needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx)_