### PR TITLE
Bump kinotic-cli to 3.0.0 on @kinotic-ai/* 3.1.0

### DIFF
--- a/kinotic-js/kinotic-cli/package.json
+++ b/kinotic-js/kinotic-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kinotic-ai/kinotic-cli",
-    "version": "2.5.0",
+    "version": "3.0.0",
     "description": "Kinotic CLI provides the ability to build, deploy, and manage Kinotic applications that run on the Kinotic OS.",
     "author": "Kinotic Developers",
     "bin": {
@@ -18,10 +18,10 @@
     ],
     "dependencies": {
         "@inquirer/prompts": "^8.3.2",
-        "@kinotic-ai/core": "^2.0.0",
+        "@kinotic-ai/core": "^3.1.0",
         "@kinotic-ai/idl": "^1.0.9",
-        "@kinotic-ai/os-api": "^2.0.0",
-        "@kinotic-ai/persistence": "^2.0.0",
+        "@kinotic-ai/os-api": "^3.1.0",
+        "@kinotic-ai/persistence": "^3.1.0",
         "@kinotic-ai/spawn": "^0.5.0",
         "@oclif/core": "^4.9.0",
         "c12": "^3.3.3",

--- a/kinotic-js/kinotic-cli/pnpm-lock.yaml
+++ b/kinotic-js/kinotic-cli/pnpm-lock.yaml
@@ -12,17 +12,17 @@ importers:
         specifier: ^8.3.2
         version: 8.5.2(@types/node@25.9.3)
       '@kinotic-ai/core':
-        specifier: ^1.7.0
-        version: 1.7.0(typescript@5.9.3)
+        specifier: ^3.1.0
+        version: 3.1.0(typescript@5.9.3)
       '@kinotic-ai/idl':
         specifier: ^1.0.9
         version: 1.0.9(typescript@5.9.3)
       '@kinotic-ai/os-api':
-        specifier: ^1.11.0
-        version: 1.11.0(@kinotic-ai/core@1.7.0(typescript@5.9.3))(typescript@5.9.3)
+        specifier: ^3.1.0
+        version: 3.1.0(@kinotic-ai/core@3.1.0(typescript@5.9.3))(typescript@5.9.3)
       '@kinotic-ai/persistence':
-        specifier: ^1.4.0
-        version: 1.4.0(@kinotic-ai/core@1.7.0(typescript@5.9.3))(typescript@5.9.3)
+        specifier: ^3.1.0
+        version: 3.1.0(@kinotic-ai/core@3.1.0(typescript@5.9.3))(typescript@5.9.3)
       '@kinotic-ai/spawn':
         specifier: ^0.5.0
         version: 0.5.0(typescript@5.9.3)
@@ -59,9 +59,6 @@ importers:
       radash:
         specifier: ^12.1.1
         version: 12.1.1
-      reflect-metadata:
-        specifier: ^0.2.2
-        version: 0.2.2
       simple-git:
         specifier: 3.36.0
         version: 3.36.0
@@ -481,8 +478,16 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@kinotic-ai/core@1.7.0':
-    resolution: {integrity: sha512-b6lnOKS5NmHl2leKSMrao1lxVmtFK5NxTakaEJgAec1ACg+VZ8u44SCfAp7FYZAPbA0fUvuYx8m0n1sMvdjS9g==}
+  '@kinotic-ai/core@3.1.0':
+    resolution: {integrity: sha512-EGmQ3HlOiZpPAl8udICk8iHqTMCzmtVrRA7gMMgfC7u6GQUDPCQnuiVWrOkDfrg7VrAmuwN95HbnrrFcqpTZuA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@kinotic-ai/idl@1.0.10':
+    resolution: {integrity: sha512-+bhCgJmtCI/6EuPScyy8xzxEofS6Lj9NFi2MLxulftKe7Azid4yyIn/XuaKsCx8zTGjUOXYC9hOmIOBS2TjecA==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -497,19 +502,19 @@ packages:
       typescript:
         optional: true
 
-  '@kinotic-ai/os-api@1.11.0':
-    resolution: {integrity: sha512-q7fNduAHIImb7TLn4o+mgCfrC0sVhokh64AfxJB1JkXIkwV1I9+QM1Kc9iQM1MDbiZdiYaUYepxZ4acjjb5jXA==}
+  '@kinotic-ai/os-api@3.1.0':
+    resolution: {integrity: sha512-al2PJCHtSSySwqIuYCrwrf1uXKxLxDc1idV6GPbxzAkjJiDTODP3GyeTB2kwLNHwcCi9dCktvhoQNBCN6+P1/w==}
     peerDependencies:
-      '@kinotic-ai/core': '>=1.7.0'
+      '@kinotic-ai/core': '>=3.1.0'
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@kinotic-ai/persistence@1.4.0':
-    resolution: {integrity: sha512-LvqeEdb/2zgDILp6Aoyl/oEmc1a9rWY5T6fuRsnSpwT4689jqzbADtDHV8RKmJPgxDysZntW7VjV0+fbJnFHKw==}
+  '@kinotic-ai/persistence@3.1.0':
+    resolution: {integrity: sha512-QXIVOATahEkFMZh4CFQVeUotajpXP9VFYrXrOf7tav7BT8r1vi/BmCPUNQnVH4L+Wan3ifSSER/yk3KrmLksNQ==}
     peerDependencies:
-      '@kinotic-ai/core': '>=1.7.0'
+      '@kinotic-ai/core': '>=3.1.0'
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -2070,7 +2075,7 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@kinotic-ai/core@1.7.0(typescript@5.9.3)':
+  '@kinotic-ai/core@3.1.0(typescript@5.9.3)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -2079,7 +2084,6 @@ snapshots:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@8.1.1)
       p-tap: 4.0.0
-      reflect-metadata: 0.2.2
       rxjs: 7.8.2
       typescript-optional: 3.0.0-alpha.3
       uuid: 13.0.2
@@ -2088,26 +2092,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@kinotic-ai/idl@1.0.10(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@kinotic-ai/idl@1.0.9(typescript@5.9.3)':
     dependencies:
       reflect-metadata: 0.2.2
     optionalDependencies:
       typescript: 5.9.3
 
-  '@kinotic-ai/os-api@1.11.0(@kinotic-ai/core@1.7.0(typescript@5.9.3))(typescript@5.9.3)':
+  '@kinotic-ai/os-api@3.1.0(@kinotic-ai/core@3.1.0(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@kinotic-ai/core': 1.7.0(typescript@5.9.3)
-      '@kinotic-ai/idl': 1.0.9(typescript@5.9.3)
-      '@kinotic-ai/persistence': 1.4.0(@kinotic-ai/core@1.7.0(typescript@5.9.3))(typescript@5.9.3)
+      '@kinotic-ai/core': 3.1.0(typescript@5.9.3)
+      '@kinotic-ai/idl': 1.0.10(typescript@5.9.3)
+      '@kinotic-ai/persistence': 3.1.0(@kinotic-ai/core@3.1.0(typescript@5.9.3))(typescript@5.9.3)
       rxjs: 7.8.2
     optionalDependencies:
       typescript: 5.9.3
 
-  '@kinotic-ai/persistence@1.4.0(@kinotic-ai/core@1.7.0(typescript@5.9.3))(typescript@5.9.3)':
+  '@kinotic-ai/persistence@3.1.0(@kinotic-ai/core@3.1.0(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@kinotic-ai/core': 1.7.0(typescript@5.9.3)
-      '@kinotic-ai/idl': 1.0.9(typescript@5.9.3)
-      reflect-metadata: 0.2.2
+      '@kinotic-ai/core': 3.1.0(typescript@5.9.3)
+      '@kinotic-ai/idl': 1.0.10(typescript@5.9.3)
       rxjs: 7.8.2
     optionalDependencies:
       typescript: 5.9.3

--- a/kinotic-js/kinotic-cli/pnpm-workspace.yaml
+++ b/kinotic-js/kinotic-cli/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 allowBuilds:
   esbuild: false
 minimumReleaseAgeExclude:
-  - '@kinotic-ai/core@1.7.0'
-  - '@kinotic-ai/os-api@1.11.0'
-  - '@kinotic-ai/persistence@1.4.0'
+  - '@kinotic-ai/core@3.1.0'
+  - '@kinotic-ai/os-api@3.1.0'
+  - '@kinotic-ai/persistence@3.1.0'
   - '@kinotic-ai/spawn@0.3.0'
   - '@kinotic-ai/spawn@0.4.0'


### PR DESCRIPTION
## What

Moves the CLI onto the 3.1.0 ecosystem and releases it as **3.0.0**.

```diff
- "version": "2.5.0",
+ "version": "3.0.0",
  ...
- "@kinotic-ai/core": "^2.0.0",
- "@kinotic-ai/os-api": "^2.0.0",
- "@kinotic-ai/persistence": "^2.0.0",
+ "@kinotic-ai/core": "^3.1.0",
+ "@kinotic-ai/os-api": "^3.1.0",
+ "@kinotic-ai/persistence": "^3.1.0",
```

- `pnpm-workspace.yaml` `minimumReleaseAgeExclude` pins updated to `@3.1.0` (they were stale at `1.x`), so pnpm installs the freshly published releases without the release-age delay.
- `pnpm-lock.yaml` regenerated (resolves core/os-api/persistence at 3.1.0).

## Why 3.0.0

The CLI now targets the 3.1.0 ecosystem and the repository code it **generates** matches the 3.1.0 persistence API — a breaking change for CLI users who regenerate. It lands as a major bump on the CLI's own version line (npm latest is 2.3.0; 2.4.0/2.5.0 were staged but never published).

## Testing

- `pnpm build` (`tsc -b`) **passes** against 3.1.0 with **zero source changes** — the CLI's use of `Kinotic`, `ConnectionInfo`, `BearerTokenAuthProvider`, the config types, and the repository/query types is compatible. This is the gate that matters, since `prepack` runs `build`.
- `pnpm test` (mocha) has one pre-existing failure unrelated to this change: `GqlConversion.test.ts` imports `src/internal/converter/graphql/GqlConversionState.js`, but that `graphql/` directory is not in the repo (removed without updating the test). It is not in the publish path.

## Follow-up

Once this is published, e2e-tests' `@kinotic-ai/kinotic-cli` dep moves from `^2.3.0` to `^3.0.0` (that bump rides along with PR #294 / the e2e update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx)_