### PR TITLE
Ship the oclif launcher so the kinotic bin publishes (CLI 3.1.0)

### DIFF
--- a/kinotic-js/kinotic-cli/.gitignore
+++ b/kinotic-js/kinotic-cli/.gitignore
@@ -11,3 +11,6 @@ node_modules
 .yalc
 oclif.manifest.json
 structures.json
+
+# bin/ holds the oclif launcher (run.js); the repo-root .gitignore blanket-ignores bin/
+!/bin/

--- a/kinotic-js/kinotic-cli/bin/dev.cmd
+++ b/kinotic-js/kinotic-cli/bin/dev.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+node "%~dp0\dev" %*

--- a/kinotic-js/kinotic-cli/bin/dev.js
+++ b/kinotic-js/kinotic-cli/bin/dev.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env tsx
+// eslint-disable-next-line node/shebang
+(async () => {
+  const oclif = await import('@oclif/core')
+  await oclif.execute({type: 'esm', development: true, dir: import.meta.url})
+})()

--- a/kinotic-js/kinotic-cli/bin/run.cmd
+++ b/kinotic-js/kinotic-cli/bin/run.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+node "%~dp0\run" %*

--- a/kinotic-js/kinotic-cli/bin/run.js
+++ b/kinotic-js/kinotic-cli/bin/run.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// eslint-disable-next-line node/shebang
+(async () => {
+  const oclif = await import('@oclif/core')
+  await oclif.execute({type: 'esm', dir: import.meta.url})
+})()

--- a/kinotic-js/kinotic-cli/package.json
+++ b/kinotic-js/kinotic-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kinotic-ai/kinotic-cli",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "description": "Kinotic CLI provides the ability to build, deploy, and manage Kinotic applications that run on the Kinotic OS.",
     "author": "Kinotic Developers",
     "bin": {


### PR DESCRIPTION
## The bug

The published `@kinotic-ai/kinotic-cli` tarball ships **no `bin/` directory**, so the `kinotic` command is broken for every consumer:

```
node_modules/@kinotic-ai/kinotic-cli/  →  README.md  dist/  package.json   (no bin/)
```

...even though `package.json` declares `"bin": { "kinotic": "./bin/run.js" }` and lists `/bin` in `files`.

## Root cause

The `bin/` launchers were dropped during the `structures → kinotic` migration and never re-added. They stayed invisible because the repo-root `.gitignore:12` has a blanket `bin/` (there to ignore Java IDE/Gradle `bin/` output dirs), which also swallows this package's legitimate source `bin/`. So the launchers only ever existed in dirty working copies — a publish from a clean checkout (or CI) packs a `bin`-less tarball, and `pnpm build` only writes `dist/`, so it never recreated them.

## Fix

Restore the standard oclif launcher set (matching the old `structures-cli/bin`):

- `bin/run.js` (mode `100755`) — the published entrypoint
- `bin/run.cmd` — Windows shim
- `bin/dev.js` (mode `100755`) — run commands from TS source via `tsx`
- `bin/dev.cmd` — Windows dev shim

and negate the ignore for this package's `bin/` in `kinotic-js/kinotic-cli/.gitignore` (`!/bin/`) so they're tracked and packed — scoped to the CLI, leaving the broad root rule intact for the Java modules.

## Verification

- `node bin/run.js --version` → `@kinotic-ai/kinotic-cli/3.1.0 …`, and `--help` loads the commands from `dist/commands` (gen, init, login, …).
- `bin/dev.js` runs the same via `tsx` (dev mode).
- `npm pack --dry-run` now lists all four `bin/*` files in the tarball.

Released as **3.1.0**.

## Follow-up

Publish `@kinotic-ai/kinotic-cli@3.1.0`. Consumers on `^3.0.0` (e2e after #294) resolve it automatically — no downstream dep change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx