### PR TITLE
Update Application e2e tests for dash-slugified ids

### DIFF
--- a/kinotic-js/e2e-tests/test/native/Application.test.ts
+++ b/kinotic-js/e2e-tests/test/native/Application.test.ts
@@ -18,7 +18,7 @@ describe('Kinotic JS', () => {
     it('derives the application id from the slugified name', async () => {
         const application = await Kinotic.applications.createApplicationIfNotExist('E2E Slug. Test!', 'Application id derivation')
         try {
-            expect(application.id).toBe('e2e_slug_test')
+            expect(application.id).toBe('e2e-slug-test')
         } finally {
             await Kinotic.applications.deleteById(application.id)
         }
@@ -28,7 +28,7 @@ describe('Kinotic JS', () => {
         const first = await Kinotic.applications.createApplicationIfNotExist('E2E Idempotent App', 'first')
         try {
             // The slug itself and the punctuated name mint the same id
-            const second = await Kinotic.applications.createApplicationIfNotExist('e2e_idempotent_app', 'second')
+            const second = await Kinotic.applications.createApplicationIfNotExist('e2e-idempotent-app', 'second')
             expect(second.id).toBe(first.id)
             expect(second.description).toBe('first')
         } finally {


### PR DESCRIPTION
## What

The e2e pipeline (post-#294) is green except for 2 tests in `test/native/Application.test.ts`, both asserting the **pre-3.1.0 underscore** convention:

```
× derives the application id from the slugified name
  → expected 'e2e-slug-test' to be 'e2e_slug_test'
× returns the existing application when the slugified name matches
  → Invalid zone label 'e2e_idempotent_app'. Labels must be lowercase letters, digits, and interior dashes
```

## Why

3.1.0 slugifies application ids with **dashes** (`Slugify.builder().build()`), and the zone-label grammar rejects underscores.

- Test 1 still expected `e2e_slug_test`; `'E2E Slug. Test!'` now mints `e2e-slug-test`.
- Test 2 passed the literal `'e2e_idempotent_app'` as the second name. `com.github.slugify` keeps literal underscores, so that value survives as `e2e_idempotent_app` and throws in `validateLabel` before the idempotency check runs.

## Fix

```diff
- expect(application.id).toBe('e2e_slug_test')
+ expect(application.id).toBe('e2e-slug-test')

- const second = await Kinotic.applications.createApplicationIfNotExist('e2e_idempotent_app', 'second')
+ const second = await Kinotic.applications.createApplicationIfNotExist('e2e-idempotent-app', 'second')
```

The idempotency intent is preserved: `'E2E Idempotent App'` and the dashed slug `'e2e-idempotent-app'` both mint `e2e-idempotent-app`, so the second call returns the existing app (`description === 'first'`).

## Testing

Integration tests against the docker-compose 3.1.0 server — can't run in the sandbox (no Docker). The change matches the id the server actually returned in the failing run (`e2e-slug-test`); CI on develop verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx)_