### PR TITLE
Add multi-environment architecture implementation plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,8 @@ Never remove or alter an existing authorship comment — `Created by <name> on <
 ## Properties
 Properties should never be created for something that will not need to be configured differently in different environments. i.e. Kinotic Cloud dev vs Kinotic Cloud prod. In the case of a route or something that will be the same for multiple environments, create a constant.
 
+Never gate a bean on a Spring profile — `@Profile` is for test contexts only; profile-gated beans are hard to audit. Profiles are property bundles: an `application-<name>.yml` selects property values for a deployment shape. Enabling or disabling behavior is done with explicit `kinotic.*` properties read by `@ConditionalOnProperty` (the `kinotic.disable*` module flags are the established idiom), so what a deployment runs can be read from its YAML alone.
+
 ## Dependency Versions
 
 Never hardcode a dependency version in a module `build.gradle`. Every version lives as a `*Version` property in `gradle.properties` (kept alphabetical) and is pinned once in the `dependencyManagement` block of `buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle`. The module declares the artifact with no version, so the managed version applies.

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -91,6 +91,13 @@ override):
   little gain given the fixed, Kinotic-operated environment set.)
 - **kinotic-server stops serving the entity data plane.** `kinotic-frontend` browses entity data
   (data views) against the *selected environment's* gateway URL.
+- **Definition management is OS management code, not persistence code** (owner decision): the
+  `EntityDefinition`/`NamedQueriesDefinition` models and their repositories move to
+  **kinotic-domain** (with the other OS domain objects), the `@Publish` management services move
+  to **kinotic-os-api** (with `ApplicationService`/`ProjectService`), and kinotic-persistence
+  publishes **only** the `app-api` data-access services. The JS packages already have this shape
+  — `IEntityDefinitionService` lives in `@kinotic-ai/os-api` — so the move aligns the server
+  modules with it, at the cost of a CRI namespace change (Phase 3).
 - **Entity data is served over the STOMP/RPC path only** (`JsonEntitiesRepository` in `app-api`).
   The GraphQL/OpenAPI/MCP HTTP surfaces are dropped from scope: the code under
   `kinotic-persistence/.../internal/endpoints/` is deliberately dormant (nothing calls
@@ -286,33 +293,49 @@ public EntityServiceCache(@Qualifier(ENTITY_DATA_CRUD_SERVICE_TEMPLATE) CrudServ
    entity-data beans are defined as **aliases of the OS pair** (identical behavior); Phase 4
    replaces the alias with construction from `kinotic.applicationGateway.elastic-*` properties.
 4. `EntityDefinitionRepository` / `NamedQueriesDefinitionRepository` are **metadata**, not entity
-   data — they stay on the OS (`@Primary`) template.
+   data — they stay on the OS (`@Primary`) template (and move to kinotic-domain in Phase 3).
 
 Verify with a full `:kinotic-server:test` run; this phase must be invisible at runtime.
 
-## Phase 3 — split kinotic-persistence wiring into definition-management vs data-plane
+## Phase 3 — move definition management out of kinotic-persistence
 
-Both roles need `kinotic-persistence` (the gateway role needs `EntityDefinition`, converters,
-`EntityService`; the OS role needs definition CRUD). Today one library config wires everything
-behind `kinotic.disablePersistence`. Split the Spring wiring, keep one Gradle module:
+Definitions are OS domain objects; they move to the modules that own OS management. After this
+phase, **kinotic-persistence is the data plane only and publishes only `app-api` data-access
+services**. The dependency direction supports the move without cycles (persistence → os-api →
+domain → core):
 
-- **Definition-management half** — definition/named-query management services
-  (`DefaultEntityDefinitionService`, `NamedQueries*`, their `@Publish` registrations in `os-api`).
-- **Data-plane half** — `EntityServiceCache`, `DefaultEntityService` wiring,
-  `JsonEntitiesRepository`/`AdminJsonEntitiesRepository` (`app-api` zone),
-  `PersistenceInitializer`. The dormant GraphQL/OpenAPI endpoint code stays outside both halves —
-  unwired, kept for reference.
+- **To kinotic-domain** (with the other OS domain models/repos):
+  - `EntityDefinition`, `NamedQueriesDefinition` models — plus whichever supporting model types
+    they reference (`MultiTenancyType`, decorators, …); enumerate by following the imports, don't
+    guess. kinotic-domain gains a **kinotic-idl dependency** (the `schema` field is
+    `ObjectC3Type`) — it has `elasticsearch-java` already.
+  - `EntityDefinitionRepository`, `NamedQueriesDefinitionRepository` (they already extend
+    domain's `AbstractProjectScopedRepository`; today they just live in the wrong module).
+  - The **Elastic mapping conversion** (`EntityDefinitionConversionService.convertToElasticMapping`
+    + `internal/converters/elastic` + `common`) — needed by the Phase 5 mapping-sync service,
+    which also lands in kinotic-domain (next to the ES client config it uses). Split it out of
+    `EntityDefinitionConversionService`, whose GraphQL/OpenAPI conversion parts stay behind in
+    kinotic-persistence with the dormant endpoint code they serve.
+- **To kinotic-os-api** (with `ApplicationService`/`ProjectService`):
+  - `EntityDefinitionService`, `NamedQueriesDefinitionService`, `MigrationService` interfaces +
+    `Default*` impls (`@Publish`, `os-api` zone — os-api's `package-info.java` already declares
+    it). **Publishing an EntityDefinition no longer creates indices here** —
+    `validateAndCreate` keeps computing/persisting `itemIndex` but the
+    `createIndex`/`createIndexTemplate`/`createDataStream` calls move into the Phase 5
+    mapping-sync service. Deletion likewise.
+- **Stays in kinotic-persistence**: `EntityServiceCache`, `DefaultEntityService`,
+  `JsonEntitiesRepository`/`AdminJsonEntitiesRepository`/`NamedQueriesService` (`app-api`),
+  `PersistenceInitializer`, and the dormant GraphQL/OpenAPI/insights reference code. The
+  existing `kinotic.disablePersistence` gate now means exactly "the data plane" — **no new
+  flags needed**.
 
-Gate each half with the module-gate idiom already in the codebase:
-`kinotic.disableEntityDefinitionManagement` / `kinotic.disableEntityDataPlane`
-(`@ConditionalOnProperty`, same shape as `KinoticPersistenceLibrary`'s gate, nested under it).
-In this phase both default ON — **no behavior change**; the role mechanism (Phase 4) takes over
-setting them. Important nuance: **publishing an EntityDefinition no longer creates indices** on
-the definition-management side — `DefaultEntityDefinitionService.validateAndCreate` keeps
-computing/persisting `itemIndex` but the `createIndex`/`createIndexTemplate`/`createDataStream`
-calls move into the Phase 5 mapping-sync service, which applies them per target environment.
-Deletion likewise: deleting/withdrawing a definition takes effect in an env cluster through the
-same sync path.
+**Wire-contract change**: the management services' CRI namespace changes
+(`org.kinotic.persistence.api.services` → `org.kinotic.os.api.services`). Update the proxy
+targets in `@kinotic-ai/os-api` in the same change — e.g. `IEntityDefinitionService.ts:71`
+currently binds `` `${OS_API_ZONE}.org.kinotic.persistence.api.services.EntityDefinitionService` ``
+(the JS *package* layout already matches the target module layout; only the CRI strings move).
+Server and JS ship together at this phase boundary. Preserve authorship comments verbatim on
+every moved file.
 
 ## Phase 4 — the `APPLICATION_GATEWAY` role (single binary, Spring profiles)
 
@@ -334,10 +357,9 @@ and lose to nothing):
 
 | derived value | `OS_SERVER` | `APPLICATION_GATEWAY` |
 |---|---|---|
-| `kinotic.disableOsApi` | false | **true** |
+| `kinotic.disableOsApi` (includes definition management after Phase 3) | false | **true** |
 | `kinotic.disableGithub` | false | **true** |
-| `kinotic.disableEntityDefinitionManagement` (Phase 3) | false | **true** |
-| `kinotic.disableEntityDataPlane` (Phase 3) | false *(flips to true at the Phase 8 cutover — a one-line code change in this mapping)* | false |
+| `kinotic.disablePersistence` (= the data plane after Phase 3) | false *(flips to true at the Phase 8 cutover — a one-line code change in this mapping)* | false |
 | publishable-zone allowlist | `os-api`, `system` (+ `app-api` until the Phase 8 cutover) | `app-api`, `app` |
 
 ```yaml
@@ -356,8 +378,8 @@ kinotic:
 `ApplicationGatewayProperties` (`environmentId`, env-cluster `elasticConnections`/credentials)
 binds under `kinotic.applicationGateway` and lives in kinotic-core next to `KinoticProperties`
 (both kinotic-domain — JWT env claim — and kinotic-persistence — entity-data clients — need it,
-and both depend on core). The OS-cluster connection keeps using `kinotic.domain.elastic-*`. The
-data-plane half (Phase 3) now constructs the `entityDataElasticClient`/
+and both depend on core). The OS-cluster connection keeps using `kinotic.domain.elastic-*`.
+kinotic-persistence (data-plane-only after Phase 3) now constructs the `entityDataElasticClient`/
 `entityDataCrudServiceTemplate` beans from `kinotic.applicationGateway.elastic-*` — one code
 path, replacing Phase 2's alias; the base `application.yml` defaults those connections to
 `localhost:9200` so single-ES local dev keeps working without extra config.
@@ -400,9 +422,8 @@ Work items in this phase:
 
    | Service | Zone | In a gateway process? |
    |---|---|---|
-   | `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, `NamedQueriesService` (persistence) | `app-api` (explicit `@Zone`) | yes — the data plane |
-   | `EntityDefinitionService`, `NamedQueriesDefinitionService`, `MigrationService` (persistence) | `os-api` (package-level `@Zone` in `api/services/package-info.java`) | no — `disableEntityDefinitionManagement` (role-derived) |
-   | `ApplicationService`, `ProjectService`, `MemberService`, `LogService`/`LogManager`, `DeviceApprovalService`, `InviteEmailTemplateService`, `KinoticClusterInfoService`, `EnvironmentService` (Phase 1), `PromotionService` (Phase 9) — all os-api | `os-api` | no — `disableOsApi` (role-derived) gates the whole `KinoticOsApiLibrary` |
+   | `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, `NamedQueriesService` (persistence — its entire published surface after Phase 3) | `app-api` (explicit `@Zone`) | yes — the data plane |
+   | `ApplicationService`, `ProjectService`, `MemberService`, `LogService`/`LogManager`, `DeviceApprovalService`, `InviteEmailTemplateService`, `KinoticClusterInfoService`, `EntityDefinitionService`/`NamedQueriesDefinitionService`/`MigrationService` (moved in Phase 3), `EnvironmentService` (Phase 1), `PromotionService` (Phase 9) — all os-api | `os-api` | no — `disableOsApi` (role-derived) gates the whole `KinoticOsApiLibrary` |
    | `GitHubAppInstallationService`, `GitHubWebhookEventService`, `GitHubProjectRepoService` (github) | `os-api` | no — `disableGithub` (role-derived) |
    | `WorkloadOrchestrationService`, `VmNodeOrchestrationService` (orchestrator, once Phase 6 wires it in) | `system` (`@Zone` in `api/workload/package-info.java`) | no — verify the orchestrator library has (or add) the same `disable*` gate, driven by the role |
    | `DataInsightsService` | `os-api` (`insights/package-info.java`) | published nowhere — dropped from scope (see design decisions) |
@@ -452,10 +473,13 @@ versions is open question 8 — resolve it with Navid before implementing this p
   built with the Phase 2 factory method) exposes one admin client per environment. Gated to the
   `OS_SERVER` role. A publish/promotion targeting an environment with no configured cluster
   fails fast with a clear message.
-- **Mapping sync service (OS role).** The index/template/create/update logic Phase 3 lifted out
-  of `DefaultEntityDefinitionService` (mappings via `entityDefinitionConversionService`,
-  data-stream vs index decision by `isStream()`) becomes a service invoked with a *target
-  environment's* template: apply a deployment record's definitions to that env cluster —
+- **Mapping sync service (OS role, kinotic-domain internal).** The index/template/create/update
+  logic Phase 3 lifted out of `DefaultEntityDefinitionService` (mappings via the Elastic
+  conversion moved to kinotic-domain, data-stream vs index decision by `isStream()`) becomes a
+  domain-internal service — next to `EnvironmentClusterClients` and the repositories it reads —
+  invoked with a *target environment's* template by its two callers, `DefaultEntityDefinitionService`
+  (os-api, dev auto-sync) and the promotion job (Phase 9): apply a deployment record's
+  definitions to that env cluster —
   create missing indices/templates, update mappings, remove indices for withdrawn definitions.
   Idempotent (ES create-index races return `resource_already_exists_exception` — treat as
   success); errors surface synchronously to the caller (publish flow or promotion job), which
@@ -534,7 +558,7 @@ One image (`kinoticai/kinotic-server`) everywhere; the role/profile decides what
   kinotic namespace (OS admin user, index-management-only ES role); OS ES reachable from kinotic
   + gateway namespaces. Provision the two distinct ES users per env cluster (Phase 5 least
   privilege) in the ECK/compose setups.
-- **Cutover**: flip the `OS_SERVER` role mapping to `disableEntityDataPlane=true` and drop
+- **Cutover**: flip the `OS_SERVER` role mapping to `disablePersistence=true` and drop
   `app-api` from its zone allowlist (the one-line code changes flagged in Phase 4), once the
   frontend (Phase 7) talks to gateways for entity data. From here the OS bus carries no entity
   data plane.

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -107,19 +107,23 @@ override):
   stereotypes) so `DataInsightsService` is published nowhere; keep the classes. Its internals
   are already mostly commented out pending Spring AI 2 (`DataInsightsConfiguration`'s
   `ChatClient` bean is disabled), so this completes an unwiring that is half-done today.
-- **Single binary, two roles** (owner decision). Every library module already has a whole-module
-  gate (`kinotic.disableOsApi`, `disableGithub`, `disablePersistence`, `disableApiGateway`,
-  `disableDomain` — see current state), so role composition is the established idiom. A required
-  `kinotic.role` enum (`OS_SERVER` | `APPLICATION_GATEWAY`, **no default — missing role fails
-  startup**) derives the disable flags and the publishable-zone allowlist *in code*, so the two
-  deployment shapes are two tested configurations, not a hand-maintained flag matrix, and the
-  fail-open `matchIfMissing = true` defaults on the existing gates can never silently enable an
-  OS module on a gateway. Accepted trade-offs of one image: the gateway jar carries the OS admin
-  SPA and OS module bytecode (never instantiated); image size is not optimized per role.
+- **Single binary, two roles, explicit profiles** (owner decision). Every library module already
+  has a whole-module gate (`kinotic.disableOsApi`, `disableGithub`, `disablePersistence`,
+  `disableApiGateway`, `disableDomain` — see current state), so role composition is the
+  established idiom. Two profiles in `kinotic-server/src/main/resources` —
+  `application-os-server.yml` and `application-app-gateway.yml` — each set `kinotic.role` plus
+  the disable flags **explicitly in YAML** (no derivation mechanism, no hidden property
+  sources). `kinotic.role` is a required (`@NotNull`) enum — a roleless boot fails validation —
+  consumed at runtime by the publishable-zone allowlist (a field on the enum constants), role
+  conditions on beans, and the JWT env claim. The **allowlist startup guard is what makes this
+  safe**: any drift — a forgotten flag on a new module, a stray env var override — that lets an
+  `os-api`/`system` service register in a gateway kills the process at boot. Accepted
+  trade-offs of one image: the gateway jar carries the OS admin SPA and OS module bytecode
+  (never instantiated); image size is not optimized per role.
 - **No OS service *bean* exists in a gateway process — absence, not just authorization.**
   Service publication is bean-driven (`ServiceRegistrationBeanPostProcessor` registers every
   Spring bean implementing a `@Publish` interface), so a bean the role gates keep out of the
-  context cannot be invoked no matter what the authorizer does. The role-derived gates + the
+  context cannot be invoked no matter what the authorizer does. The per-role profile gates + the
   Phase 3 split achieve this (see Phase 4 for the inventory and the startup allowlist that makes
   it a hard invariant instead of an emergent property), and the guards that don't depend on the
   process at all remain underneath: separate env bus (no `os-api` listener to reach), the
@@ -349,49 +353,47 @@ Spring profile in `kinotic-server/src/main/resources`.
 public enum KinoticRole { OS_SERVER, APPLICATION_GATEWAY }
 ```
 
-`kinotic.role` has **no default** — a process without a role fails startup with a clear message.
-The role→flags mapping lives *in code*. Mechanism: the disable flags are consumed by
-`@ConditionalOnProperty` on the library classes, which evaluates against the Spring `Environment`
-during context refresh — so the role must be translated into `Environment` properties *before*
-refresh. That is exactly what an `EnvironmentPostProcessor` is for (registered in
-`META-INF/spring.factories`; verify the registration and ordering against Spring Boot 4
-specifically — the repo is on Boot 4.0.7):
+`kinotic.role` has **no default** — declare it `@NotNull` on `KinoticProperties` so a roleless
+boot fails property validation with a clear message (the codebase already validates properties
+this way; verify `KinoticProperties` participates in validation the same way `DomainProperties`
+does). **No flag derivation, no `EnvironmentPostProcessor`** (owner decision — explicit YAML
+over hidden property sources): each role is a Spring profile in
+`kinotic-server/src/main/resources` that sets the role *and* the disable flags visibly, per the
+table below.
 
-```java
-// kinotic-core/.../internal/config/KinoticRoleEnvironmentPostProcessor.java  (target shape)
-public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
-    String raw = environment.getProperty("kinotic.role");
-    if (raw == null) throw new IllegalStateException(
-        "kinotic.role is required: one of " + Arrays.toString(KinoticRole.values()));
-    KinoticRole role = KinoticRole.valueOf(raw.trim().toUpperCase());   // unknown value → hard failure
+The role property's runtime consumers:
+- **Publishable-zone allowlist** — a `Set<String>` field on each `KinoticRole` constant, read by
+  `ServiceRegistrationBeanPostProcessor` at registration time (`"app"` matching the leading
+  label of `app.<org>.<app>` zones). Never a property; nothing evaluates it via the
+  `Environment`.
+- **Zone policy + route gating** — plain
+  `@ConditionalOnProperty(name = "kinotic.role", havingValue = "...")` on the policy beans and
+  role-specific `SuppliesGatewayRoutes` beans; conditions can check the role directly, no
+  derived flags needed.
+- **JWT environment claim** behavior (item 3 below).
 
-    Map<String, Object> derived = switch (role) { /* the table below */ };
-    // addFirst = highest precedence: profile YAML or a stray env var can never override the role,
-    // and the fail-open matchIfMissing defaults never engage because every flag is set explicitly
-    environment.getPropertySources().addFirst(new MapPropertySource("kinoticRoleDerived", derived));
-}
-```
+Accepted trade, stated plainly: profile YAML can drift — a *new* module gate added later and
+forgotten in a profile is silently ON (`matchIfMissing = true`). The allowlist guard and the
+gateway-role boot test exist precisely to convert that drift into a **startup failure** (the
+new module's `os-api`/`system` services register → allowlist violation → the process dies
+loudly). The same guard neutralizes a stray `KINOTIC_DISABLE*` env var overriding profile YAML.
 
-It runs after the `application-*.yml` files load (so it can read `kinotic.role` from the
-profile) but before any condition evaluates — the existing library gates need zero changes. The
-**zone allowlist never becomes a property at all**: it is consumed at runtime by
-`ServiceRegistrationBeanPostProcessor`, which asks the enum directly
-(`KinoticRole.getPublishableZones()`, a `Set<String>` field on each constant — `"app"` matching
-the leading label of `app.<org>.<app>` zones). Only the disable flags pass through the
-`Environment`, because only `@ConditionalOnProperty` needs them there.
-
-| derived value | `OS_SERVER` | `APPLICATION_GATEWAY` |
+| profile sets | `application-os-server.yml` | `application-app-gateway.yml` |
 |---|---|---|
+| `kinotic.role` | `OS_SERVER` | `APPLICATION_GATEWAY` |
 | `kinotic.disableOsApi` (includes definition management after Phase 3) | false | **true** |
 | `kinotic.disableGithub` | false | **true** |
-| `kinotic.disablePersistence` (= the data plane after Phase 3) | false *(flips to true at the Phase 8 cutover — a one-line code change in this mapping)* | false |
-| publishable-zone allowlist | `os-api`, `system` (+ `app-api` until the Phase 8 cutover) | `app-api`, `app` |
+| `kinotic.disablePersistence` (= the data plane after Phase 3) | false *(flips to true at the Phase 8 cutover)* | false |
+| publishable-zone allowlist *(in code, on the enum — not YAML)* | `os-api`, `system` (+ `app-api` until the Phase 8 cutover) | `app-api`, `app` |
 
 ```yaml
-# kinotic-server/src/main/resources/application-app-gateway.yml  (new profile — sets ONE role value
-# plus per-deployment data; it never hand-sets disable flags)
+# kinotic-server/src/main/resources/application-app-gateway.yml  (new profile — role, flags, and
+# per-deployment data, all visible in one place)
 kinotic:
   role: APPLICATION_GATEWAY
+  disableOsApi: true
+  disableGithub: true
+  disablePersistence: false
   applicationGateway:
     environmentId: ${KINOTIC_ENVIRONMENT_ID}
     elastic-connections:
@@ -399,6 +401,9 @@ kinotic:
         port: 9200
         scheme: http
 ```
+
+`application-os-server.yml` mirrors it with the `OS_SERVER` values; existing deployments add the
+new profile to their active set (e.g. `production,os-server`).
 
 `ApplicationGatewayProperties` (`environmentId`, env-cluster `elasticConnections`/credentials)
 binds under `kinotic.applicationGateway` and lives in kinotic-core next to `KinoticProperties`
@@ -420,7 +425,7 @@ Work items in this phase:
    `StompAuthorizerFactory` is constructed and pick the smallest seam.
 2. **Auth surface per role.** `SuppliesGatewayRoutes` beans are mounted by discovery
    (`ApiGatewayVertcleFactory` iterates all beans), so the REST surface follows which route
-   beans exist in the context. GitHub routes disappear via the role-derived `disableGithub`.
+   beans exist in the context. GitHub routes disappear via the profile's `disableGithub`.
    The kinotic-domain handlers need role gates: gateway role mounts app-scope routes only
    (`ApplicationLoginHandler`, `SessionEndpointHandler`, invite acceptance if app-scoped); org
    login, signup, and CLI device-login handlers are OS_SERVER-only. Verify which module
@@ -438,7 +443,7 @@ Work items in this phase:
    `KinoticIgniteConfigCaches`) — anything OS-specific should not be created on env clusters.
 5. **No entity HTTP surface.** The GraphQL/OpenAPI/MCP code stays dormant (see design
    decisions) — the gateway role's only entity-data surface is the `app-api` RPC path.
-6. **No SPA in the gateway role.** The role mapping (or profile) sets the web-server verticle
+6. **No SPA in the gateway role.** The app-gateway profile sets the web-server verticle
    disabled (`WebServerProperties`); the SPA files remain in the jar — accepted single-image
    trade-off — but are never served.
 7. **No OS services published — verified inventory + startup guard.** Everything is on the
@@ -448,15 +453,15 @@ Work items in this phase:
    | Service | Zone | In a gateway process? |
    |---|---|---|
    | `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, `NamedQueriesService` (persistence — its entire published surface after Phase 3) | `app-api` (explicit `@Zone`) | yes — the data plane |
-   | `ApplicationService`, `ProjectService`, `MemberService`, `LogService`/`LogManager`, `DeviceApprovalService`, `InviteEmailTemplateService`, `KinoticClusterInfoService`, `EntityDefinitionService`/`NamedQueriesDefinitionService`/`MigrationService` (moved in Phase 3), `EnvironmentService` (Phase 1), `PromotionService` (Phase 9) — all os-api | `os-api` | no — `disableOsApi` (role-derived) gates the whole `KinoticOsApiLibrary` |
-   | `GitHubAppInstallationService`, `GitHubWebhookEventService`, `GitHubProjectRepoService` (github) | `os-api` | no — `disableGithub` (role-derived) |
+   | `ApplicationService`, `ProjectService`, `MemberService`, `LogService`/`LogManager`, `DeviceApprovalService`, `InviteEmailTemplateService`, `KinoticClusterInfoService`, `EntityDefinitionService`/`NamedQueriesDefinitionService`/`MigrationService` (moved in Phase 3), `EnvironmentService` (Phase 1), `PromotionService` (Phase 9) — all os-api | `os-api` | no — `disableOsApi` (app-gateway profile) gates the whole `KinoticOsApiLibrary` |
+   | `GitHubAppInstallationService`, `GitHubWebhookEventService`, `GitHubProjectRepoService` (github) | `os-api` | no — `disableGithub` (app-gateway profile) |
    | `WorkloadOrchestrationService`, `VmNodeOrchestrationService` (orchestrator, once Phase 6 wires it in) | `system` (`@Zone` in `api/workload/package-info.java`) | no — verify the orchestrator library has (or add) the same `disable*` gate, driven by the role |
    | `DataInsightsService` | `os-api` (`insights/package-info.java`) | published nowhere — dropped from scope (see design decisions) |
 
    `kinotic-domain` publishes **nothing** (`LocalAuthenticationService` is deliberately not
    `@Publish` — raw passwords never travel over RPC). The **publishable-zone allowlist** turns
    this table from configuration into an invariant: `ServiceRegistrationBeanPostProcessor`
-   (kinotic-core) checks every registration's single `@Zone` against the role-derived allowlist
+   (kinotic-core) checks every registration's single `@Zone` against the role's allowlist (a field on the `KinoticRole` enum)
    and **fails startup** on a violation — a future module gate that's forgotten, renamed, or
    fail-opens can never silently publish an OS service in a gateway process. A service with
    **no** `@Zone` registers at an un-zoned address (per the `Zone` javadoc): treat un-zoned
@@ -540,8 +545,8 @@ versions is open question 8 — resolve it with Navid before implementing this p
   currently depended on by nothing, so orchestration RPCs are dead weight until this lands.
   Confirm with Navid this is intended before doing it. Since the binary is shared, this also
   puts the orchestrator on every gateway process's classpath: give the orchestrator library the
-  same `kinotic.disable*` gate as the other modules (if it lacks one) and add it to the role
-  mapping (`APPLICATION_GATEWAY` → disabled) **in the same commit** — the zone-allowlist guard
+  same `kinotic.disable*` gate as the other modules (if it lacks one) and set it in
+  `application-app-gateway.yml` (disabled) **in the same commit** — the zone-allowlist guard
   will fail gateway startup if this is forgotten, which is the guard working as intended.
 - Workload provisioning must inject the environment's gateway connection info (host/port of
   `Environment.gatewayUrl` or an internal equivalent) into the VM's env vars so the customer
@@ -583,10 +588,10 @@ One image (`kinoticai/kinotic-server`) everywhere; the role/profile decides what
   kinotic namespace (OS admin user, index-management-only ES role); OS ES reachable from kinotic
   + gateway namespaces. Provision the two distinct ES users per env cluster (Phase 5 least
   privilege) in the ECK/compose setups.
-- **Cutover**: flip the `OS_SERVER` role mapping to `disablePersistence=true` and drop
-  `app-api` from its zone allowlist (the one-line code changes flagged in Phase 4), once the
-  frontend (Phase 7) talks to gateways for entity data. From here the OS bus carries no entity
-  data plane.
+- **Cutover**: set `disablePersistence: true` in `application-os-server.yml` and drop `app-api`
+  from `OS_SERVER`'s allowlist on the `KinoticRole` enum (flagged in Phase 4), once the frontend
+  (Phase 7) talks to gateways for entity data. From here the OS bus carries no entity data
+  plane.
 - **Local dev without containers**: document running the same app twice from the IDE —
   `KinoticServerApplication` with the default (OS) profile and again with `app-gateway` — against
   one local ES playing both roles (both connection property sets default to `localhost:9200`).

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -17,27 +17,32 @@ applications:
 1. **One "OS" Elasticsearch cluster** holds every domain object the Kinotic OS manages
    (organizations, applications, projects, IAM, entity *definitions*, workloads, …).
 2. **One Elasticsearch cluster per environment** holds customer entity *data* only.
-3. **One `kinotic-application-gateway` deployable per environment** (new Gradle module, an
-   application module like `kinotic-server`). It is the edge for customer applications: UI ↔
-   backend-microservice RPC, and entity-data reads/writes for that environment.
-4. **One `kinotic-server` cluster** remains the single edge for `kinotic-frontend` — all OS
-   configuration (orgs, apps, projects, members, entity definitions, environments) goes there.
+3. **One application-gateway deployment per environment** — the *same* `kinotic-server` binary
+   running with `kinotic.role: APPLICATION_GATEWAY` (a Spring profile per role; **no new Gradle
+   module**). It is the edge for customer applications: UI ↔ backend-microservice RPC, and
+   entity-data reads/writes for that environment.
+4. **One `kinotic-server` cluster in the `OS_SERVER` role** remains the single edge for
+   `kinotic-frontend` — all OS configuration (orgs, apps, projects, members, entity definitions,
+   environments) goes there.
 
 ## Target topology
 
 ```
                         ┌────────────────────────────────────────────┐
- kinotic-frontend ────► │ kinotic-server cluster (Ignite cluster "os")│──► OS ES cluster
- kinotic-cli      ────► │  os_api / system zones, OIDC login, GitHub, │    (kinotic_* domain
- VmManagers (STOMP)───► │  orchestrator, entity-definition mgmt      │     indices)
+ kinotic-frontend ────► │ kinotic-server, role OS_SERVER              │──► OS ES cluster
+ kinotic-cli      ────► │ (Ignite cluster "os"): os_api/system zones, │    (kinotic_* domain
+ VmManagers (STOMP)───► │ OIDC login, GitHub, orchestrator,           │     indices)
+                        │ entity-definition mgmt                      │
                         └────────────────────────────────────────────┘
                                                                    ▲ read/write OS metadata
  customer UI  ─────────► ┌──────────────────────────────────────────┴─┐
- customer microservices─►│ kinotic-application-gateway (per env,      │──► env ES cluster
- (STOMP, per env)        │ Ignite cluster "env-<id>"): app login,     │    (entity data only)
-                         │ app.<org>.<app> + app_api zones, entity    │
-                         │ data plane (RPC over STOMP only)           │
+ customer microservices─►│ kinotic-server, role APPLICATION_GATEWAY   │──► env ES cluster
+ (STOMP, per env)        │ (per env, Ignite cluster "env-<id>"):      │    (entity data only)
+                         │ app login, app.<org>.<app> + app_api       │
+                         │ zones, entity data plane (RPC over STOMP)  │
                          └────────────────────────────────────────────┘
+
+One container image; the role decides what a process is.
 ```
 
 Design decisions baked into this plan (each has an "open questions" entry if Navid may want to
@@ -76,12 +81,24 @@ override):
   stereotypes) so `DataInsightsService` is published nowhere; keep the classes. Its internals
   are already mostly commented out pending Spring AI 2 (`DataInsightsConfiguration`'s
   `ChatClient` bean is disabled), so this completes an unwiring that is half-done today.
-- **No OS service exists on the gateway — absence, not just authorization.** Service publication
-  is bean-driven (`ServiceRegistrationBeanPostProcessor` registers every Spring bean implementing
-  a `@Publish` interface), so a service that is not on the gateway's classpath/context cannot be
-  invoked there no matter what the authorizer does. The gateway's dependency set + the Phase 3
-  split already achieve this (see Phase 4 item 5 for the inventory and the startup guard that
-  makes it a hard invariant instead of an emergent property).
+- **Single binary, two roles** (owner decision). Every library module already has a whole-module
+  gate (`kinotic.disableOsApi`, `disableGithub`, `disablePersistence`, `disableApiGateway`,
+  `disableDomain` — see current state), so role composition is the established idiom. A required
+  `kinotic.role` enum (`OS_SERVER` | `APPLICATION_GATEWAY`, **no default — missing role fails
+  startup**) derives the disable flags and the publishable-zone allowlist *in code*, so the two
+  deployment shapes are two tested configurations, not a hand-maintained flag matrix, and the
+  fail-open `matchIfMissing = true` defaults on the existing gates can never silently enable an
+  OS module on a gateway. Accepted trade-offs of one image: the gateway jar carries the OS admin
+  SPA and OS module bytecode (never instantiated); image size is not optimized per role.
+- **No OS service *bean* exists in a gateway process — absence, not just authorization.**
+  Service publication is bean-driven (`ServiceRegistrationBeanPostProcessor` registers every
+  Spring bean implementing a `@Publish` interface), so a bean the role gates keep out of the
+  context cannot be invoked no matter what the authorizer does. The role-derived gates + the
+  Phase 3 split achieve this (see Phase 4 for the inventory and the startup allowlist that makes
+  it a hard invariant instead of an emergent property), and the guards that don't depend on the
+  process at all remain underneath: separate env bus (no `os_api` listener to reach), the
+  `StompAuthorizer` policy, and OS-cluster ES credentials that physically cannot write OS config
+  indices.
 
 ---
 
@@ -145,6 +162,19 @@ reference — do not wire it up, and do not delete it.
 **Module graph:** `kinotic-server` (only `java-application-conventions` module) depends on core,
 domain, os-api, persistence, github, api-gateway. `kinotic-orchestrator` is an **orphan** — no
 module depends on it, so `WorkloadOrchestrationService` is not currently wired into any deployable.
+
+**Module gates:** every library module is wholly gated by a `kinotic.disable*` property on its
+`@Import`ed library class — the seams role composition builds on. Note the fail-open default
+(`matchIfMissing = true`: a *missing* flag means *enabled*), which is why the role mechanism
+(Phase 4) must set these explicitly rather than relying on profile YAML remembering to:
+
+```java
+// kinotic-os-api/src/main/java/org/kinotic/os/KinoticOsApiLibrary.java:14
+@ConditionalOnProperty(value = "kinotic.disableOsApi", havingValue = "false", matchIfMissing = true)
+// same idiom: kinotic.disableGithub (KinoticGithubLibrary), disablePersistence
+// (KinoticPersistenceLibrary), disableApiGateway (KinoticApiGatewayLibrary),
+// disableDomain (KinoticDomainLibrary), disableClustering (KinoticProperties)
+```
 
 **Deployment:** one ECK ES cluster (`deployment/helm/eck-stack`), one kinotic-server chart
 (`deployment/helm/kinotic`), env vars `KINOTIC_DOMAIN_ELASTICCONNECTIONS_*`. Compose:
@@ -227,10 +257,9 @@ public EntityServiceCache(@Qualifier(ENTITY_DATA_CRUD_SERVICE_TEMPLATE) CrudServ
 ```
 
    Same treatment for `DefaultEntityService` construction, `DefaultEntityDefinitionService`'s
-   index-lifecycle calls, and `PersistenceInitializer`'s health checks. The entity-data beans are
-   **supplied by the deployable**, not by kinotic-persistence: kinotic-server defines them as
-   aliases of the OS beans (identical behavior today); the gateway builds them from its own
-   connection properties (Phase 4).
+   index-lifecycle calls, and `PersistenceInitializer`'s health checks. In this phase the
+   entity-data beans are defined as **aliases of the OS pair** (identical behavior); Phase 4
+   replaces the alias with construction from `kinotic.applicationGateway.elastic-*` properties.
 4. `EntityDefinitionRepository` / `NamedQueriesDefinitionRepository` are **metadata**, not entity
    data — they stay on the OS (`@Primary`) template.
 
@@ -238,120 +267,130 @@ Verify with a full `:kinotic-server:test` run; this phase must be invisible at r
 
 ## Phase 3 — split kinotic-persistence wiring into definition-management vs data-plane
 
-Both future deployables depend on `kinotic-persistence` (the gateway needs `EntityDefinition`,
-converters, `EntityService`; the server needs definition CRUD). Today one auto-config wires
-everything. Split the Spring wiring, keep one Gradle module:
+Both roles need `kinotic-persistence` (the gateway role needs `EntityDefinition`, converters,
+`EntityService`; the OS role needs definition CRUD). Today one library config wires everything
+behind `kinotic.disablePersistence`. Split the Spring wiring, keep one Gradle module:
 
-- `KinoticEntityDefinitionAutoConfiguration` — definition/named-query management services
-  (`DefaultEntityDefinitionService`, `NamedQueries*`, their `@Publish` registrations in `os_api`),
-  used by kinotic-server.
-- `KinoticEntityDataAutoConfiguration` — the data plane: `EntityServiceCache`,
-  `DefaultEntityService` wiring, `JsonEntitiesRepository`/`AdminJsonEntitiesRepository`
-  (`app_api` zone), `PersistenceInitializer`. The dormant GraphQL/OpenAPI endpoint code stays
-  outside both auto-configs — unwired, kept for reference.
+- **Definition-management half** — definition/named-query management services
+  (`DefaultEntityDefinitionService`, `NamedQueries*`, their `@Publish` registrations in `os_api`).
+- **Data-plane half** — `EntityServiceCache`, `DefaultEntityService` wiring,
+  `JsonEntitiesRepository`/`AdminJsonEntitiesRepository` (`app_api` zone),
+  `PersistenceInitializer`. The dormant GraphQL/OpenAPI endpoint code stays outside both halves —
+  unwired, kept for reference.
 
-Gate each with `@ConditionalOnProperty` (e.g. `kinotic.persistence.definition-management.enabled`,
-`kinotic.persistence.data-plane.enabled`) set in each deployable's `application.yml`. These
-properties genuinely differ per deployable, so they pass the "Properties" rule. Important nuance:
-**publishing an EntityDefinition no longer creates indices** on the server side —
-`DefaultEntityDefinitionService.validateAndCreate` keeps computing/persisting `itemIndex` but the
-`createIndex`/`createIndexTemplate`/`createDataStream` calls move behind the data-plane side
-(Phase 5 reconciler). Deletion likewise: the OS side marks/deletes the definition; gateways
-reconcile index removal.
+Gate each half with the module-gate idiom already in the codebase:
+`kinotic.disableEntityDefinitionManagement` / `kinotic.disableEntityDataPlane`
+(`@ConditionalOnProperty`, same shape as `KinoticPersistenceLibrary`'s gate, nested under it).
+In this phase both default ON — **no behavior change**; the role mechanism (Phase 4) takes over
+setting them. Important nuance: **publishing an EntityDefinition no longer creates indices** on
+the definition-management side — `DefaultEntityDefinitionService.validateAndCreate` keeps
+computing/persisting `itemIndex` but the `createIndex`/`createIndexTemplate`/`createDataStream`
+calls move behind the data-plane half (Phase 5 reconciler). Deletion likewise: the OS side
+marks/deletes the definition; gateways reconcile index removal.
 
-kinotic-server after this phase: definition-management ON, data-plane OFF (except in a local-dev
-profile — see Phase 8).
+## Phase 4 — the `APPLICATION_GATEWAY` role (single binary, Spring profiles)
 
-## Phase 4 — new deployable: `kinotic-application-gateway`
+No new Gradle module. The role mechanism lives in kinotic-core; the role's runtime shape is a
+Spring profile in `kinotic-server/src/main/resources`.
 
-New top-level Gradle module (auto-included by root `settings.gradle` — it just needs its own
-`settings.gradle` like the others):
-
-```groovy
-// kinotic-application-gateway/build.gradle
-plugins { id 'org.kinotic.java-application-conventions' }
-dependencies {
-    implementation project(':kinotic-core')
-    implementation project(':kinotic-domain')       // IAM/auth, OS repositories, app login REST
-    implementation project(':kinotic-persistence')  // data plane only (Phase 3 flag)
-    implementation project(':kinotic-api-gateway')  // STOMP engine, router, web-server verticle
-    // deliberately NOT os-api, NOT github, NOT frontend
-}
-```
+**The role mechanism.** A required enum on the `kinotic` prefix:
 
 ```java
-// kinotic-application-gateway/src/main/java/org/kinotic/appgateway/KinoticApplicationGatewayApplication.java
-@SpringBootApplication
-@EnableKinotic
-public class KinoticApplicationGatewayApplication { ... }   // mirror KinoticServerApplication
+// kinotic-core/.../api/config/KinoticRole.java  (new file)
+public enum KinoticRole { OS_SERVER, APPLICATION_GATEWAY }
 ```
 
-Configuration (`api/config/ApplicationGatewayProperties.java`, prefix
-`kinotic.applicationGateway`):
+`kinotic.role` has **no default** — a process without a role fails startup with a clear message.
+The role→flags mapping lives *in code* (an `EnvironmentPostProcessor` or equivalent that sets the
+properties before binding — verify the right Spring Boot 4 hook rather than assuming; the
+requirement is that the derived values win over the fail-open `matchIfMissing = true` defaults
+and lose to nothing):
 
-```java
-private String environmentId;                        // which Environment this deployment serves
-private List<ElasticConnectionInfo> elasticConnections;  // the env's entity-data cluster
-private String elasticUsername; private String elasticPassword;
+| derived value | `OS_SERVER` | `APPLICATION_GATEWAY` |
+|---|---|---|
+| `kinotic.disableOsApi` | false | **true** |
+| `kinotic.disableGithub` | false | **true** |
+| `kinotic.disableEntityDefinitionManagement` (Phase 3) | false | **true** |
+| `kinotic.disableEntityDataPlane` (Phase 3) | false *(flips to true at the Phase 8 cutover — a one-line code change in this mapping)* | false |
+| publishable-zone allowlist | `os_api`, `system` (+ `app_api` until the Phase 8 cutover) | `app_api`, `app` |
+
+```yaml
+# kinotic-server/src/main/resources/application-app-gateway.yml  (new profile — sets ONE role value
+# plus per-deployment data; it never hand-sets disable flags)
+kinotic:
+  role: APPLICATION_GATEWAY
+  applicationGateway:
+    environmentId: ${KINOTIC_ENVIRONMENT_ID}
+    elastic-connections:
+      - host: ${KINOTIC_ENV_ES_HOST}
+        port: 9200
+        scheme: http
 ```
 
-The OS cluster connection reuses the existing `kinotic.domain.elastic-*` properties (that's what
-all the domain repositories bind to). The gateway defines the `entityDataElasticClient` /
-`entityDataCrudServiceTemplate` beans (Phase 2 qualifiers) from `kinotic.applicationGateway.*` —
-where kinotic-server aliases them to the OS beans, the gateway points them at its environment's
-cluster.
+`ApplicationGatewayProperties` (`environmentId`, env-cluster `elasticConnections`/credentials)
+binds under `kinotic.applicationGateway` and lives in kinotic-core next to `KinoticProperties`
+(both kinotic-domain — JWT env claim — and kinotic-persistence — entity-data clients — need it,
+and both depend on core). The OS-cluster connection keeps using `kinotic.domain.elastic-*`. The
+data-plane half (Phase 3) now constructs the `entityDataElasticClient`/
+`entityDataCrudServiceTemplate` beans from `kinotic.applicationGateway.elastic-*` — one code
+path, replacing Phase 2's alias; the base `application.yml` defaults those connections to
+`localhost:9200` so single-ES local dev keeps working without extra config.
 
 Work items in this phase:
 
-1. **Zone policy.** `StompAuthorizerFactory` currently encodes one global policy. The gateway
-   must not expose `os_api`/`system`: application participants keep today's rules
-   (`app_api.**` + `app.<org>.<app>.**`); organization participants (frontend browsing data) get
-   `app_api.**` send only; system participants are for platform tooling. kinotic-server's policy
-   conversely drops `app_api` for application participants (they have no business on the OS bus
-   anymore). Make the authorizer policy a bean the deployable supplies rather than forking the
-   class — check how `StompAuthorizerFactory` is constructed and pick the smallest seam.
-2. **Auth surface.** Mount only the app-scope REST routes (`ApplicationLoginHandler`,
-   `SessionEndpointHandler`, invite acceptance if app-scoped). `SuppliesGatewayRoutes` beans are
-   mounted by discovery (`ApiGatewayVertcleFactory` iterates all beans), so this falls out of
-   which beans exist on the gateway's classpath/context — org login, signup, GitHub, and CLI
-   device-login handlers must not be wired here. Verify which module contributes each
-   `SuppliesGatewayRoutes` bean and gate accordingly.
+1. **Zone policy per role.** `StompAuthorizerFactory` currently encodes one global policy. Make
+   the policy a bean selected by role: `APPLICATION_GATEWAY` — application participants keep
+   today's rules (`app_api.**` + `app.<org>.<app>.**`), organization participants (frontend
+   browsing data) get `app_api.**` send only, no participant reaches `os_api`/`system`;
+   `OS_SERVER` — conversely drops `app_api` for application participants (after the Phase 8
+   cutover; they have no business on the OS bus). Don't fork the class — check how
+   `StompAuthorizerFactory` is constructed and pick the smallest seam.
+2. **Auth surface per role.** `SuppliesGatewayRoutes` beans are mounted by discovery
+   (`ApiGatewayVertcleFactory` iterates all beans), so the REST surface follows which route
+   beans exist in the context. GitHub routes disappear via the role-derived `disableGithub`.
+   The kinotic-domain handlers need role gates: gateway role mounts app-scope routes only
+   (`ApplicationLoginHandler`, `SessionEndpointHandler`, invite acceptance if app-scoped); org
+   login, signup, and CLI device-login handlers are OS_SERVER-only. Verify which module
+   contributes each `SuppliesGatewayRoutes` bean and gate accordingly.
 3. **JWT environment binding.** `KinoticJwtIssuer` (kinotic-domain) mints platform JWTs; signing
-   keys come from `platformSecrets` shared across deployables. Add an `environmentId` claim when
-   the issuer runs inside a gateway, and make the gateway's `KinoticSecurityService` validation
-   path reject tokens whose claim doesn't match its own `environmentId` (a dev token must not
-   work against prod). kinotic-server accepts only tokens without the claim (or ignores — decide
-   during implementation and document in AUTH docs).
-4. **Ignite cluster identity.** The gateway joins Ignite cluster `env-<environmentId>`; verify
-   how `KinoticIgniteConfig` names/discovers the cluster (`kinotic.ignite.*`) and ensure two
-   clusters on one network can't merge. Also audit what the gateway actually uses Ignite for
-   (session store, eventbus, caches in `KinoticIgniteConfigCaches`) — anything OS-specific should
-   not be created on env clusters.
+   keys come from `platformSecrets` shared across deployments. In the gateway role, add an
+   `environmentId` claim at mint and reject tokens whose claim doesn't match this deployment's
+   `environmentId` in the `KinoticSecurityService` validation path (a dev token must not work
+   against prod). The OS role accepts only tokens without the claim (or ignores — decide during
+   implementation and document with the auth docs).
+4. **Ignite cluster identity.** A gateway deployment joins Ignite cluster
+   `env-<environmentId>`; verify how `KinoticIgniteConfig` names/discovers the cluster
+   (`kinotic.ignite.*`) and ensure two clusters on one network can't merge. Also audit what the
+   gateway role actually uses Ignite for (session store, eventbus, caches in
+   `KinoticIgniteConfigCaches`) — anything OS-specific should not be created on env clusters.
 5. **No entity HTTP surface.** The GraphQL/OpenAPI/MCP code stays dormant (see design
-   decisions) — the gateway's only entity-data surface is the `app_api` RPC path.
-6. **No SPA.** `WebServerProperties.enabled=false` by default; the gateway serves no frontend.
-7. **No OS services published — verified inventory + startup guard.** The full `@Publish`
-   inventory on the gateway's classpath (core + domain + persistence + api-gateway) is:
+   decisions) — the gateway role's only entity-data surface is the `app_api` RPC path.
+6. **No SPA in the gateway role.** The role mapping (or profile) sets the web-server verticle
+   disabled (`WebServerProperties`); the SPA files remain in the jar — accepted single-image
+   trade-off — but are never served.
+7. **No OS services published — verified inventory + startup guard.** Everything is on the
+   classpath in a single binary, so what matters is which *beans* the role admits. The full
+   `@Publish` inventory and its fate in the gateway role:
 
-   | Service | Zone | On gateway? |
+   | Service | Zone | In a gateway process? |
    |---|---|---|
-   | `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, `NamedQueriesService` | `app_api` (explicit `@Zones`) | yes — the data plane |
-   | `EntityDefinitionService`, `NamedQueriesDefinitionService`, `MigrationService` | `os_api` (package-level `@Zones` in `api/services/package-info.java`) | no — definition-management auto-config is off (Phase 3) |
-   | `DataInsightsService` | `os_api` (`insights/package-info.java`) | no — dropped from scope entirely, published nowhere (see design decisions) |
+   | `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, `NamedQueriesService` (persistence) | `app_api` (explicit `@Zones`) | yes — the data plane |
+   | `EntityDefinitionService`, `NamedQueriesDefinitionService`, `MigrationService` (persistence) | `os_api` (package-level `@Zones` in `api/services/package-info.java`) | no — `disableEntityDefinitionManagement` (role-derived) |
+   | `ApplicationService`, `ProjectService`, `MemberService`, `LogService`/`LogManager`, `DeviceApprovalService`, `InviteEmailTemplateService`, `KinoticClusterInfoService`, `EnvironmentService` (os-api) | `os_api` | no — `disableOsApi` (role-derived) gates the whole `KinoticOsApiLibrary` |
+   | `GitHubAppInstallationService`, `GitHubWebhookEventService`, `GitHubProjectRepoService` (github) | `os_api` | no — `disableGithub` (role-derived) |
+   | `WorkloadOrchestrationService`, `VmNodeOrchestrationService` (orchestrator, once Phase 6 wires it in) | verify | no — verify the orchestrator library has (or add) the same `disable*` gate, driven by the role |
+   | `DataInsightsService` | `os_api` (`insights/package-info.java`) | published nowhere — dropped from scope (see design decisions) |
 
    `kinotic-domain` publishes **nothing** (`LocalAuthenticationService` is deliberately not
-   `@Publish` — raw passwords never travel over RPC). `kinotic-os-api`, `kinotic-github`, and
-   `kinotic-orchestrator` are not dependencies, so their `os_api` services cannot exist here.
-   To turn this from an emergent property into an invariant, add a per-deployable **publishable
-   zone allowlist** checked in `ServiceRegistrationBeanPostProcessor` (kinotic-core): a
-   `KinoticProperties` list (gateway: `app_api`, `app`; kinotic-server: `os_api`, `system`) —
-   registration of a bean whose `@Publish` zones fall outside the allowlist **fails startup**,
-   so accidentally adding a dependency that carries an OS service breaks the build/boot loudly
-   instead of silently widening the gateway's surface. Client-*hosted* services are already
-   constrained by the authorizer (an `ApplicationParticipant` may only host inside its own
-   `app.<org>.<app>` zone). Note the resulting depth: even if the `StompAuthorizer` had a bug
-   allowing an `os_api` send, there is no `os_api` listener on the environment bus — the send
-   has nothing to reach.
+   `@Publish` — raw passwords never travel over RPC). The **publishable-zone allowlist** turns
+   this table from configuration into an invariant: `ServiceRegistrationBeanPostProcessor`
+   (kinotic-core) checks every registration against the role-derived allowlist and **fails
+   startup** on a violation — a future module gate that's forgotten, renamed, or fail-opens can
+   never silently publish an OS service in a gateway process. Client-*hosted* services are
+   already constrained by the authorizer (an `ApplicationParticipant` may only host inside its
+   own `app.<org>.<app>` zone). Depth beneath all of this: even if the `StompAuthorizer` had a
+   bug allowing an `os_api` send, there is no `os_api` listener on the environment bus — the
+   send has nothing to reach.
 
 ## Phase 5 — entity index reconciler (gateway side)
 
@@ -384,7 +423,11 @@ own cluster match:
   nodes by the workload's `environmentId`.
 - **Wire kinotic-orchestrator into kinotic-server** (`kinotic-server/build.gradle`) — it is
   currently depended on by nothing, so orchestration RPCs are dead weight until this lands.
-  Confirm with Navid this is intended before doing it.
+  Confirm with Navid this is intended before doing it. Since the binary is shared, this also
+  puts the orchestrator on every gateway process's classpath: give the orchestrator library the
+  same `kinotic.disable*` gate as the other modules (if it lacks one) and add it to the role
+  mapping (`APPLICATION_GATEWAY` → disabled) **in the same commit** — the zone-allowlist guard
+  will fail gateway startup if this is forgotten, which is the guard working as intended.
 - Workload provisioning must inject the environment's gateway connection info (host/port of
   `Environment.gatewayUrl` or an internal equivalent) into the VM's env vars so the customer
   microservice's `@kinotic-ai/core` client connects to the right gateway. VmManagers themselves
@@ -410,22 +453,27 @@ own cluster match:
 - `@kinotic-ai/persistence` itself is unchanged (same `app_api` zone, same service CRI) — it just
   gets pointed at a gateway instead of kinotic-server.
 
-## Phase 8 — deployment + local dev + docs
+## Phase 8 — deployment, cutover, local dev + docs
+
+One image (`kinoticai/kinotic-server`) everywhere; the role/profile decides what a container is.
 
 - **Compose** (`deployment/docker-compose/`): second ES service (env cluster) +
-  `compose.kinotic-application-gateway.yml` (env=`development`, distinct STOMP/HTTP ports).
-  `compose.yml` wires: OS ES + env ES + migration + kinotic-server + one gateway.
-- **Helm**: new chart `deployment/helm/kinotic-application-gateway/` cloned from the kinotic
-  chart's shape (config-map env-var emission pattern for `KINOTIC_APPLICATIONGATEWAY_*` +
-  existing `KINOTIC_DOMAIN_ELASTIC*` for the OS cluster). One eck-stack release per environment
-  (new values overlays); NetworkPolicy: env ES reachable only from its gateway namespace, OS ES
-  reachable from kinotic + gateway namespaces.
-- **Images**: publish `kinoticai/kinotic-application-gateway` alongside
-  `kinoticai/kinotic-server` (mirror whatever builds the server image — check the conventions
-  plugin / CI, don't guess).
-- **Local dev without containers**: document running `KinoticServerApplication` +
-  `KinoticApplicationGatewayApplication` side by side against one local ES playing both roles
-  (both property sets point at `localhost:9200`). That keeps a one-ES laptop workflow.
+  `compose.kinotic-app-gateway.yml` running the *same* kinotic-server image with
+  `SPRING_PROFILES_ACTIVE` including `app-gateway` (env=`development`, distinct STOMP/HTTP
+  ports). `compose.yml` wires: OS ES + env ES + migration + kinotic-server + one gateway.
+- **Helm**: parameterize the existing `deployment/helm/kinotic` chart by role (profile +
+  `KINOTIC_APPLICATIONGATEWAY_*` env vars for gateway releases) rather than cloning a second
+  chart — one gateway release per environment via values overlays. One eck-stack release per
+  environment. NetworkPolicy: env ES reachable only from its gateway namespace, OS ES reachable
+  from kinotic + gateway namespaces.
+- **Cutover**: flip the `OS_SERVER` role mapping to `disableEntityDataPlane=true` and drop
+  `app_api` from its zone allowlist (the one-line code changes flagged in Phase 4), once the
+  frontend (Phase 7) talks to gateways for entity data. From here the OS bus carries no entity
+  data plane.
+- **Local dev without containers**: document running the same app twice from the IDE —
+  `KinoticServerApplication` with the default (OS) profile and again with `app-gateway` — against
+  one local ES playing both roles (both connection property sets default to `localhost:9200`).
+  That keeps a one-ES laptop workflow.
 - **Docs**: `website/content/**` — grep for `app_api`, `58503`, login routes, and anything
   describing "the server" as the single endpoint; reconcile every hit. Any pages advertising the
   GraphQL/OpenAPI/MCP HTTP endpoints describe dropped functionality — flag them to Navid (remove
@@ -439,13 +487,14 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
   `EntityDefinition` via the definition-management path against cluster A, run the data plane +
   reconciler against cluster B, assert the entity index exists only in B and `kinotic_*` domain
   indices only in A, then exercise `JsonEntitiesRepository` CRUD end-to-end.
-- **Gateway boot test**: start `KinoticApplicationGatewayApplication` (test profile), assert:
-  the `ServiceRegistry` contains **zero** registrations in `os_api`/`system` zones (the
+- **Gateway-role boot test**: start `KinoticServerApplication` with the `app-gateway` profile,
+  assert: the `ServiceRegistry` contains **zero** registrations in `os_api`/`system` zones (the
   no-OS-services invariant), os_api CRIs are rejected by the authorizer for an application
   participant, app login routes respond, org signup routes 404.
-- **Zone allowlist guard**: a context that registers a bean with an out-of-allowlist `@Publish`
-  zone fails startup (drive through `ServiceRegistrationBeanPostProcessor` with a real context,
-  not a mock).
+- **Role guard**: booting with no `kinotic.role` fails startup with a clear message; booting the
+  gateway role with a context that registers a bean carrying an out-of-allowlist `@Publish` zone
+  fails startup (drive through `ServiceRegistrationBeanPostProcessor` with a real context, not a
+  mock).
 - **JWT env binding**: token minted with `environmentId=development` rejected by a gateway
   configured as `production` (drive through the real `SecurityService.authenticate`).
 - **Existing e2e** (`compose.kinotic-e2e-test.yml`, `kinotic-js/workspace/packages/e2e-tests`):
@@ -482,7 +531,7 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
 - CLAUDE.md rules apply in full: Lombok, enums over string constants, `api/` vs `internal/`
   layout, one top-level type per file, no version literals in module `build.gradle`, docs synced
   in the same change, and the smells catalog (in particular: no speculative config beyond the
-  per-deployable flags specified here, no test-only seams).
+  role mechanism and per-role flags specified here, no test-only seams).
 - `docs/future-prompts/Gateway ABAC.md` describes a planned authorization overhaul that will land
   in this same gateway — keep the authorizer seam (Phase 4 item 1) small and policy-shaped so
   ABAC can replace it without another restructuring.

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -4,6 +4,11 @@ This is a phased implementation plan. Each phase compiles and passes tests on it
 reasonable PR boundary. Current-state claims below were verified against the tree at the time of
 writing — re-verify with fresh inspection before acting on any of them (files move).
 
+**STOP AT EVERY PHASE BOUNDARY.** When a phase is complete (implemented, tested, committed,
+pushed), report what was done and wait for Navid's explicit approval before starting the next
+phase. Do not begin any work belonging to a later phase while waiting — no "preparatory"
+refactors, no scaffolding. This applies between every pair of consecutive phases, 1 through 8.
+
 ## Goal
 
 Support multiple runtime environments (e.g. `development`, `production`) for customer
@@ -468,6 +473,10 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
 
 ## Guardrails for the implementer
 
+- **One phase per approval.** Finish the phase, report, and wait for Navid's go-ahead before
+  touching the next one (see the stop rule at the top of this document). If a phase turns out to
+  need something from a later phase, stop and raise it — don't pull the later work forward on
+  your own.
 - Re-verify every `path:line` anchor in this plan before editing; don't trust the plan over the
   tree.
 - CLAUDE.md rules apply in full: Lombok, enums over string constants, `api/` vs `internal/`

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -1,8 +1,10 @@
 # Multi-environment support for Kinotic Applications
 
 This is a phased implementation plan. Each phase compiles and passes tests on its own and is a
-reasonable PR boundary. Current-state claims below were verified against the tree at the time of
-writing — re-verify with fresh inspection before acting on any of them (files move).
+reasonable PR boundary. Current-state claims below were verified against `develop` at `d2487ff`
+("Update Application e2e tests for dash-slugified ids", 2026-07) — re-verify with fresh
+inspection before acting on any of them (files move; the zone model was reworked once already:
+single `@Zone`, dash names).
 
 **STOP AT EVERY PHASE BOUNDARY.** When a phase is complete (implemented, tested, committed,
 pushed), report what was done and wait for Navid's explicit approval before starting the next
@@ -30,7 +32,7 @@ applications:
 ```
                         ┌────────────────────────────────────────────┐
  kinotic-frontend ────► │ kinotic-server, role OS_SERVER              │──► OS ES cluster
- kinotic-cli      ────► │ (Ignite cluster "os"): os_api/system zones, │    (kinotic_* domain
+ kinotic-cli      ────► │ (Ignite cluster "os"): os-api/system zones, │    (kinotic_* domain
  VmManagers (STOMP)───► │ OIDC login, GitHub, orchestrator,           │     indices)
                         │ entity-definition mgmt                      │
                         └────────────────────────────────────────────┘
@@ -38,7 +40,7 @@ applications:
  customer UI  ─────────► ┌──────────────────────────────────────────┴─┐
  customer microservices─►│ kinotic-server, role APPLICATION_GATEWAY   │──► env ES cluster
  (STOMP, per env)        │ (per env, Ignite cluster "env-<id>"):      │    (entity data only)
-                         │ app login, app.<org>.<app> + app_api       │
+                         │ app login, app.<org>.<app> + app-api       │
                          │ zones, entity data plane (RPC over STOMP)  │
                          └────────────────────────────────────────────┘
 
@@ -60,9 +62,9 @@ override):
 - **Event-bus topology: one Ignite/Vert.x cluster per environment**, separate from the
   kinotic-server cluster. Gateways of the same environment cluster together (so a UI on replica
   A reaches a microservice on replica B). Because each environment has its own bus, the existing
-  zone grammar (`app.<orgId>.<appId>`, `app_api`) is unchanged — no collisions between a dev and
-  prod instance of the same app, and `@kinotic-ai/persistence`'s hardcoded `app_api` CRI keeps
-  working.
+  zone grammar (`app.<orgId>.<appId>`, `app-api`) is unchanged — no collisions between a dev and
+  prod instance of the same app, and the `APP_API_ZONE` CRIs built by `@kinotic-ai/persistence`
+  keep working.
 - **VmManagers stay on the kinotic-server bus** (they are platform infrastructure, connected via
   `@kinotic-ai/core` STOMP). Customer microservices running *inside* the VMs connect to their
   environment's gateway. This keeps `WorkloadOrchestrationService` → `VmManagerProxy` routing
@@ -89,7 +91,7 @@ override):
   little gain given the fixed, Kinotic-operated environment set.)
 - **kinotic-server stops serving the entity data plane.** `kinotic-frontend` browses entity data
   (data views) against the *selected environment's* gateway URL.
-- **Entity data is served over the STOMP/RPC path only** (`JsonEntitiesRepository` in `app_api`).
+- **Entity data is served over the STOMP/RPC path only** (`JsonEntitiesRepository` in `app-api`).
   The GraphQL/OpenAPI/MCP HTTP surfaces are dropped from scope: the code under
   `kinotic-persistence/.../internal/endpoints/` is deliberately dormant (nothing calls
   `PersistenceVerticleFactory`) and is kept for reference — leave it unwired and undeleted.
@@ -113,7 +115,7 @@ override):
   context cannot be invoked no matter what the authorizer does. The role-derived gates + the
   Phase 3 split achieve this (see Phase 4 for the inventory and the startup allowlist that makes
   it a hard invariant instead of an emergent property), and the guards that don't depend on the
-  process at all remain underneath: separate env bus (no `os_api` listener to reach), the
+  process at all remain underneath: separate env bus (no `os-api` listener to reach), the
   `StompAuthorizer` policy, and OS-cluster ES credentials that physically cannot write OS config
   indices.
 
@@ -164,8 +166,14 @@ entityDefinition.setItemIndex(this.persistenceProperties.getIndexPrefix() + logi
 // PersistenceProperties.indexPrefix = "kinotic_" (final)
 ```
 
-**Zones** (`kinotic-domain/.../internal/utils/DomainUtil.java:35-51`): `os_api`, `app_api`,
-`system`, `APP_ZONE_PREFIX="app"` → `app.<orgId>.<appId>`. Per-connection enforcement in
+**Zones** (`kinotic-domain/.../internal/utils/DomainUtil.java`, constants near the top): `os-api`,
+`app-api`, `system`, `APP_ZONE_PREFIX="app"` → `app.<orgId>.<appId>`. Names use **dashes**, not
+underscores (CRIs are valid URIs by convention; ids are dash-slugified). A service declares
+**exactly one zone** via `@Zone` (`kinotic-core/.../api/annotations/Zone.java`) on the type or its
+`package-info.java` — type-level overrides package-level, and **no declaration means the service
+registers at an un-zoned address**. The JS side mirrors the constants in
+`@kinotic-ai/os-api`'s `PlatformZones.ts` (re-exporting `APP_API_ZONE` from
+`@kinotic-ai/persistence`). Per-connection enforcement in
 `kinotic-api-gateway/.../internal/endpoints/stomp/StompAuthorizerFactory.java` keyed on participant
 type (`SystemParticipant` / `OrganizationParticipant` / `ApplicationParticipant`).
 
@@ -226,7 +234,7 @@ environments are platform infrastructure shared by all orgs.
   `kinotic-migration/src/main/resources/migrations/V<next>__environment.sql` (mirror the columns
   from the model; follow `V1__init.sql` style).
 - Publish CRUD in **kinotic-os-api** (next to `ApplicationService`):
-  `api/services/EnvironmentService` (`@Publish`, `@Version`, zone `os_api`, extends
+  `api/services/EnvironmentService` (`@Publish`, `@Version`, zone `os-api`, extends
   `IdentifiableCrudService<Environment, String>`) → `internal/api/services/DefaultEnvironmentService`.
   Authorization: mutations SYSTEM participants only; reads allowed to organization participants
   (the frontend needs the list + `gatewayUrl`). Follow whatever participant-check pattern
@@ -289,9 +297,9 @@ Both roles need `kinotic-persistence` (the gateway role needs `EntityDefinition`
 behind `kinotic.disablePersistence`. Split the Spring wiring, keep one Gradle module:
 
 - **Definition-management half** — definition/named-query management services
-  (`DefaultEntityDefinitionService`, `NamedQueries*`, their `@Publish` registrations in `os_api`).
+  (`DefaultEntityDefinitionService`, `NamedQueries*`, their `@Publish` registrations in `os-api`).
 - **Data-plane half** — `EntityServiceCache`, `DefaultEntityService` wiring,
-  `JsonEntitiesRepository`/`AdminJsonEntitiesRepository` (`app_api` zone),
+  `JsonEntitiesRepository`/`AdminJsonEntitiesRepository` (`app-api` zone),
   `PersistenceInitializer`. The dormant GraphQL/OpenAPI endpoint code stays outside both halves —
   unwired, kept for reference.
 
@@ -330,7 +338,7 @@ and lose to nothing):
 | `kinotic.disableGithub` | false | **true** |
 | `kinotic.disableEntityDefinitionManagement` (Phase 3) | false | **true** |
 | `kinotic.disableEntityDataPlane` (Phase 3) | false *(flips to true at the Phase 8 cutover — a one-line code change in this mapping)* | false |
-| publishable-zone allowlist | `os_api`, `system` (+ `app_api` until the Phase 8 cutover) | `app_api`, `app` |
+| publishable-zone allowlist | `os-api`, `system` (+ `app-api` until the Phase 8 cutover) | `app-api`, `app` |
 
 ```yaml
 # kinotic-server/src/main/resources/application-app-gateway.yml  (new profile — sets ONE role value
@@ -358,9 +366,9 @@ Work items in this phase:
 
 1. **Zone policy per role.** `StompAuthorizerFactory` currently encodes one global policy. Make
    the policy a bean selected by role: `APPLICATION_GATEWAY` — application participants keep
-   today's rules (`app_api.**` + `app.<org>.<app>.**`), organization participants (frontend
-   browsing data) get `app_api.**` send only, no participant reaches `os_api`/`system`;
-   `OS_SERVER` — conversely drops `app_api` for application participants (after the Phase 8
+   today's rules (`app-api.**` + `app.<org>.<app>.**`), organization participants (frontend
+   browsing data) get `app-api.**` send only, no participant reaches `os-api`/`system`;
+   `OS_SERVER` — conversely drops `app-api` for application participants (after the Phase 8
    cutover; they have no business on the OS bus). Don't fork the class — check how
    `StompAuthorizerFactory` is constructed and pick the smallest seam.
 2. **Auth surface per role.** `SuppliesGatewayRoutes` beans are mounted by discovery
@@ -382,7 +390,7 @@ Work items in this phase:
    gateway role actually uses Ignite for (session store, eventbus, caches in
    `KinoticIgniteConfigCaches`) — anything OS-specific should not be created on env clusters.
 5. **No entity HTTP surface.** The GraphQL/OpenAPI/MCP code stays dormant (see design
-   decisions) — the gateway role's only entity-data surface is the `app_api` RPC path.
+   decisions) — the gateway role's only entity-data surface is the `app-api` RPC path.
 6. **No SPA in the gateway role.** The role mapping (or profile) sets the web-server verticle
    disabled (`WebServerProperties`); the SPA files remain in the jar — accepted single-image
    trade-off — but are never served.
@@ -392,22 +400,25 @@ Work items in this phase:
 
    | Service | Zone | In a gateway process? |
    |---|---|---|
-   | `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, `NamedQueriesService` (persistence) | `app_api` (explicit `@Zones`) | yes — the data plane |
-   | `EntityDefinitionService`, `NamedQueriesDefinitionService`, `MigrationService` (persistence) | `os_api` (package-level `@Zones` in `api/services/package-info.java`) | no — `disableEntityDefinitionManagement` (role-derived) |
-   | `ApplicationService`, `ProjectService`, `MemberService`, `LogService`/`LogManager`, `DeviceApprovalService`, `InviteEmailTemplateService`, `KinoticClusterInfoService`, `EnvironmentService` (Phase 1), `PromotionService` (Phase 9) — all os-api | `os_api` | no — `disableOsApi` (role-derived) gates the whole `KinoticOsApiLibrary` |
-   | `GitHubAppInstallationService`, `GitHubWebhookEventService`, `GitHubProjectRepoService` (github) | `os_api` | no — `disableGithub` (role-derived) |
-   | `WorkloadOrchestrationService`, `VmNodeOrchestrationService` (orchestrator, once Phase 6 wires it in) | verify | no — verify the orchestrator library has (or add) the same `disable*` gate, driven by the role |
-   | `DataInsightsService` | `os_api` (`insights/package-info.java`) | published nowhere — dropped from scope (see design decisions) |
+   | `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, `NamedQueriesService` (persistence) | `app-api` (explicit `@Zone`) | yes — the data plane |
+   | `EntityDefinitionService`, `NamedQueriesDefinitionService`, `MigrationService` (persistence) | `os-api` (package-level `@Zone` in `api/services/package-info.java`) | no — `disableEntityDefinitionManagement` (role-derived) |
+   | `ApplicationService`, `ProjectService`, `MemberService`, `LogService`/`LogManager`, `DeviceApprovalService`, `InviteEmailTemplateService`, `KinoticClusterInfoService`, `EnvironmentService` (Phase 1), `PromotionService` (Phase 9) — all os-api | `os-api` | no — `disableOsApi` (role-derived) gates the whole `KinoticOsApiLibrary` |
+   | `GitHubAppInstallationService`, `GitHubWebhookEventService`, `GitHubProjectRepoService` (github) | `os-api` | no — `disableGithub` (role-derived) |
+   | `WorkloadOrchestrationService`, `VmNodeOrchestrationService` (orchestrator, once Phase 6 wires it in) | `system` (`@Zone` in `api/workload/package-info.java`) | no — verify the orchestrator library has (or add) the same `disable*` gate, driven by the role |
+   | `DataInsightsService` | `os-api` (`insights/package-info.java`) | published nowhere — dropped from scope (see design decisions) |
 
    `kinotic-domain` publishes **nothing** (`LocalAuthenticationService` is deliberately not
    `@Publish` — raw passwords never travel over RPC). The **publishable-zone allowlist** turns
    this table from configuration into an invariant: `ServiceRegistrationBeanPostProcessor`
-   (kinotic-core) checks every registration against the role-derived allowlist and **fails
-   startup** on a violation — a future module gate that's forgotten, renamed, or fail-opens can
-   never silently publish an OS service in a gateway process. Client-*hosted* services are
+   (kinotic-core) checks every registration's single `@Zone` against the role-derived allowlist
+   and **fails startup** on a violation — a future module gate that's forgotten, renamed, or
+   fail-opens can never silently publish an OS service in a gateway process. A service with
+   **no** `@Zone` registers at an un-zoned address (per the `Zone` javadoc): treat un-zoned
+   registrations as allowlist violations in the gateway role — every service a gateway publishes
+   must be deliberately zoned. Client-*hosted* services are
    already constrained by the authorizer (an `ApplicationParticipant` may only host inside its
    own `app.<org>.<app>` zone). Depth beneath all of this: even if the `StompAuthorizer` had a
-   bug allowing an `os_api` send, there is no `os_api` listener on the environment bus — the
+   bug allowing an `os-api` send, there is no `os-api` listener on the environment bus — the
    send has nothing to reach.
 
 ## Phase 5 — deployment records + per-environment mapping sync (OS side)
@@ -461,11 +472,11 @@ versions is open question 8 — resolve it with Navid before implementing this p
 - **ES least privilege** (per env cluster): gateway data user — document CRUD on entity
   indices, no index management; OS admin user — index/template/mapping management, no document
   read/write. Wire these as distinct users in the ECK/compose setups (Phase 8).
-- **Stranded os_api data service.** `MigrationService` is `os_api`-zoned (published by
+- **Stranded os-api data service.** `MigrationService` is `os-api`-zoned (published by
   kinotic-server, callable by the frontend via `@kinotic-ai/os-api`) but operates on **entity
   data**, which now lives only in env clusters that kinotic-server cannot reach. It doesn't touch
   OS config, so hosting it on the gateway would not violate the no-OS-services invariant — but it
-  would need re-zoning out of `os_api` (e.g. into `app_api` with organization-participant
+  would need re-zoning out of `os-api` (e.g. into `app-api` with organization-participant
   authorization, invoked over the frontend's per-environment connection) or deferring. See open
   question 5 — do not silently leave it published-but-broken.
 
@@ -505,7 +516,7 @@ versions is open question 8 — resolve it with Navid before implementing this p
   keep the source for reference.
 - Gateway CORS must allow the frontend origin (and later customer app origins — flag as open
   question; likely per-application allowed-origins data on `Application`).
-- `@kinotic-ai/persistence` itself is unchanged (same `app_api` zone, same service CRI) — it just
+- `@kinotic-ai/persistence` itself is unchanged (same `app-api` zone, same service CRI) — it just
   gets pointed at a gateway instead of kinotic-server.
 
 ## Phase 8 — deployment, cutover, local dev + docs
@@ -524,14 +535,14 @@ One image (`kinoticai/kinotic-server`) everywhere; the role/profile decides what
   + gateway namespaces. Provision the two distinct ES users per env cluster (Phase 5 least
   privilege) in the ECK/compose setups.
 - **Cutover**: flip the `OS_SERVER` role mapping to `disableEntityDataPlane=true` and drop
-  `app_api` from its zone allowlist (the one-line code changes flagged in Phase 4), once the
+  `app-api` from its zone allowlist (the one-line code changes flagged in Phase 4), once the
   frontend (Phase 7) talks to gateways for entity data. From here the OS bus carries no entity
   data plane.
 - **Local dev without containers**: document running the same app twice from the IDE —
   `KinoticServerApplication` with the default (OS) profile and again with `app-gateway` — against
   one local ES playing both roles (both connection property sets default to `localhost:9200`).
   That keeps a one-ES laptop workflow.
-- **Docs**: `website/content/**` — grep for `app_api`, `58503`, login routes, and anything
+- **Docs**: `website/content/**` — grep for `app-api`, `58503`, login routes, and anything
   describing "the server" as the single endpoint; reconcile every hit. Any pages advertising the
   GraphQL/OpenAPI/MCP HTTP endpoints describe dropped functionality — flag them to Navid (remove
   vs mark unsupported) rather than silently leaving them. Add an environments concept page.
@@ -543,7 +554,7 @@ entirely in the `OS_SERVER` role (it needs kinotic-github, the orchestrator, and
 OS-role modules). Builds on Phase 5 (deployment records + mapping sync) and Phase 6 (env-scoped
 workloads).
 
-**Service surface**: `PromotionService` (`@Publish`, zone `os_api`) in kinotic-os-api —
+**Service surface**: `PromotionService` (`@Publish`, zone `os-api`) in kinotic-os-api —
 `promote(organizationId, applicationId, targetEnvironmentId)` returning progress the frontend
 can render, plus promotion history/status reads. Authorization: organization participants for
 their own applications (verify against the participant-check pattern in
@@ -598,8 +609,8 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
   service creates the entity index only in B and `kinotic_*` domain indices exist only in A,
   then exercise `JsonEntitiesRepository` CRUD (data plane pointed at B) end-to-end.
 - **Gateway-role boot test**: start `KinoticServerApplication` with the `app-gateway` profile,
-  assert: the `ServiceRegistry` contains **zero** registrations in `os_api`/`system` zones (the
-  no-OS-services invariant), os_api CRIs are rejected by the authorizer for an application
+  assert: the `ServiceRegistry` contains **zero** registrations in `os-api`/`system` zones (the
+  no-OS-services invariant), os-api CRIs are rejected by the authorizer for an application
   participant, app login routes respond, org signup routes 404.
 - **Role guard**: booting with no `kinotic.role` fails startup with a clear message; booting the
   gateway role with a context that registers a bean carrying an out-of-allowlist `@Publish` zone
@@ -638,7 +649,7 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
    orchestrator's orphan status deliberate? (Phase 9 assumes it: both the Grind flow engine and
    `WorkloadOrchestrationService` live there.)
 4. **Customer app CORS/origins** at the gateway — per-application allowed-origins data?
-5. **`MigrationService`**: `os_api`-zoned but operates on entity data that moves to the env
+5. **`MigrationService`**: `os-api`-zoned but operates on entity data that moves to the env
    clusters (see Phase 5). Re-home it on the gateway under an org-participant-authorized
    surface, or defer the functionality for now?
 6. **Dev auto-sync**: does publishing an `EntityDefinition` auto-update the `development`

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -66,6 +66,12 @@ override):
   The GraphQL/OpenAPI/MCP HTTP surfaces are dropped from scope: the code under
   `kinotic-persistence/.../internal/endpoints/` is deliberately dormant (nothing calls
   `PersistenceVerticleFactory`) and is kept for reference — leave it unwired and undeleted.
+- **No OS service exists on the gateway — absence, not just authorization.** Service publication
+  is bean-driven (`ServiceRegistrationBeanPostProcessor` registers every Spring bean implementing
+  a `@Publish` interface), so a service that is not on the gateway's classpath/context cannot be
+  invoked there no matter what the authorizer does. The gateway's dependency set + the Phase 3
+  split already achieve this (see Phase 4 item 5 for the inventory and the startup guard that
+  makes it a hard invariant instead of an emergent property).
 
 ---
 
@@ -314,6 +320,27 @@ Work items in this phase:
 5. **No entity HTTP surface.** The GraphQL/OpenAPI/MCP code stays dormant (see design
    decisions) — the gateway's only entity-data surface is the `app_api` RPC path.
 6. **No SPA.** `WebServerProperties.enabled=false` by default; the gateway serves no frontend.
+7. **No OS services published — verified inventory + startup guard.** The full `@Publish`
+   inventory on the gateway's classpath (core + domain + persistence + api-gateway) is:
+
+   | Service | Zone | On gateway? |
+   |---|---|---|
+   | `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, `NamedQueriesService` | `app_api` (explicit `@Zones`) | yes — the data plane |
+   | `EntityDefinitionService`, `NamedQueriesDefinitionService`, `MigrationService`, `DataInsightsService` | `os_api` (package-level `@Zones` in `api/services/package-info.java` + `insights/package-info.java`) | no — definition-management auto-config is off (Phase 3) |
+
+   `kinotic-domain` publishes **nothing** (`LocalAuthenticationService` is deliberately not
+   `@Publish` — raw passwords never travel over RPC). `kinotic-os-api`, `kinotic-github`, and
+   `kinotic-orchestrator` are not dependencies, so their `os_api` services cannot exist here.
+   To turn this from an emergent property into an invariant, add a per-deployable **publishable
+   zone allowlist** checked in `ServiceRegistrationBeanPostProcessor` (kinotic-core): a
+   `KinoticProperties` list (gateway: `app_api`, `app`; kinotic-server: `os_api`, `system`) —
+   registration of a bean whose `@Publish` zones fall outside the allowlist **fails startup**,
+   so accidentally adding a dependency that carries an OS service breaks the build/boot loudly
+   instead of silently widening the gateway's surface. Client-*hosted* services are already
+   constrained by the authorizer (an `ApplicationParticipant` may only host inside its own
+   `app.<org>.<app>` zone). Note the resulting depth: even if the `StompAuthorizer` had a bug
+   allowing an `os_api` send, there is no `os_api` listener on the environment bus — the send
+   has nothing to reach.
 
 ## Phase 5 — entity index reconciler (gateway side)
 
@@ -329,9 +356,13 @@ own cluster match:
   (mapping changes) the same way the current update path does. Deletions: remove index/template.
 - Make creation idempotent and concurrency-safe across gateway replicas (ES create-index races
   return `resource_already_exists_exception` — treat as success).
-- `MigrationService` (data migrations over entity indices) becomes per-environment by
-  construction since it runs where the data-plane runs. Verify nothing in it still assumes the
-  OS cluster.
+- **Stranded os_api data services.** `MigrationService` and `DataInsightsService` are
+  `os_api`-zoned (published by kinotic-server, callable by the frontend via `@kinotic-ai/os-api`)
+  but operate on **entity data**, which now lives only in env clusters that kinotic-server cannot
+  reach. They don't touch OS config, so hosting them on the gateway would not violate the
+  no-OS-services invariant — but they'd need re-zoning out of `os_api` (e.g. into `app_api` with
+  organization-participant authorization, invoked over the frontend's per-environment connection)
+  or deferring. See open question 7 — do not silently leave them published-but-broken.
 
 ## Phase 6 — environment-scoped workloads
 
@@ -395,8 +426,12 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
   reconciler against cluster B, assert the entity index exists only in B and `kinotic_*` domain
   indices only in A, then exercise `JsonEntitiesRepository` CRUD end-to-end.
 - **Gateway boot test**: start `KinoticApplicationGatewayApplication` (test profile), assert:
-  os_api CRIs are rejected by the authorizer for an application participant, app login routes
-  respond, org signup routes 404.
+  the `ServiceRegistry` contains **zero** registrations in `os_api`/`system` zones (the
+  no-OS-services invariant), os_api CRIs are rejected by the authorizer for an application
+  participant, app login routes respond, org signup routes 404.
+- **Zone allowlist guard**: a context that registers a bean with an out-of-allowlist `@Publish`
+  zone fails startup (drive through `ServiceRegistrationBeanPostProcessor` with a real context,
+  not a mock).
 - **JWT env binding**: token minted with `environmentId=development` rejected by a gateway
   configured as `production` (drive through the real `SecurityService.authenticate`).
 - **Existing e2e** (`compose.kinotic-e2e-test.yml`, `kinotic-js/workspace/packages/e2e-tests`):
@@ -418,6 +453,9 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
 5. **Wiring kinotic-orchestrator into kinotic-server** (Phase 6) — intended now, or is the
    orchestrator's orphan status deliberate?
 6. **Customer app CORS/origins** at the gateway — per-application allowed-origins data?
+7. **`MigrationService` / `DataInsightsService`**: both are `os_api`-zoned but operate on entity
+   data that moves to the env clusters (see Phase 5). Re-home them on the gateway under an
+   org-participant-authorized surface, or defer the functionality for now?
 
 ## Guardrails for the implementer
 

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -113,10 +113,11 @@ override):
   composition-by-config is the established idiom. Two profiles in
   `kinotic-server/src/main/resources` — `application-os-server.yml` and
   `application-app-gateway.yml` — hold the *entire* per-deployment difference **explicitly in
-  YAML**: the disable flags and the publishable-zone allowlist
-  (`kinotic.publishableZones`). Beans that differ per deployment are selected with plain
-  `@Profile`; JWT env-claim behavior keys off whether `kinotic.applicationGateway.environmentId`
-  is set. No enum, no derivation, nothing spread through code. The **allowlist startup guard is
+  YAML**: the disable flags, the auth-route flags, and `kinotic.zones` — one list consumed by
+  both the publish guard and the STOMP authorizer (the hardcoded participant rules, temporary
+  until Gateway ABAC, are intersected with it). JWT env-claim behavior keys off whether
+  `kinotic.applicationGateway.environmentId` is set. No enum, no derivation, no
+  deployment-conditional beans — nothing spread through code. The **allowlist startup guard is
   what makes this safe**: any drift — a forgotten flag on a new module, a stray env var
   override — that lets an `os-api`/`system` service register in a gateway kills the process at
   boot. Accepted trade-offs of one image: the gateway jar carries the OS admin SPA and OS
@@ -354,7 +355,7 @@ ordinary property, visible and greppable in one file per deployment shape.
 | `kinotic.disableOsApi` (includes definition management after Phase 3) | false | **true** |
 | `kinotic.disableGithub` | false | **true** |
 | `kinotic.disablePersistence` (= the data plane after Phase 3) | false *(flips to true at the Phase 8 cutover)* | false |
-| `kinotic.publishableZones` | `os-api`, `system` (+ `app-api` until the Phase 8 cutover) | `app-api`, `app` |
+| `kinotic.zones` (publish guard ∩ authorizer) | `os-api`, `system` (+ `app-api` until the Phase 8 cutover) | `app-api`, `app` |
 
 ```yaml
 # kinotic-server/src/main/resources/application-app-gateway.yml  (new profile — flags, allowlist,
@@ -363,7 +364,7 @@ kinotic:
   disableOsApi: true
   disableGithub: true
   disablePersistence: false
-  publishableZones: [app-api, app]
+  zones: [app-api, app]
   applicationGateway:
     environmentId: ${KINOTIC_ENVIRONMENT_ID}
     elastic-connections:
@@ -377,16 +378,17 @@ profile to their active set (e.g. `production,os-server`).
 
 The three mechanisms that consume this configuration:
 
-- **`kinotic.publishableZones`** (`List<String>` on `KinoticProperties`): when set,
-  `ServiceRegistrationBeanPostProcessor` fails startup for any `@Publish` registration whose
-  zone is outside the list (`app` matching the leading label of `app.<org>.<app>` zones), and
-  for **un-zoned** registrations. When unset, registration is unrestricted — today's behavior,
-  so plain dev/test contexts keep working; both deployment profiles always set it.
-- **`@Profile` on deployment-specific beans**: the zone-policy bean and the role-specific route
-  suppliers are selected by the active profile (`@Profile("app-gateway")` /
-  `@Profile("os-server")`) — standard Spring, no new mechanism.
+- **`kinotic.zones`** (`List<String>` on `KinoticProperties`) — the zones this deployment
+  serves, consumed by two mechanisms: `ServiceRegistrationBeanPostProcessor` fails startup for
+  any `@Publish` registration whose zone is outside the list (`app` matching the leading label
+  of `app.<org>.<app>` zones) or **un-zoned**; and the `StompAuthorizer` intersects its
+  hardcoded per-participant patterns with it (work item 1). When unset, both are unrestricted —
+  today's behavior, so plain dev/test contexts keep working; both deployment profiles always
+  set it.
+- **Auth-route flags** (work item 2) gate which login route groups mount, in the existing
+  `disable*` idiom — no `@Profile`, no deployment-conditional beans.
 - **`kinotic.applicationGateway.environmentId` presence** drives the JWT env-claim behavior
-  (item 3 below): set ⇒ this deployment is an environment gateway.
+  (work item 3): set ⇒ this deployment is an environment gateway.
 
 Accepted trade, stated plainly: profile YAML can drift — a *new* module gate added later and
 forgotten in a profile is silently ON (`matchIfMissing = true`), the same misconfiguration risk
@@ -406,27 +408,38 @@ path, replacing Phase 2's alias; the base `application.yml` defaults those conne
 
 Work items in this phase:
 
-1. **Zone policy per role.** `StompAuthorizerFactory` currently encodes one global policy. Make
-   the policy a bean selected by profile: `app-gateway` — application participants keep
-   today's rules (`app-api.**` + `app.<org>.<app>.**`), organization participants (frontend
-   browsing data) get `app-api.**` send only, no participant reaches `os-api`/`system`;
-   `os-server` — conversely drops `app-api` for application participants (after the Phase 8
-   cutover; they have no business on the OS bus). Don't fork the class — check how
-   `StompAuthorizerFactory` is constructed and pick the smallest seam.
-2. **Auth surface per role.** `SuppliesGatewayRoutes` beans are mounted by discovery
-   (`ApiGatewayVertcleFactory` iterates all beans), so the REST surface follows which route
-   beans exist in the context. GitHub routes disappear via the profile's `disableGithub`.
-   The kinotic-domain handlers need profile gates: the gateway mounts app-scope routes only
-   (`ApplicationLoginHandler`, `SessionEndpointHandler`, invite acceptance if app-scoped); org
-   login, signup, and CLI device-login handlers are os-server-only. Verify which module
-   contributes each `SuppliesGatewayRoutes` bean and gate accordingly.
+1. **Zone authorization = the hardcoded rules ∩ `kinotic.zones`.** `StompAuthorizerFactory`'s
+   per-participant-type patterns stay hardcoded exactly as they are — they are temporary until
+   the Gateway ABAC work (`docs/future-prompts/Gateway ABAC.md`) replaces them with real
+   RBAC-defined path patterns — but every allowed pattern is additionally filtered by the
+   deployment's `kinotic.zones` list. The intersection lands every case where it should with
+   zero per-deployment policy code:
+
+   | participant | hardcoded today | ∩ gateway `[app-api, app]` | ∩ os-server `[os-api, system]` (post-cutover) |
+   |---|---|---|---|
+   | Organization | `os-api.**` + `app-api.**` | `app-api.**` (frontend data browsing) | `os-api.**` — `app-api` drops out at cutover automatically |
+   | Application | `app-api.**` + `app.<org>.<app>.**` | unchanged — the customer surface | ∅ — app participants have nothing on the OS bus |
+   | System | everything | `app-api.**` + `app.**` | `os-api.**` + `system.**` — VmManager orchestration intact |
+
+   (`reply://` destinations stay exempt from the intersection, as they are from de-scoping
+   today.)
+2. **Auth-route surface via flags, not profiles.** Org users never log in at an app gateway —
+   they log in at the OS server and present the minted JWT to the gateway. So the route split
+   is coarse and flag-shaped: GitHub routes already disappear via `disableGithub`; add a small
+   number of `disable*`-idiom flags for the kinotic-domain route groups (e.g.
+   `kinotic.domain.disableOrgAuthRoutes` covering org login/signup/CLI device-login,
+   `kinotic.domain.disableAppAuthRoutes` covering app login) set in the profile YAML — gateway:
+   org auth off, app auth on; os-server: the reverse as needed. Verify the actual
+   `SuppliesGatewayRoutes` bean inventory and group them into the fewest flags that make sense;
+   don't invent one flag per handler.
 3. **JWT environment binding.** `KinoticJwtIssuer` (kinotic-domain) mints platform JWTs; signing
    keys come from `platformSecrets` shared across deployments. When
    `kinotic.applicationGateway.environmentId` is set, add an
-   `environmentId` claim at mint and reject tokens whose claim doesn't match this deployment's
-   `environmentId` in the `KinoticSecurityService` validation path (a dev token must not work
-   against prod). The OS server accepts only tokens without the claim (or ignores — decide during
-   implementation and document with the auth docs).
+   `environmentId` claim at mint and reject app-participant tokens whose claim doesn't match
+   this deployment's `environmentId` in the `KinoticSecurityService` validation path (a dev
+   token must not work against prod). Organization-participant tokens are minted at the OS
+   server and carry no env claim — the gateway accepts them (their authorization is already
+   narrowed to `app-api.**` by item 1); the OS server accepts only claimless tokens.
 4. **Ignite cluster identity.** A gateway deployment joins Ignite cluster
    `env-<environmentId>`; verify how `KinoticIgniteConfig` names/discovers the cluster
    (`kinotic.ignite.*`) and ensure two clusters on one network can't merge. Also audit what the
@@ -452,7 +465,7 @@ Work items in this phase:
    `kinotic-domain` publishes **nothing** (`LocalAuthenticationService` is deliberately not
    `@Publish` — raw passwords never travel over RPC). The **publishable-zone allowlist** turns
    this table from configuration into an invariant: `ServiceRegistrationBeanPostProcessor`
-   (kinotic-core) checks every registration's single `@Zone` against `kinotic.publishableZones`
+   (kinotic-core) checks every registration's single `@Zone` against `kinotic.zones`
    and **fails startup** on a violation — a future module gate that's forgotten, renamed, or
    fail-opens can never silently publish an OS service in a gateway process. A service with
    **no** `@Zone` registers at an un-zoned address (per the `Zone` javadoc): treat un-zoned
@@ -580,7 +593,7 @@ One image (`kinoticai/kinotic-server`) everywhere; the active profile decides wh
   kinotic namespace (OS admin user, index-management-only ES role); OS ES reachable from kinotic
   + gateway namespaces. Provision the two distinct ES users per env cluster (Phase 5 least
   privilege) in the ECK/compose setups.
-- **Cutover**: set `disablePersistence: true` and drop `app-api` from `kinotic.publishableZones`
+- **Cutover**: set `disablePersistence: true` and drop `app-api` from `kinotic.zones`
   in `application-os-server.yml` (flagged in Phase 4), once the frontend
   (Phase 7) talks to gateways for entity data. From here the OS bus carries no entity data
   plane.
@@ -658,7 +671,7 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
   assert: the `ServiceRegistry` contains **zero** registrations in `os-api`/`system` zones (the
   no-OS-services invariant), os-api CRIs are rejected by the authorizer for an application
   participant, app login routes respond, org signup routes 404.
-- **Allowlist guard**: with `kinotic.publishableZones` set, a context that registers a bean
+- **Allowlist guard**: with `kinotic.zones` set, a context that registers a bean
   carrying an out-of-list (or missing) `@Zone` fails startup (drive through
   `ServiceRegistrationBeanPostProcessor` with a real context, not a mock).
 - **JWT env binding**: token minted with `environmentId=development` rejected by a gateway

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -66,6 +66,11 @@ override):
   The GraphQL/OpenAPI/MCP HTTP surfaces are dropped from scope: the code under
   `kinotic-persistence/.../internal/endpoints/` is deliberately dormant (nothing calls
   `PersistenceVerticleFactory`) and is kept for reference — leave it unwired and undeleted.
+- **Data Insights is dropped from scope** (owner decision), same reference-code treatment:
+  unwire `DataInsightsServiceImpl` and `InsightsContextService` (remove their `@Service`
+  stereotypes) so `DataInsightsService` is published nowhere; keep the classes. Its internals
+  are already mostly commented out pending Spring AI 2 (`DataInsightsConfiguration`'s
+  `ChatClient` bean is disabled), so this completes an unwiring that is half-done today.
 - **No OS service exists on the gateway — absence, not just authorization.** Service publication
   is bean-driven (`ServiceRegistrationBeanPostProcessor` registers every Spring bean implementing
   a `@Publish` interface), so a service that is not on the gateway's classpath/context cannot be
@@ -326,7 +331,8 @@ Work items in this phase:
    | Service | Zone | On gateway? |
    |---|---|---|
    | `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, `NamedQueriesService` | `app_api` (explicit `@Zones`) | yes — the data plane |
-   | `EntityDefinitionService`, `NamedQueriesDefinitionService`, `MigrationService`, `DataInsightsService` | `os_api` (package-level `@Zones` in `api/services/package-info.java` + `insights/package-info.java`) | no — definition-management auto-config is off (Phase 3) |
+   | `EntityDefinitionService`, `NamedQueriesDefinitionService`, `MigrationService` | `os_api` (package-level `@Zones` in `api/services/package-info.java`) | no — definition-management auto-config is off (Phase 3) |
+   | `DataInsightsService` | `os_api` (`insights/package-info.java`) | no — dropped from scope entirely, published nowhere (see design decisions) |
 
    `kinotic-domain` publishes **nothing** (`LocalAuthenticationService` is deliberately not
    `@Publish` — raw passwords never travel over RPC). `kinotic-os-api`, `kinotic-github`, and
@@ -356,13 +362,13 @@ own cluster match:
   (mapping changes) the same way the current update path does. Deletions: remove index/template.
 - Make creation idempotent and concurrency-safe across gateway replicas (ES create-index races
   return `resource_already_exists_exception` — treat as success).
-- **Stranded os_api data services.** `MigrationService` and `DataInsightsService` are
-  `os_api`-zoned (published by kinotic-server, callable by the frontend via `@kinotic-ai/os-api`)
-  but operate on **entity data**, which now lives only in env clusters that kinotic-server cannot
-  reach. They don't touch OS config, so hosting them on the gateway would not violate the
-  no-OS-services invariant — but they'd need re-zoning out of `os_api` (e.g. into `app_api` with
-  organization-participant authorization, invoked over the frontend's per-environment connection)
-  or deferring. See open question 7 — do not silently leave them published-but-broken.
+- **Stranded os_api data service.** `MigrationService` is `os_api`-zoned (published by
+  kinotic-server, callable by the frontend via `@kinotic-ai/os-api`) but operates on **entity
+  data**, which now lives only in env clusters that kinotic-server cannot reach. It doesn't touch
+  OS config, so hosting it on the gateway would not violate the no-OS-services invariant — but it
+  would need re-zoning out of `os_api` (e.g. into `app_api` with organization-participant
+  authorization, invoked over the frontend's per-environment connection) or deferring. See open
+  question 7 — do not silently leave it published-but-broken.
 
 ## Phase 6 — environment-scoped workloads
 
@@ -388,9 +394,12 @@ own cluster match:
   `@kinotic-ai/core` singleton (`Kinotic`) must support two live connections or the persistence
   plugin needs a per-connection instance — inspect `KinoticSingleton` before choosing; this is
   the riskiest client-side change.
-- The GraphQL/OpenAPI playground pages embed the dropped HTTP surfaces — hide or remove the
-  frontend entry points for them (confirm with Navid which), since there is no backend to point
-  them at.
+- The GraphQL/OpenAPI playground pages embed the dropped HTTP surfaces, and the Data Insights UI
+  (`src/pages/DataInsights.vue`, `DashboardView.vue`, `SavedWidgets.vue`, widget components/
+  entity repos) calls the dropped `DataInsightsService` — hide or remove the frontend entry
+  points for both (confirm with Navid which), since there is no backend behind them. Same for
+  `IDataInsightsService` in `@kinotic-ai/os-api` (`OsApiPlugin`): stop wiring it into the plugin;
+  keep the source for reference.
 - Gateway CORS must allow the frontend origin (and later customer app origins — flag as open
   question; likely per-application allowed-origins data on `Application`).
 - `@kinotic-ai/persistence` itself is unchanged (same `app_api` zone, same service CRI) — it just
@@ -453,9 +462,9 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
 5. **Wiring kinotic-orchestrator into kinotic-server** (Phase 6) — intended now, or is the
    orchestrator's orphan status deliberate?
 6. **Customer app CORS/origins** at the gateway — per-application allowed-origins data?
-7. **`MigrationService` / `DataInsightsService`**: both are `os_api`-zoned but operate on entity
-   data that moves to the env clusters (see Phase 5). Re-home them on the gateway under an
-   org-participant-authorized surface, or defer the functionality for now?
+7. **`MigrationService`**: `os_api`-zoned but operates on entity data that moves to the env
+   clusters (see Phase 5). Re-home it on the gateway under an org-participant-authorized
+   surface, or defer the functionality for now?
 
 ## Guardrails for the implementer
 

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -31,7 +31,7 @@ applications:
  customer microservices─►│ kinotic-application-gateway (per env,      │──► env ES cluster
  (STOMP, per env)        │ Ignite cluster "env-<id>"): app login,     │    (entity data only)
                          │ app.<org>.<app> + app_api zones, entity    │
-                         │ data plane (RPC + GraphQL + OpenAPI + MCP) │
+                         │ data plane (RPC over STOMP only)           │
                          └────────────────────────────────────────────┘
 ```
 
@@ -61,7 +61,11 @@ override):
   `EntityDefinition`s in the OS cluster; each gateway creates missing indices/templates in its
   own cluster lazily + on startup).
 - **kinotic-server stops serving the entity data plane.** `kinotic-frontend` browses entity data
-  (playgrounds, data views) against the *selected environment's* gateway URL.
+  (data views) against the *selected environment's* gateway URL.
+- **Entity data is served over the STOMP/RPC path only** (`JsonEntitiesRepository` in `app_api`).
+  The GraphQL/OpenAPI/MCP HTTP surfaces are dropped from scope: the code under
+  `kinotic-persistence/.../internal/endpoints/` is deliberately dormant (nothing calls
+  `PersistenceVerticleFactory`) and is kept for reference — leave it unwired and undeleted.
 
 ---
 
@@ -116,9 +120,11 @@ entityDefinition.setItemIndex(this.persistenceProperties.getIndexPrefix() + logi
 type (`SystemParticipant` / `OrganizationParticipant` / `ApplicationParticipant`).
 
 **Edges today:** `kinotic-api-gateway` (a *library* module, pulled into kinotic-server) runs STOMP
-on 58503 (`/v1`) + REST under `/api/*` + optional SPA server. The entity-data HTTP surface
-(GraphQL :4000, OpenAPI :8080, MCP :3001) is deployed by
-`kinotic-persistence/.../internal/PersistenceInitializer.java`, *not* by the gateway router.
+on 58503 (`/v1`) + REST under `/api/*` + optional SPA server. An entity-data HTTP surface
+(GraphQL/OpenAPI verticles under `kinotic-persistence/.../internal/endpoints/`) exists in code but
+is **dormant by design**: `PersistenceVerticleFactory` has no callers, and
+`PersistenceInitializer` only registers an ES health check. This code is deliberately kept for
+reference — do not wire it up, and do not delete it.
 
 **Module graph:** `kinotic-server` (only `java-application-conventions` module) depends on core,
 domain, os-api, persistence, github, api-gateway. `kinotic-orchestrator` is an **orphan** — no
@@ -171,7 +177,12 @@ Goal: make "which cluster" an explicit dependency while kinotic-server keeps tod
 (both roles → same cluster) so this phase is a pure refactor. The mechanism is **two named
 `ElasticsearchAsyncClient` beans** (plus a `CrudServiceTemplate` per client) — no new abstraction.
 
-1. Demote `CrudServiceTemplate` from `@Component` to a plain class constructed per client.
+1. Demote `CrudServiceTemplate` from `@Component` to a plain class; **both** instances are
+   constructed by `@Bean` methods — do not leave one coming from component scanning and add the
+   other via `@Bean` (two creation paths for one class, and the scanned instance's target cluster
+   would be implicit in `@Primary` resolution instead of visible in a method signature).
+   `CrudServiceTemplate` already has a hand-written constructor taking
+   `(ElasticsearchAsyncClient, ObjectMapper)`, so no Lombok/`@Qualifier` interaction to solve.
 2. In `KinoticElasticsearchConfig`, extract the client construction into a reusable factory
    method and expose the OS pair as `@Primary` named beans:
 
@@ -181,7 +192,9 @@ Goal: make "which cluster" an explicit dependency while kinotic-server keeps tod
 public ElasticsearchAsyncClient osElasticClient(JsonpMapper mapper) { ... }        // kinotic.domain.elastic-*
 
 @Bean(OS_CRUD_SERVICE_TEMPLATE) @Primary
-public CrudServiceTemplate osCrudServiceTemplate(ElasticsearchAsyncClient osElasticClient, ...) { ... }
+public CrudServiceTemplate osCrudServiceTemplate(ElasticsearchAsyncClient osElasticClient, ObjectMapper objectMapper) {
+    return new CrudServiceTemplate(osElasticClient, objectMapper);
+}
 ```
 
    `@Primary` keeps every existing injection point (all OS repositories, `kinotic-github`,
@@ -218,7 +231,8 @@ everything. Split the Spring wiring, keep one Gradle module:
   used by kinotic-server.
 - `KinoticEntityDataAutoConfiguration` — the data plane: `EntityServiceCache`,
   `DefaultEntityService` wiring, `JsonEntitiesRepository`/`AdminJsonEntitiesRepository`
-  (`app_api` zone), `PersistenceInitializer` + GraphQL/OpenAPI/MCP verticles.
+  (`app_api` zone), `PersistenceInitializer`. The dormant GraphQL/OpenAPI endpoint code stays
+  outside both auto-configs — unwired, kept for reference.
 
 Gate each with `@ConditionalOnProperty` (e.g. `kinotic.persistence.definition-management.enabled`,
 `kinotic.persistence.data-plane.enabled`) set in each deployable's `application.yml`. These
@@ -297,10 +311,8 @@ Work items in this phase:
    clusters on one network can't merge. Also audit what the gateway actually uses Ignite for
    (session store, eventbus, caches in `KinoticIgniteConfigCaches`) — anything OS-specific should
    not be created on env clusters.
-5. **Entity HTTP surface.** The GraphQL/OpenAPI/MCP verticles (data-plane auto-config) now run
-   here. Their `AuthenticationHandler` uses the same `SecurityService` — resolve the existing
-   `//FIXME: enforce the proper auth at the various levels` in `GqlVerticle` at least to the
-   point of enforcing org/app path params against the authenticated participant.
+5. **No entity HTTP surface.** The GraphQL/OpenAPI/MCP code stays dormant (see design
+   decisions) — the gateway's only entity-data surface is the `app_api` RPC path.
 6. **No SPA.** `WebServerProperties.enabled=false` by default; the gateway serves no frontend.
 
 ## Phase 5 — entity index reconciler (gateway side)
@@ -313,8 +325,7 @@ own cluster match:
   `itemIndex` exists in the env cluster — reuse the exact create logic that Phase 3 lifted out of
   `DefaultEntityDefinitionService` (mappings via `entityDefinitionConversionService`, data-stream
   vs index decision by `isStream()`).
-- On startup + periodic (reuse the Vert.x periodic pattern from `PersistenceInitializer`):
-  sweep published definitions, create missing indices, and handle definition **updates**
+- On startup + a periodic Vert.x timer: sweep published definitions, create missing indices, and handle definition **updates**
   (mapping changes) the same way the current update path does. Deletions: remove index/template.
 - Make creation idempotent and concurrency-safe across gateway replicas (ES create-index races
   return `resource_already_exists_exception` — treat as success).
@@ -340,12 +351,15 @@ own cluster match:
 ## Phase 7 — kinotic-frontend + kinotic-js
 
 - Frontend: environment selector (list from the new `EnvironmentService`). OS configuration
-  traffic is untouched (same kinotic-server connection). Entity-data views + GraphQL/OpenAPI
-  playgrounds re-point to the selected environment's `gatewayUrl` — this is a *second* Kinotic
-  connection (`src/util/helpers.ts` currently builds exactly one from `VITE_KINOTIC_*`). The
+  traffic is untouched (same kinotic-server connection). Entity-data views re-point to the
+  selected environment's `gatewayUrl` — this is a *second* Kinotic connection
+  (`src/util/helpers.ts` currently builds exactly one from `VITE_KINOTIC_*`). The
   `@kinotic-ai/core` singleton (`Kinotic`) must support two live connections or the persistence
   plugin needs a per-connection instance — inspect `KinoticSingleton` before choosing; this is
   the riskiest client-side change.
+- The GraphQL/OpenAPI playground pages embed the dropped HTTP surfaces — hide or remove the
+  frontend entry points for them (confirm with Navid which), since there is no backend to point
+  them at.
 - Gateway CORS must allow the frontend origin (and later customer app origins — flag as open
   question; likely per-application allowed-origins data on `Application`).
 - `@kinotic-ai/persistence` itself is unchanged (same `app_api` zone, same service CRI) — it just
@@ -367,9 +381,10 @@ own cluster match:
 - **Local dev without containers**: document running `KinoticServerApplication` +
   `KinoticApplicationGatewayApplication` side by side against one local ES playing both roles
   (both property sets point at `localhost:9200`). That keeps a one-ES laptop workflow.
-- **Docs**: `website/content/**` — grep for `app_api`, `58503`, GraphQL/OpenAPI base URLs, login
-  routes, and anything describing "the server" as the single endpoint; reconcile every hit. Add
-  an environments concept page. Update `docs/AUTH-README.md` if the JWT claim lands.
+- **Docs**: `website/content/**` — grep for `app_api`, `58503`, login routes, and anything
+  describing "the server" as the single endpoint; reconcile every hit. Any pages advertising the
+  GraphQL/OpenAPI/MCP HTTP endpoints describe dropped functionality — flag them to Navid (remove
+  vs mark unsupported) rather than silently leaving them. Add an environments concept page.
 
 ## Testing strategy
 

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -7,7 +7,7 @@ writing — re-verify with fresh inspection before acting on any of them (files 
 **STOP AT EVERY PHASE BOUNDARY.** When a phase is complete (implemented, tested, committed,
 pushed), report what was done and wait for Navid's explicit approval before starting the next
 phase. Do not begin any work belonging to a later phase while waiting — no "preparatory"
-refactors, no scaffolding. This applies between every pair of consecutive phases, 1 through 8.
+refactors, no scaffolding. This applies between every pair of consecutive phases, 1 through 9.
 
 ## Goal
 
@@ -48,8 +48,15 @@ One container image; the role decides what a process is.
 Design decisions baked into this plan (each has an "open questions" entry if Navid may want to
 override):
 
-- **Environments are platform-level (SYSTEM-scoped) entities**, a small fixed set operated by
-  Kinotic (`development`, `production`), stored in the OS cluster. Not per-organization.
+- **Environments are platform-level (SYSTEM-scoped) entities** (owner decision — confirmed, not
+  an open question): a fixed set operated by Kinotic (`development`, `production`), stored in the
+  OS cluster. They never belong to an organization.
+- **An application reaches an environment through an explicit Promotion** (owner decision), a
+  Kinotic-managed flow: sync the app's `EntityDefinition` ES mappings to the target env cluster,
+  deploy the application's artifacts to the target environment, and run predefined Git
+  branching/tagging actions on the app's project repos. Presence in an environment is therefore
+  a *record* written by promotion, not an implicit property of existing (see Phase 9). The
+  development environment is assumed to sync continuously on publish (open question).
 - **Event-bus topology: one Ignite/Vert.x cluster per environment**, separate from the
   kinotic-server cluster. Gateways of the same environment cluster together (so a UI on replica
   A reaches a microservice on replica B). Because each environment has its own bus, the existing
@@ -67,9 +74,11 @@ override):
 - **Entity definitions stay environment-agnostic** (one schema, data per environment). Entity
   index naming inside each env cluster is unchanged: `kinotic_<orgId>.<appId>.<entityName>` —
   the cluster itself is the environment namespace.
-- **Entity index creation moves to a gateway-side reconciler** (desired state = published
-  `EntityDefinition`s in the OS cluster; each gateway creates missing indices/templates in its
-  own cluster lazily + on startup).
+- **Entity index creation moves to a gateway-side reconciler**, driven by per-environment
+  **deployment records** in the OS cluster (written by promotion / dev auto-sync), *not* by the
+  raw set of published `EntityDefinition`s — a definition edited after promotion must not leak
+  into prod until the next promotion. Each gateway creates/updates indices and templates in its
+  own cluster to match its environment's records (lazily + on startup + periodic).
 - **kinotic-server stops serving the entity data plane.** `kinotic-frontend` browses entity data
   (data views) against the *selected environment's* gateway URL.
 - **Entity data is served over the STOMP/RPC path only** (`JsonEntitiesRepository` in `app_api`).
@@ -376,7 +385,7 @@ Work items in this phase:
    |---|---|---|
    | `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, `NamedQueriesService` (persistence) | `app_api` (explicit `@Zones`) | yes — the data plane |
    | `EntityDefinitionService`, `NamedQueriesDefinitionService`, `MigrationService` (persistence) | `os_api` (package-level `@Zones` in `api/services/package-info.java`) | no — `disableEntityDefinitionManagement` (role-derived) |
-   | `ApplicationService`, `ProjectService`, `MemberService`, `LogService`/`LogManager`, `DeviceApprovalService`, `InviteEmailTemplateService`, `KinoticClusterInfoService`, `EnvironmentService` (os-api) | `os_api` | no — `disableOsApi` (role-derived) gates the whole `KinoticOsApiLibrary` |
+   | `ApplicationService`, `ProjectService`, `MemberService`, `LogService`/`LogManager`, `DeviceApprovalService`, `InviteEmailTemplateService`, `KinoticClusterInfoService`, `EnvironmentService` (Phase 1), `PromotionService` (Phase 9) — all os-api | `os_api` | no — `disableOsApi` (role-derived) gates the whole `KinoticOsApiLibrary` |
    | `GitHubAppInstallationService`, `GitHubWebhookEventService`, `GitHubProjectRepoService` (github) | `os_api` | no — `disableGithub` (role-derived) |
    | `WorkloadOrchestrationService`, `VmNodeOrchestrationService` (orchestrator, once Phase 6 wires it in) | verify | no — verify the orchestrator library has (or add) the same `disable*` gate, driven by the role |
    | `DataInsightsService` | `os_api` (`insights/package-info.java`) | published nowhere — dropped from scope (see design decisions) |
@@ -392,27 +401,54 @@ Work items in this phase:
    bug allowing an `os_api` send, there is no `os_api` listener on the environment bus — the
    send has nothing to reach.
 
-## Phase 5 — entity index reconciler (gateway side)
+## Phase 5 — deployment records + entity index reconciler (gateway side)
 
-The OS cluster's `kinotic_entity_definition` index is the desired state; each gateway makes its
-own cluster match:
+Desired state per environment is a **deployment record**, not the raw definition set — this is
+what makes promotion (Phase 9) possible: prod's indices reflect the last *promoted* state, never
+a definition edit made after promotion.
 
-- On `EntityServiceCache` miss (already loads the `EntityDefinition` from the OS cluster via
-  `EntityDefinitionRepository`): before constructing the `DefaultEntityService`, ensure
-  `itemIndex` exists in the env cluster — reuse the exact create logic that Phase 3 lifted out of
-  `DefaultEntityDefinitionService` (mappings via `entityDefinitionConversionService`, data-stream
-  vs index decision by `isStream()`).
-- On startup + a periodic Vert.x timer: sweep published definitions, create missing indices, and handle definition **updates**
-  (mapping changes) the same way the current update path does. Deletions: remove index/template.
+New domain object in kinotic-domain (`kinotic_application_deployment` index + migration SQL):
+
+```java
+@Getter @Setter @Accessors(chain = true) @NoArgsConstructor
+public class ApplicationDeployment implements ApplicationScoped<String> {
+    private String id;                     // <organizationId>.<applicationId>.<environmentId>
+    private String organizationId;
+    private String applicationId;
+    private String environmentId;
+    private List<EntityDefinition> entityDefinitions;  // snapshot taken at deploy/promotion time
+    private DeploymentStatus status;       // enum: PENDING, SYNCING, ACTIVE, FAILED — new file
+    private Date created; private Date updated;
+}
+```
+
+Whether the record embeds full definition snapshots (shown) or references immutable definition
+versions is open question 8 — resolve it with Navid before implementing this phase.
+
+- **Dev auto-sync (assumed, open question)**: publishing an `EntityDefinition` upserts the
+  `development` deployment record for its application, so the dev env tracks publishes
+  continuously through the same mechanism promotion uses.
+- **Reconciler (gateway role)**: on startup + a periodic Vert.x timer, load this environment's
+  deployment records from the OS cluster and make the env cluster match — create missing
+  indices/templates, apply mapping updates, remove indices for withdrawn definitions. Reuse the
+  exact create logic Phase 3 lifted out of `DefaultEntityDefinitionService` (mappings via
+  `entityDefinitionConversionService`, data-stream vs index decision by `isStream()`).
+  `EntityServiceCache` also verifies-on-miss before constructing a `DefaultEntityService`, and
+  must serve entity RPCs from the **record's** definitions, not the live `kinotic_entity_definition`
+  docs, so wire schema and index mappings can't drift apart within an environment.
+- The reconciler reports per-record sync status back onto the deployment record (`status`,
+  plus error detail on failure) — the gateway already has scoped OS-cluster write access; add
+  this index to its ES role. Promotion (Phase 9) awaits this status.
 - Make creation idempotent and concurrency-safe across gateway replicas (ES create-index races
-  return `resource_already_exists_exception` — treat as success).
+  return `resource_already_exists_exception` — treat as success; last-writer-wins on status is
+  acceptable).
 - **Stranded os_api data service.** `MigrationService` is `os_api`-zoned (published by
   kinotic-server, callable by the frontend via `@kinotic-ai/os-api`) but operates on **entity
   data**, which now lives only in env clusters that kinotic-server cannot reach. It doesn't touch
   OS config, so hosting it on the gateway would not violate the no-OS-services invariant — but it
   would need re-zoning out of `os_api` (e.g. into `app_api` with organization-participant
   authorization, invoked over the frontend's per-environment connection) or deferring. See open
-  question 7 — do not silently leave it published-but-broken.
+  question 5 — do not silently leave it published-but-broken.
 
 ## Phase 6 — environment-scoped workloads
 
@@ -479,6 +515,57 @@ One image (`kinoticai/kinotic-server`) everywhere; the role/profile decides what
   GraphQL/OpenAPI/MCP HTTP endpoints describe dropped functionality — flag them to Navid (remove
   vs mark unsupported) rather than silently leaving them. Add an environments concept page.
 
+## Phase 9 — Promotion (Develop → Prod)
+
+A Kinotic-managed, predefined flow that moves an application into a target environment. Runs
+entirely in the `OS_SERVER` role (it needs kinotic-github, the orchestrator, and OS data — all
+OS-role modules). Builds on Phase 5 (deployment records/reconciler) and Phase 6 (env-scoped
+workloads).
+
+**Service surface**: `PromotionService` (`@Publish`, zone `os_api`) in kinotic-os-api —
+`promote(organizationId, applicationId, targetEnvironmentId)` returning progress the frontend
+can render, plus promotion history/status reads. Authorization: organization participants for
+their own applications (verify against the participant-check pattern in
+`DefaultApplicationService`).
+
+**Flow engine**: the Grind job framework in kinotic-orchestrator is the natural fit — a
+predefined multi-step flow with progress and diagnostics is exactly its shape:
+
+```java
+// kinotic-orchestrator/.../api/grind/JobService.java:18
+Flux<Result<?>> assemble(JobDefinition jobDefinition);   // Steps/Tasks with Progress + Diagnostic results
+```
+
+Verify it end-to-end before committing to it (it has `src/testx/` tests but has never run inside
+a deployable — Phase 6 wires the module in); if it proves unfit, a plain service method
+executing the steps sequentially is acceptable — do not build a *third* flow mechanism.
+
+**The predefined steps** (Kinotic-managed; not user-customizable in this iteration):
+
+1. **Git actions** — branch/tag each of the application's project repos per the predefined
+   promotion convention (e.g. tag the promoted commit, cut/advance a release branch — exact
+   convention from Navid at implementation time). Uses kinotic-github
+   (`GitHubProjectRepoService` / the GitHub client it wraps); `Project` already carries
+   `repoFullName`/`repoDefaultBranch`.
+2. **Definition sync** — snapshot the application's current `EntityDefinition`s into the target
+   environment's `ApplicationDeployment` record (Phase 5). The target gateway's reconciler
+   applies the mappings; the job awaits the record's `status` turning `ACTIVE` (or surfaces the
+   failure detail). No direct OS-server → env-cluster ES connection is ever needed.
+3. **Artifact deployment** — create/update the application's `Workload`s with
+   `environmentId = target` from the promoted artifacts, via `WorkloadOrchestrationService`
+   (Phase 6). What an "artifact" is (image reference, who built it, where it's recorded) is
+   open question 10 — pin it down before this phase.
+4. **Record + report** — promotion history persisted (who, when, what versions, outcome), and
+   the deployment record is the durable statement of what's live in the environment.
+
+**Ordering/rollback**: steps are sequential with fail-fast; a failed promotion leaves the
+previous deployment record intact (snapshot-swap, not in-place edit) so the environment keeps
+serving the last good state. Rollback = re-promote a previous snapshot; don't build a separate
+rollback mechanism.
+
+**Frontend**: promotion trigger + progress/history UI (extends the Phase 7 environment
+selector); regenerate `@kinotic-ai/os-api` for `PromotionService`.
+
 ## Testing strategy
 
 Follow the repo rule: behavioral tests through real infrastructure over mocked units.
@@ -497,28 +584,52 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
   mock).
 - **JWT env binding**: token minted with `environmentId=development` rejected by a gateway
   configured as `production` (drive through the real `SecurityService.authenticate`).
+- **Promotion end-to-end** (two ES containers, OS role + gateway role processes): publish a
+  definition (dev auto-sync creates indices in the dev cluster), promote to `production`, assert
+  the prod cluster gains the promoted mappings and the deployment record goes `ACTIVE`; then
+  edit the definition *without* promoting and assert the prod cluster is untouched — that last
+  assertion is the whole point of deployment records. Git steps against a test repo or stubbed
+  at the GitHub client boundary (the flow logic, not GitHub, is under test).
 - **Existing e2e** (`compose.kinotic-e2e-test.yml`, `kinotic-js/workspace/packages/e2e-tests`):
   extend the compose topology; the JS SDK tests should pass unmodified against a gateway — that
   is the wire-compat check.
 
+## Decided (owner answers — no longer open)
+
+- Environments are a system-level construct with a fixed, Kinotic-operated set — never
+  per-organization.
+- An application reaches an environment via explicit Promotion (Phase 9): definition-mapping
+  sync to the target env cluster, artifact deployment, and predefined Git branching/tagging.
+- Single binary with roles (Phase 4); GraphQL/OpenAPI/MCP and Data Insights dropped as dormant
+  reference code.
+
 ## Open questions for Navid (answer before/at handoff)
 
-1. **Environment set**: platform-global fixed set (assumed here) vs per-organization custom
-   environments? Per-org changes `Environment` to `OrganizationScoped` and multiplies clusters.
-2. **App ↔ environment enablement**: is every application implicitly present in every
-   environment (assumed), or is there an explicit "deploy app X to env Y" record?
-3. **App end-users per environment?** Assumed shared (`IamUser` unchanged; env binding only via
+1. **App end-users per environment?** Assumed shared (`IamUser` unchanged; env binding only via
    the JWT claim from whichever gateway they logged into). If dev/prod user separation is wanted,
    `IamUser` needs an `environmentId` and the login handlers need env context.
-4. **Frontend data browsing via env gateway** (assumed) vs kinotic-server holding connections to
+2. **Frontend data browsing via env gateway** (assumed) vs kinotic-server holding connections to
    every env cluster. The latter avoids the dual-connection frontend work but couples the OS
    server to every environment's ES.
-5. **Wiring kinotic-orchestrator into kinotic-server** (Phase 6) — intended now, or is the
-   orchestrator's orphan status deliberate?
-6. **Customer app CORS/origins** at the gateway — per-application allowed-origins data?
-7. **`MigrationService`**: `os_api`-zoned but operates on entity data that moves to the env
+3. **Wiring kinotic-orchestrator into kinotic-server** (Phase 6) — intended now, or is the
+   orchestrator's orphan status deliberate? (Phase 9 assumes it: both the Grind flow engine and
+   `WorkloadOrchestrationService` live there.)
+4. **Customer app CORS/origins** at the gateway — per-application allowed-origins data?
+5. **`MigrationService`**: `os_api`-zoned but operates on entity data that moves to the env
    clusters (see Phase 5). Re-home it on the gateway under an org-participant-authorized
    surface, or defer the functionality for now?
+6. **Dev auto-sync**: does publishing an `EntityDefinition` auto-update the `development`
+   environment (assumed in Phase 5), or does even dev require an explicit deploy action?
+7. **Promotion path**: is the flow strictly `development → production`, or is the environment
+   ordering something the `Environment` model must express (a field/sequence) once more
+   environments exist? With a fixed set, the flow can start as a constant.
+8. **Definition snapshot semantics** (Phase 5): does the `ApplicationDeployment` record embed
+   full `EntityDefinition` snapshots (assumed — simple, immutable) or reference versioned
+   definitions (requires definition versioning that doesn't exist today)?
+9. **Git promotion convention** (Phase 9): the exact branch/tag actions per promotion (tag name
+   scheme, release branch policy, which commit is promoted).
+10. **What is an application artifact** (Phase 9): image reference on `Workload`? Built by what
+    (kinotic-github CI? external)? Where is the promotable artifact version recorded?
 
 ## Guardrails for the implementer
 

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -1,0 +1,413 @@
+# Multi-environment support for Kinotic Applications
+
+This is a phased implementation plan. Each phase compiles and passes tests on its own and is a
+reasonable PR boundary. Current-state claims below were verified against the tree at the time of
+writing — re-verify with fresh inspection before acting on any of them (files move).
+
+## Goal
+
+Support multiple runtime environments (e.g. `development`, `production`) for customer
+applications:
+
+1. **One "OS" Elasticsearch cluster** holds every domain object the Kinotic OS manages
+   (organizations, applications, projects, IAM, entity *definitions*, workloads, …).
+2. **One Elasticsearch cluster per environment** holds customer entity *data* only.
+3. **One `kinotic-application-gateway` deployable per environment** (new Gradle module, an
+   application module like `kinotic-server`). It is the edge for customer applications: UI ↔
+   backend-microservice RPC, and entity-data reads/writes for that environment.
+4. **One `kinotic-server` cluster** remains the single edge for `kinotic-frontend` — all OS
+   configuration (orgs, apps, projects, members, entity definitions, environments) goes there.
+
+## Target topology
+
+```
+                        ┌────────────────────────────────────────────┐
+ kinotic-frontend ────► │ kinotic-server cluster (Ignite cluster "os")│──► OS ES cluster
+ kinotic-cli      ────► │  os_api / system zones, OIDC login, GitHub, │    (kinotic_* domain
+ VmManagers (STOMP)───► │  orchestrator, entity-definition mgmt      │     indices)
+                        └────────────────────────────────────────────┘
+                                                                   ▲ read/write OS metadata
+ customer UI  ─────────► ┌──────────────────────────────────────────┴─┐
+ customer microservices─►│ kinotic-application-gateway (per env,      │──► env ES cluster
+ (STOMP, per env)        │ Ignite cluster "env-<id>"): app login,     │    (entity data only)
+                         │ app.<org>.<app> + app_api zones, entity    │
+                         │ data plane (RPC + GraphQL + OpenAPI + MCP) │
+                         └────────────────────────────────────────────┘
+```
+
+Design decisions baked into this plan (each has an "open questions" entry if Navid may want to
+override):
+
+- **Environments are platform-level (SYSTEM-scoped) entities**, a small fixed set operated by
+  Kinotic (`development`, `production`), stored in the OS cluster. Not per-organization.
+- **Event-bus topology: one Ignite/Vert.x cluster per environment**, separate from the
+  kinotic-server cluster. Gateways of the same environment cluster together (so a UI on replica
+  A reaches a microservice on replica B). Because each environment has its own bus, the existing
+  zone grammar (`app.<orgId>.<appId>`, `app_api`) is unchanged — no collisions between a dev and
+  prod instance of the same app, and `@kinotic-ai/persistence`'s hardcoded `app_api` CRI keeps
+  working.
+- **VmManagers stay on the kinotic-server bus** (they are platform infrastructure, connected via
+  `@kinotic-ai/core` STOMP). Customer microservices running *inside* the VMs connect to their
+  environment's gateway. This keeps `WorkloadOrchestrationService` → `VmManagerProxy` routing
+  untouched.
+- **The gateway reads OS metadata directly from the OS ES cluster** (IAM users, applications,
+  OIDC configs, entity definitions) rather than proxying RPC to kinotic-server. It therefore has
+  two ES clients. Scope its OS-cluster credentials to the indices it needs via ES security roles
+  (it must write a few IAM indices: refresh tokens, device grants, pending invites).
+- **Entity definitions stay environment-agnostic** (one schema, data per environment). Entity
+  index naming inside each env cluster is unchanged: `kinotic_<orgId>.<appId>.<entityName>` —
+  the cluster itself is the environment namespace.
+- **Entity index creation moves to a gateway-side reconciler** (desired state = published
+  `EntityDefinition`s in the OS cluster; each gateway creates missing indices/templates in its
+  own cluster lazily + on startup).
+- **kinotic-server stops serving the entity data plane.** `kinotic-frontend` browses entity data
+  (playgrounds, data views) against the *selected environment's* gateway URL.
+
+---
+
+## Current state (verified anchors)
+
+**No `Environment` concept exists.** Scoping hierarchy is Organization → Application → Project,
+via marker interfaces:
+
+```java
+// kinotic-domain/src/main/java/org/kinotic/domain/api/model/OrganizationScoped.java
+// ApplicationScoped extends OrganizationScoped; ProjectScoped extends ApplicationScoped
+```
+
+**Exactly one ES client bean** serves both OS domain objects and customer entity data:
+
+```java
+// kinotic-domain/src/main/java/org/kinotic/domain/internal/config/KinoticElasticsearchConfig.java:36
+@Bean
+public ElasticsearchAsyncClient elasticsearchAsyncClient(JsonpMapper jsonpMapper){
+    HttpHost[] hosts = domainProperties.getElasticConnections().stream()...  // kinotic.domain.elastic-connections
+```
+
+```java
+// kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/CrudServiceTemplate.java:52
+@Component
+public class CrudServiceTemplate {
+    private final ElasticsearchAsyncClient esAsyncClient;   // the single join point
+```
+
+Every OS repository extends `AbstractRepository`/`Abstract{Organization,Application,Project}ScopedRepository`
+(`kinotic-domain/.../internal/api/repositories/`) and passes a literal `kinotic_*` index name plus
+the shared client/template. The entity-data path consumes the *same* beans:
+
+```java
+// kinotic-persistence/.../internal/api/services/EntityServiceCache.java:40-41
+private final CrudServiceTemplate crudServiceTemplate;
+private final ElasticsearchAsyncClient esAsyncClient;      // same beans as the OS repos
+```
+
+Entity index name derivation:
+
+```java
+// kinotic-persistence/.../internal/api/services/DefaultEntityDefinitionService.java (validateAndCreate)
+entityDefinition.setItemIndex(this.persistenceProperties.getIndexPrefix() + logicalIndexName);
+// PersistenceUtil.createEntityDefinitionId → (orgId + "." + appId + "." + name).toLowerCase()
+// PersistenceProperties.indexPrefix = "kinotic_" (final)
+```
+
+**Zones** (`kinotic-domain/.../internal/utils/DomainUtil.java:35-51`): `os_api`, `app_api`,
+`system`, `APP_ZONE_PREFIX="app"` → `app.<orgId>.<appId>`. Per-connection enforcement in
+`kinotic-api-gateway/.../internal/endpoints/stomp/StompAuthorizerFactory.java` keyed on participant
+type (`SystemParticipant` / `OrganizationParticipant` / `ApplicationParticipant`).
+
+**Edges today:** `kinotic-api-gateway` (a *library* module, pulled into kinotic-server) runs STOMP
+on 58503 (`/v1`) + REST under `/api/*` + optional SPA server. The entity-data HTTP surface
+(GraphQL :4000, OpenAPI :8080, MCP :3001) is deployed by
+`kinotic-persistence/.../internal/PersistenceInitializer.java`, *not* by the gateway router.
+
+**Module graph:** `kinotic-server` (only `java-application-conventions` module) depends on core,
+domain, os-api, persistence, github, api-gateway. `kinotic-orchestrator` is an **orphan** — no
+module depends on it, so `WorkloadOrchestrationService` is not currently wired into any deployable.
+
+**Deployment:** one ECK ES cluster (`deployment/helm/eck-stack`), one kinotic-server chart
+(`deployment/helm/kinotic`), env vars `KINOTIC_DOMAIN_ELASTICCONNECTIONS_*`. Compose:
+`deployment/docker-compose/compose.elasticsearch.yml` (single node).
+
+---
+
+## Phase 1 — `Environment` domain model + OS API
+
+New domain object in `kinotic-domain/src/main/java/org/kinotic/domain/api/model/Environment.java`:
+
+```java
+@Getter @Setter @Accessors(chain = true) @NoArgsConstructor
+public class Environment implements Identifiable<String> {
+    private String id;                 // slug of name, minted like Application ids ("development")
+    private String name;
+    private String description;
+    private String gatewayUrl;         // public base URL of this environment's application gateway
+    private EnvironmentStatus status;  // enum: PROVISIONING, ACTIVE, DISABLED — new file
+    private Date created;
+    private Date updated;
+}
+```
+
+`gatewayUrl` is data, not a Spring property — the frontend and OS services discover per-environment
+gateways through it. It is SYSTEM-scoped (plain `Identifiable`, like `Organization`), because
+environments are platform infrastructure shared by all orgs.
+
+- `EnvironmentRepository extends AbstractRepository<Environment>` with index `kinotic_environment`
+  (`kinotic-domain/.../internal/api/repositories/`, same shape as `OrganizationRepository`).
+- Migration: add `kinotic_environment` `CREATE TABLE` to a new
+  `kinotic-migration/src/main/resources/migrations/V<next>__environment.sql` (mirror the columns
+  from the model; follow `V1__init.sql` style).
+- Publish CRUD in **kinotic-os-api** (next to `ApplicationService`):
+  `api/services/EnvironmentService` (`@Publish`, `@Version`, zone `os_api`, extends
+  `IdentifiableCrudService<Environment, String>`) → `internal/api/services/DefaultEnvironmentService`.
+  Authorization: mutations SYSTEM participants only; reads allowed to organization participants
+  (the frontend needs the list + `gatewayUrl`). Follow whatever participant-check pattern
+  `DefaultApplicationService` uses — verify it rather than inventing one.
+- Regenerate/extend `@kinotic-ai/os-api` client proxy for the new service
+  (`kinotic-js/workspace/packages/os-api`).
+
+## Phase 2 — split the ES client seam (no behavior change yet)
+
+Goal: make "which cluster" an explicit dependency while kinotic-server keeps today's behavior
+(both roles → same cluster) so this phase is a pure refactor.
+
+1. Demote `CrudServiceTemplate` from `@Component` to a plain class constructed per client.
+2. In `KinoticElasticsearchConfig`, build clients from a reusable factory method and expose named
+   beans:
+
+```java
+// kinotic-domain/.../internal/config/KinoticElasticsearchConfig.java  (target shape)
+@Bean @Primary
+public ElasticsearchAsyncClient osElasticClient(JsonpMapper mapper) { ... }        // kinotic.domain.elastic-*
+
+@Bean @Primary
+public CrudServiceTemplate osCrudServiceTemplate(ElasticsearchAsyncClient osElasticClient, ...) { ... }
+```
+
+   `@Primary` keeps every existing injection point (all OS repositories, `kinotic-github`,
+   secret storage, etc.) compiling and resolving to the OS cluster untouched.
+3. Introduce the entity-data-side abstraction in **kinotic-persistence**:
+
+```java
+// kinotic-persistence/.../api/services/EntityDataClients.java  (new)
+public interface EntityDataClients {
+    ElasticsearchAsyncClient client();
+    CrudServiceTemplate template();
+}
+```
+
+   Inject `EntityDataClients` (instead of the bare beans) into `EntityServiceCache`,
+   `DefaultEntityService` construction, `DefaultEntityDefinitionService`'s index-lifecycle calls,
+   and `PersistenceInitializer`'s health checks. In kinotic-server the default implementation
+   delegates to the OS client — identical behavior, one seam.
+4. `EntityDefinitionRepository` / `NamedQueriesDefinitionRepository` are **metadata**, not entity
+   data — they stay on the OS template.
+
+Verify with a full `:kinotic-server:test` run; this phase must be invisible at runtime.
+
+## Phase 3 — split kinotic-persistence wiring into definition-management vs data-plane
+
+Both future deployables depend on `kinotic-persistence` (the gateway needs `EntityDefinition`,
+converters, `EntityService`; the server needs definition CRUD). Today one auto-config wires
+everything. Split the Spring wiring, keep one Gradle module:
+
+- `KinoticEntityDefinitionAutoConfiguration` — definition/named-query management services
+  (`DefaultEntityDefinitionService`, `NamedQueries*`, their `@Publish` registrations in `os_api`),
+  used by kinotic-server.
+- `KinoticEntityDataAutoConfiguration` — the data plane: `EntityServiceCache`,
+  `DefaultEntityService` wiring, `JsonEntitiesRepository`/`AdminJsonEntitiesRepository`
+  (`app_api` zone), `PersistenceInitializer` + GraphQL/OpenAPI/MCP verticles.
+
+Gate each with `@ConditionalOnProperty` (e.g. `kinotic.persistence.definition-management.enabled`,
+`kinotic.persistence.data-plane.enabled`) set in each deployable's `application.yml`. These
+properties genuinely differ per deployable, so they pass the "Properties" rule. Important nuance:
+**publishing an EntityDefinition no longer creates indices** on the server side —
+`DefaultEntityDefinitionService.validateAndCreate` keeps computing/persisting `itemIndex` but the
+`createIndex`/`createIndexTemplate`/`createDataStream` calls move behind the data-plane side
+(Phase 5 reconciler). Deletion likewise: the OS side marks/deletes the definition; gateways
+reconcile index removal.
+
+kinotic-server after this phase: definition-management ON, data-plane OFF (except in a local-dev
+profile — see Phase 8).
+
+## Phase 4 — new deployable: `kinotic-application-gateway`
+
+New top-level Gradle module (auto-included by root `settings.gradle` — it just needs its own
+`settings.gradle` like the others):
+
+```groovy
+// kinotic-application-gateway/build.gradle
+plugins { id 'org.kinotic.java-application-conventions' }
+dependencies {
+    implementation project(':kinotic-core')
+    implementation project(':kinotic-domain')       // IAM/auth, OS repositories, app login REST
+    implementation project(':kinotic-persistence')  // data plane only (Phase 3 flag)
+    implementation project(':kinotic-api-gateway')  // STOMP engine, router, web-server verticle
+    // deliberately NOT os-api, NOT github, NOT frontend
+}
+```
+
+```java
+// kinotic-application-gateway/src/main/java/org/kinotic/appgateway/KinoticApplicationGatewayApplication.java
+@SpringBootApplication
+@EnableKinotic
+public class KinoticApplicationGatewayApplication { ... }   // mirror KinoticServerApplication
+```
+
+Configuration (`api/config/ApplicationGatewayProperties.java`, prefix
+`kinotic.applicationGateway`):
+
+```java
+private String environmentId;                        // which Environment this deployment serves
+private List<ElasticConnectionInfo> elasticConnections;  // the env's entity-data cluster
+private String elasticUsername; private String elasticPassword;
+```
+
+The OS cluster connection reuses the existing `kinotic.domain.elastic-*` properties (that's what
+all the domain repositories bind to). The gateway's `EntityDataClients` implementation builds the
+env-cluster client from `kinotic.applicationGateway.*` — this replaces the server's
+delegate-to-OS default from Phase 2.
+
+Work items in this phase:
+
+1. **Zone policy.** `StompAuthorizerFactory` currently encodes one global policy. The gateway
+   must not expose `os_api`/`system`: application participants keep today's rules
+   (`app_api.**` + `app.<org>.<app>.**`); organization participants (frontend browsing data) get
+   `app_api.**` send only; system participants are for platform tooling. kinotic-server's policy
+   conversely drops `app_api` for application participants (they have no business on the OS bus
+   anymore). Make the authorizer policy a bean the deployable supplies rather than forking the
+   class — check how `StompAuthorizerFactory` is constructed and pick the smallest seam.
+2. **Auth surface.** Mount only the app-scope REST routes (`ApplicationLoginHandler`,
+   `SessionEndpointHandler`, invite acceptance if app-scoped). `SuppliesGatewayRoutes` beans are
+   mounted by discovery (`ApiGatewayVertcleFactory` iterates all beans), so this falls out of
+   which beans exist on the gateway's classpath/context — org login, signup, GitHub, and CLI
+   device-login handlers must not be wired here. Verify which module contributes each
+   `SuppliesGatewayRoutes` bean and gate accordingly.
+3. **JWT environment binding.** `KinoticJwtIssuer` (kinotic-domain) mints platform JWTs; signing
+   keys come from `platformSecrets` shared across deployables. Add an `environmentId` claim when
+   the issuer runs inside a gateway, and make the gateway's `KinoticSecurityService` validation
+   path reject tokens whose claim doesn't match its own `environmentId` (a dev token must not
+   work against prod). kinotic-server accepts only tokens without the claim (or ignores — decide
+   during implementation and document in AUTH docs).
+4. **Ignite cluster identity.** The gateway joins Ignite cluster `env-<environmentId>`; verify
+   how `KinoticIgniteConfig` names/discovers the cluster (`kinotic.ignite.*`) and ensure two
+   clusters on one network can't merge. Also audit what the gateway actually uses Ignite for
+   (session store, eventbus, caches in `KinoticIgniteConfigCaches`) — anything OS-specific should
+   not be created on env clusters.
+5. **Entity HTTP surface.** The GraphQL/OpenAPI/MCP verticles (data-plane auto-config) now run
+   here. Their `AuthenticationHandler` uses the same `SecurityService` — resolve the existing
+   `//FIXME: enforce the proper auth at the various levels` in `GqlVerticle` at least to the
+   point of enforcing org/app path params against the authenticated participant.
+6. **No SPA.** `WebServerProperties.enabled=false` by default; the gateway serves no frontend.
+
+## Phase 5 — entity index reconciler (gateway side)
+
+The OS cluster's `kinotic_entity_definition` index is the desired state; each gateway makes its
+own cluster match:
+
+- On `EntityServiceCache` miss (already loads the `EntityDefinition` from the OS cluster via
+  `EntityDefinitionRepository`): before constructing the `DefaultEntityService`, ensure
+  `itemIndex` exists in the env cluster — reuse the exact create logic that Phase 3 lifted out of
+  `DefaultEntityDefinitionService` (mappings via `entityDefinitionConversionService`, data-stream
+  vs index decision by `isStream()`).
+- On startup + periodic (reuse the Vert.x periodic pattern from `PersistenceInitializer`):
+  sweep published definitions, create missing indices, and handle definition **updates**
+  (mapping changes) the same way the current update path does. Deletions: remove index/template.
+- Make creation idempotent and concurrency-safe across gateway replicas (ES create-index races
+  return `resource_already_exists_exception` — treat as success).
+- `MigrationService` (data migrations over entity indices) becomes per-environment by
+  construction since it runs where the data-plane runs. Verify nothing in it still assumes the
+  OS cluster.
+
+## Phase 6 — environment-scoped workloads
+
+- `Workload` (`kinotic-domain/.../api/model/workload/Workload.java`) gains `environmentId`
+  (required when `applicationId` is set); `VmNode` gains `environmentId` (a node belongs to one
+  environment). Update the corresponding migration SQL.
+- `kinotic-orchestrator` node selection (`DefaultWorkloadOrchestrationService`) filters candidate
+  nodes by the workload's `environmentId`.
+- **Wire kinotic-orchestrator into kinotic-server** (`kinotic-server/build.gradle`) — it is
+  currently depended on by nothing, so orchestration RPCs are dead weight until this lands.
+  Confirm with Navid this is intended before doing it.
+- Workload provisioning must inject the environment's gateway connection info (host/port of
+  `Environment.gatewayUrl` or an internal equivalent) into the VM's env vars so the customer
+  microservice's `@kinotic-ai/core` client connects to the right gateway. VmManagers themselves
+  keep connecting to kinotic-server.
+
+## Phase 7 — kinotic-frontend + kinotic-js
+
+- Frontend: environment selector (list from the new `EnvironmentService`). OS configuration
+  traffic is untouched (same kinotic-server connection). Entity-data views + GraphQL/OpenAPI
+  playgrounds re-point to the selected environment's `gatewayUrl` — this is a *second* Kinotic
+  connection (`src/util/helpers.ts` currently builds exactly one from `VITE_KINOTIC_*`). The
+  `@kinotic-ai/core` singleton (`Kinotic`) must support two live connections or the persistence
+  plugin needs a per-connection instance — inspect `KinoticSingleton` before choosing; this is
+  the riskiest client-side change.
+- Gateway CORS must allow the frontend origin (and later customer app origins — flag as open
+  question; likely per-application allowed-origins data on `Application`).
+- `@kinotic-ai/persistence` itself is unchanged (same `app_api` zone, same service CRI) — it just
+  gets pointed at a gateway instead of kinotic-server.
+
+## Phase 8 — deployment + local dev + docs
+
+- **Compose** (`deployment/docker-compose/`): second ES service (env cluster) +
+  `compose.kinotic-application-gateway.yml` (env=`development`, distinct STOMP/HTTP ports).
+  `compose.yml` wires: OS ES + env ES + migration + kinotic-server + one gateway.
+- **Helm**: new chart `deployment/helm/kinotic-application-gateway/` cloned from the kinotic
+  chart's shape (config-map env-var emission pattern for `KINOTIC_APPLICATIONGATEWAY_*` +
+  existing `KINOTIC_DOMAIN_ELASTIC*` for the OS cluster). One eck-stack release per environment
+  (new values overlays); NetworkPolicy: env ES reachable only from its gateway namespace, OS ES
+  reachable from kinotic + gateway namespaces.
+- **Images**: publish `kinoticai/kinotic-application-gateway` alongside
+  `kinoticai/kinotic-server` (mirror whatever builds the server image — check the conventions
+  plugin / CI, don't guess).
+- **Local dev without containers**: document running `KinoticServerApplication` +
+  `KinoticApplicationGatewayApplication` side by side against one local ES playing both roles
+  (both property sets point at `localhost:9200`). That keeps a one-ES laptop workflow.
+- **Docs**: `website/content/**` — grep for `app_api`, `58503`, GraphQL/OpenAPI base URLs, login
+  routes, and anything describing "the server" as the single endpoint; reconcile every hit. Add
+  an environments concept page. Update `docs/AUTH-README.md` if the JWT claim lands.
+
+## Testing strategy
+
+Follow the repo rule: behavioral tests through real infrastructure over mocked units.
+
+- **Two-cluster integration test** (Testcontainers, two ES containers): publish an
+  `EntityDefinition` via the definition-management path against cluster A, run the data plane +
+  reconciler against cluster B, assert the entity index exists only in B and `kinotic_*` domain
+  indices only in A, then exercise `JsonEntitiesRepository` CRUD end-to-end.
+- **Gateway boot test**: start `KinoticApplicationGatewayApplication` (test profile), assert:
+  os_api CRIs are rejected by the authorizer for an application participant, app login routes
+  respond, org signup routes 404.
+- **JWT env binding**: token minted with `environmentId=development` rejected by a gateway
+  configured as `production` (drive through the real `SecurityService.authenticate`).
+- **Existing e2e** (`compose.kinotic-e2e-test.yml`, `kinotic-js/workspace/packages/e2e-tests`):
+  extend the compose topology; the JS SDK tests should pass unmodified against a gateway — that
+  is the wire-compat check.
+
+## Open questions for Navid (answer before/at handoff)
+
+1. **Environment set**: platform-global fixed set (assumed here) vs per-organization custom
+   environments? Per-org changes `Environment` to `OrganizationScoped` and multiplies clusters.
+2. **App ↔ environment enablement**: is every application implicitly present in every
+   environment (assumed), or is there an explicit "deploy app X to env Y" record?
+3. **App end-users per environment?** Assumed shared (`IamUser` unchanged; env binding only via
+   the JWT claim from whichever gateway they logged into). If dev/prod user separation is wanted,
+   `IamUser` needs an `environmentId` and the login handlers need env context.
+4. **Frontend data browsing via env gateway** (assumed) vs kinotic-server holding connections to
+   every env cluster. The latter avoids the dual-connection frontend work but couples the OS
+   server to every environment's ES.
+5. **Wiring kinotic-orchestrator into kinotic-server** (Phase 6) — intended now, or is the
+   orchestrator's orphan status deliberate?
+6. **Customer app CORS/origins** at the gateway — per-application allowed-origins data?
+
+## Guardrails for the implementer
+
+- Re-verify every `path:line` anchor in this plan before editing; don't trust the plan over the
+  tree.
+- CLAUDE.md rules apply in full: Lombok, enums over string constants, `api/` vs `internal/`
+  layout, one top-level type per file, no version literals in module `build.gradle`, docs synced
+  in the same change, and the smells catalog (in particular: no speculative config beyond the
+  per-deployable flags specified here, no test-only seams).
+- `docs/future-prompts/Gateway ABAC.md` describes a planned authorization overhaul that will land
+  in this same gateway — keep the authorizer seam (Phase 4 item 1) small and policy-shaped so
+  ABAC can replace it without another restructuring.

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -350,10 +350,35 @@ public enum KinoticRole { OS_SERVER, APPLICATION_GATEWAY }
 ```
 
 `kinotic.role` has **no default** — a process without a role fails startup with a clear message.
-The role→flags mapping lives *in code* (an `EnvironmentPostProcessor` or equivalent that sets the
-properties before binding — verify the right Spring Boot 4 hook rather than assuming; the
-requirement is that the derived values win over the fail-open `matchIfMissing = true` defaults
-and lose to nothing):
+The role→flags mapping lives *in code*. Mechanism: the disable flags are consumed by
+`@ConditionalOnProperty` on the library classes, which evaluates against the Spring `Environment`
+during context refresh — so the role must be translated into `Environment` properties *before*
+refresh. That is exactly what an `EnvironmentPostProcessor` is for (registered in
+`META-INF/spring.factories`; verify the registration and ordering against Spring Boot 4
+specifically — the repo is on Boot 4.0.7):
+
+```java
+// kinotic-core/.../internal/config/KinoticRoleEnvironmentPostProcessor.java  (target shape)
+public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+    String raw = environment.getProperty("kinotic.role");
+    if (raw == null) throw new IllegalStateException(
+        "kinotic.role is required: one of " + Arrays.toString(KinoticRole.values()));
+    KinoticRole role = KinoticRole.valueOf(raw.trim().toUpperCase());   // unknown value → hard failure
+
+    Map<String, Object> derived = switch (role) { /* the table below */ };
+    // addFirst = highest precedence: profile YAML or a stray env var can never override the role,
+    // and the fail-open matchIfMissing defaults never engage because every flag is set explicitly
+    environment.getPropertySources().addFirst(new MapPropertySource("kinoticRoleDerived", derived));
+}
+```
+
+It runs after the `application-*.yml` files load (so it can read `kinotic.role` from the
+profile) but before any condition evaluates — the existing library gates need zero changes. The
+**zone allowlist never becomes a property at all**: it is consumed at runtime by
+`ServiceRegistrationBeanPostProcessor`, which asks the enum directly
+(`KinoticRole.getPublishableZones()`, a `Set<String>` field on each constant — `"app"` matching
+the leading label of `app.<org>.<app>` zones). Only the disable flags pass through the
+`Environment`, because only `@ConditionalOnProperty` needs them there.
 
 | derived value | `OS_SERVER` | `APPLICATION_GATEWAY` |
 |---|---|---|

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -125,7 +125,7 @@ override):
 - **No OS service *bean* exists in a gateway process — absence, not just authorization.**
   Service publication is bean-driven (`ServiceRegistrationBeanPostProcessor` registers every
   Spring bean implementing a `@Publish` interface), so a bean the role gates keep out of the
-  context cannot be invoked no matter what the authorizer does. The per-profile gates + the
+  context cannot be invoked no matter what the authorizer does. The `kinotic.disable*` gates + the
   Phase 3 split achieve this (see Phase 4 for the inventory and the startup allowlist that makes
   it a hard invariant instead of an emergent property), and the guards that don't depend on the
   process at all remain underneath: separate env bus (no `os-api` listener to reach), the
@@ -350,6 +350,11 @@ No new Gradle module, and **no role concept in code**. The entire per-deployment
 lives in two Spring profiles in `kinotic-server/src/main/resources`; everything they set is an
 ordinary property, visible and greppable in one file per deployment shape.
 
+**Repo convention (binding):** Spring profiles are *property bundles only* — never gate a bean
+on `@Profile` except in test contexts; it's hard to audit. Every bean/module gate is an explicit
+`kinotic.*` property read by `@ConditionalOnProperty`, exactly like the existing `disable*`
+flags. The profile YAML selects property values; the properties gate behavior.
+
 | profile sets | `application-os-server.yml` | `application-app-gateway.yml` |
 |---|---|---|
 | `kinotic.disableOsApi` (includes definition management after Phase 3) | false | **true** |
@@ -451,7 +456,7 @@ Work items in this phase:
    disabled (`WebServerProperties`); the SPA files remain in the jar — accepted single-image
    trade-off — but are never served.
 7. **No OS services published — verified inventory + startup guard.** Everything is on the
-   classpath in a single binary, so what matters is which *beans* the profile admits. The full
+   classpath in a single binary, so what matters is which *beans* the disable props admit. The full
    `@Publish` inventory and its fate in a gateway process:
 
    | Service | Zone | In a gateway process? |

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -74,11 +74,19 @@ override):
 - **Entity definitions stay environment-agnostic** (one schema, data per environment). Entity
   index naming inside each env cluster is unchanged: `kinotic_<orgId>.<appId>.<entityName>` —
   the cluster itself is the environment namespace.
-- **Entity index creation moves to a gateway-side reconciler**, driven by per-environment
-  **deployment records** in the OS cluster (written by promotion / dev auto-sync), *not* by the
-  raw set of published `EntityDefinition`s — a definition edited after promotion must not leak
-  into prod until the next promotion. Each gateway creates/updates indices and templates in its
-  own cluster to match its environment's records (lazily + on startup + periodic).
+- **ES index/mapping lifecycle is performed by the OS server directly, per environment** (owner
+  decision). The OS server holds one **admin-scoped** ES client per environment, used only
+  during promotion and dev auto-sync to create/update indices, templates, and mappings. Least
+  privilege via ES security roles — each env cluster has two users: the gateway's data user
+  (document CRUD on entity indices, no index management) and the OS server's admin user
+  (index/template/mapping management, **no document read or write**) — so the OS server can
+  shape env clusters but can never touch customer data. What is applied is recorded in
+  per-environment **deployment records** (written by promotion / dev auto-sync), *not* inferred
+  from the raw set of published `EntityDefinition`s — a definition edited after promotion must
+  not leak into prod until the next promotion, and gateways serve entity RPCs from the record's
+  snapshot. (The alternative — a gateway-side reconciler pulling desired state, keeping the OS
+  server off env clusters entirely — was considered and rejected as more moving parts for
+  little gain given the fixed, Kinotic-operated environment set.)
 - **kinotic-server stops serving the entity data plane.** `kinotic-frontend` browses entity data
   (data views) against the *selected environment's* gateway URL.
 - **Entity data is served over the STOMP/RPC path only** (`JsonEntitiesRepository` in `app_api`).
@@ -294,8 +302,9 @@ In this phase both default ON — **no behavior change**; the role mechanism (Ph
 setting them. Important nuance: **publishing an EntityDefinition no longer creates indices** on
 the definition-management side — `DefaultEntityDefinitionService.validateAndCreate` keeps
 computing/persisting `itemIndex` but the `createIndex`/`createIndexTemplate`/`createDataStream`
-calls move behind the data-plane half (Phase 5 reconciler). Deletion likewise: the OS side
-marks/deletes the definition; gateways reconcile index removal.
+calls move into the Phase 5 mapping-sync service, which applies them per target environment.
+Deletion likewise: deleting/withdrawing a definition takes effect in an env cluster through the
+same sync path.
 
 ## Phase 4 — the `APPLICATION_GATEWAY` role (single binary, Spring profiles)
 
@@ -401,11 +410,12 @@ Work items in this phase:
    bug allowing an `os_api` send, there is no `os_api` listener on the environment bus — the
    send has nothing to reach.
 
-## Phase 5 — deployment records + entity index reconciler (gateway side)
+## Phase 5 — deployment records + per-environment mapping sync (OS side)
 
 Desired state per environment is a **deployment record**, not the raw definition set — this is
 what makes promotion (Phase 9) possible: prod's indices reflect the last *promoted* state, never
-a definition edit made after promotion.
+a definition edit made after promotion. The OS server applies that state to env clusters
+directly, synchronously, through admin-scoped clients.
 
 New domain object in kinotic-domain (`kinotic_application_deployment` index + migration SQL):
 
@@ -425,23 +435,32 @@ public class ApplicationDeployment implements ApplicationScoped<String> {
 Whether the record embeds full definition snapshots (shown) or references immutable definition
 versions is open question 8 — resolve it with Navid before implementing this phase.
 
+- **Per-environment admin clients (OS role only).** Properties map the fixed environment set to
+  cluster connections — `kinotic.environmentClusters.<envId>.{elastic-connections, username,
+  password}` — and a bean (e.g. `EnvironmentClusterClients`, `Map<String, CrudServiceTemplate>`
+  built with the Phase 2 factory method) exposes one admin client per environment. Gated to the
+  `OS_SERVER` role. A publish/promotion targeting an environment with no configured cluster
+  fails fast with a clear message.
+- **Mapping sync service (OS role).** The index/template/create/update logic Phase 3 lifted out
+  of `DefaultEntityDefinitionService` (mappings via `entityDefinitionConversionService`,
+  data-stream vs index decision by `isStream()`) becomes a service invoked with a *target
+  environment's* template: apply a deployment record's definitions to that env cluster —
+  create missing indices/templates, update mappings, remove indices for withdrawn definitions.
+  Idempotent (ES create-index races return `resource_already_exists_exception` — treat as
+  success); errors surface synchronously to the caller (publish flow or promotion job), which
+  sets the record `status`.
 - **Dev auto-sync (assumed, open question)**: publishing an `EntityDefinition` upserts the
-  `development` deployment record for its application, so the dev env tracks publishes
-  continuously through the same mechanism promotion uses.
-- **Reconciler (gateway role)**: on startup + a periodic Vert.x timer, load this environment's
-  deployment records from the OS cluster and make the env cluster match — create missing
-  indices/templates, apply mapping updates, remove indices for withdrawn definitions. Reuse the
-  exact create logic Phase 3 lifted out of `DefaultEntityDefinitionService` (mappings via
-  `entityDefinitionConversionService`, data-stream vs index decision by `isStream()`).
-  `EntityServiceCache` also verifies-on-miss before constructing a `DefaultEntityService`, and
-  must serve entity RPCs from the **record's** definitions, not the live `kinotic_entity_definition`
-  docs, so wire schema and index mappings can't drift apart within an environment.
-- The reconciler reports per-record sync status back onto the deployment record (`status`,
-  plus error detail on failure) — the gateway already has scoped OS-cluster write access; add
-  this index to its ES role. Promotion (Phase 9) awaits this status.
-- Make creation idempotent and concurrency-safe across gateway replicas (ES create-index races
-  return `resource_already_exists_exception` — treat as success; last-writer-wins on status is
-  acceptable).
+  `development` deployment record for its application and applies the mappings to the dev
+  cluster in the same operation — dev goes through the same record + sync path promotion uses,
+  just triggered by publish.
+- **Gateway side**: `EntityServiceCache` serves entity RPCs from its environment's **deployment
+  record** definitions, not the live `kinotic_entity_definition` docs — wire schema and index
+  mappings must come from the same snapshot or they drift within an environment. A cache miss
+  with no deployment record (or a missing index) is an error to surface, not something the
+  gateway repairs — the OS server owns index lifecycle; gateways never create indices.
+- **ES least privilege** (per env cluster): gateway data user — document CRUD on entity
+  indices, no index management; OS admin user — index/template/mapping management, no document
+  read/write. Wire these as distinct users in the ECK/compose setups (Phase 8).
 - **Stranded os_api data service.** `MigrationService` is `os_api`-zoned (published by
   kinotic-server, callable by the frontend via `@kinotic-ai/os-api`) but operates on **entity
   data**, which now lives only in env clusters that kinotic-server cannot reach. It doesn't touch
@@ -500,8 +519,10 @@ One image (`kinoticai/kinotic-server`) everywhere; the role/profile decides what
 - **Helm**: parameterize the existing `deployment/helm/kinotic` chart by role (profile +
   `KINOTIC_APPLICATIONGATEWAY_*` env vars for gateway releases) rather than cloning a second
   chart — one gateway release per environment via values overlays. One eck-stack release per
-  environment. NetworkPolicy: env ES reachable only from its gateway namespace, OS ES reachable
-  from kinotic + gateway namespaces.
+  environment. NetworkPolicy: env ES reachable from its gateway namespace (data user) and the
+  kinotic namespace (OS admin user, index-management-only ES role); OS ES reachable from kinotic
+  + gateway namespaces. Provision the two distinct ES users per env cluster (Phase 5 least
+  privilege) in the ECK/compose setups.
 - **Cutover**: flip the `OS_SERVER` role mapping to `disableEntityDataPlane=true` and drop
   `app_api` from its zone allowlist (the one-line code changes flagged in Phase 4), once the
   frontend (Phase 7) talks to gateways for entity data. From here the OS bus carries no entity
@@ -519,7 +540,7 @@ One image (`kinoticai/kinotic-server`) everywhere; the role/profile decides what
 
 A Kinotic-managed, predefined flow that moves an application into a target environment. Runs
 entirely in the `OS_SERVER` role (it needs kinotic-github, the orchestrator, and OS data — all
-OS-role modules). Builds on Phase 5 (deployment records/reconciler) and Phase 6 (env-scoped
+OS-role modules). Builds on Phase 5 (deployment records + mapping sync) and Phase 6 (env-scoped
 workloads).
 
 **Service surface**: `PromotionService` (`@Publish`, zone `os_api`) in kinotic-os-api —
@@ -548,9 +569,10 @@ executing the steps sequentially is acceptable — do not build a *third* flow m
    (`GitHubProjectRepoService` / the GitHub client it wraps); `Project` already carries
    `repoFullName`/`repoDefaultBranch`.
 2. **Definition sync** — snapshot the application's current `EntityDefinition`s into the target
-   environment's `ApplicationDeployment` record (Phase 5). The target gateway's reconciler
-   applies the mappings; the job awaits the record's `status` turning `ACTIVE` (or surfaces the
-   failure detail). No direct OS-server → env-cluster ES connection is ever needed.
+   environment's `ApplicationDeployment` record and apply the mappings to the target env
+   cluster via the Phase 5 mapping-sync service (the env's admin-scoped client). Synchronous:
+   mapping conflicts and cluster errors fail this step directly with the ES error detail, and
+   the step sets the record `status` (`ACTIVE` on success, `FAILED` with detail otherwise).
 3. **Artifact deployment** — create/update the application's `Workload`s with
    `environmentId = target` from the promoted artifacts, via `WorkloadOrchestrationService`
    (Phase 6). What an "artifact" is (image reference, who built it, where it's recorded) is
@@ -571,9 +593,10 @@ selector); regenerate `@kinotic-ai/os-api` for `PromotionService`.
 Follow the repo rule: behavioral tests through real infrastructure over mocked units.
 
 - **Two-cluster integration test** (Testcontainers, two ES containers): publish an
-  `EntityDefinition` via the definition-management path against cluster A, run the data plane +
-  reconciler against cluster B, assert the entity index exists only in B and `kinotic_*` domain
-  indices only in A, then exercise `JsonEntitiesRepository` CRUD end-to-end.
+  `EntityDefinition` via the definition-management path against OS cluster A with the
+  environment cluster B configured in `kinotic.environmentClusters`; assert the mapping-sync
+  service creates the entity index only in B and `kinotic_*` domain indices exist only in A,
+  then exercise `JsonEntitiesRepository` CRUD (data plane pointed at B) end-to-end.
 - **Gateway-role boot test**: start `KinoticServerApplication` with the `app-gateway` profile,
   assert: the `ServiceRegistry` contains **zero** registrations in `os_api`/`system` zones (the
   no-OS-services invariant), os_api CRIs are rejected by the authorizer for an application

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -364,8 +364,8 @@ flags. The profile YAML selects property values; the properties gate behavior.
 |---|---|---|
 | `kinotic.disableOsApi` (includes definition management after Phase 3) | false | **true** |
 | `kinotic.disableGithub` | false | **true** |
-| `kinotic.disablePersistence` (= the data plane after Phase 3) | false *(flips to true at the Phase 8 cutover)* | false |
-| `kinotic.zones` (publish guard ∩ authorizer) | `os-api`, `system` (+ `app-api` until the Phase 8 cutover) | `app-api`, `app` |
+| `kinotic.disablePersistence` (= the data plane after Phase 3) | false *(flips to true at the cloud cutover — companion plan)* | false |
+| `kinotic.zones` (publish guard ∩ authorizer) | `os-api`, `system` (+ `app-api` until the cloud cutover — companion plan) | `app-api`, `app` |
 
 ```yaml
 # kinotic-server/src/main/resources/application-app-gateway.yml  (new profile — flags, allowlist,
@@ -545,7 +545,8 @@ versions is open question 8 — resolve it with Navid before implementing this p
   gateway repairs — the OS server owns index lifecycle; gateways never create indices.
 - **ES least privilege** (per env cluster): gateway data user — document CRUD on entity
   indices, no index management; OS admin user — index/template/mapping management, no document
-  read/write. Wire these as distinct users in the ECK/compose setups (Phase 8).
+  read/write. Wire these as distinct users in the cloud ES clusters (companion cloud-deployment
+  plan); the local single-ES compose does not need them.
 - **Stranded os-api data service.** `MigrationService` is `os-api`-zoned (published by
   kinotic-server, callable by the frontend via `@kinotic-ai/os-api`) but operates on **entity
   data**, which now lives only in env clusters that kinotic-server cannot reach. It doesn't touch
@@ -593,37 +594,33 @@ versions is open question 8 — resolve it with Navid before implementing this p
 - `@kinotic-ai/persistence` itself is unchanged (same `app-api` zone, same service CRI) — it just
   gets pointed at a gateway instead of kinotic-server.
 
-## Phase 8 — deployment, cutover, local dev + docs
+## Phase 8 — local compose, local dev + docs
 
-One image (`kinoticai/kinotic-server`) everywhere; the active profile decides what a container is.
+Local is deliberately simple: **only the `development` environment exists locally, and one
+kinotic-server runs everything.** The cloud deployment (per-env clusters, gateway releases,
+Terraform, and the cutover) is captured in the companion plan
+`docs/future-prompts/Multi-environment cloud deployment.md` — it is blocked on infra budget and
+is NOT part of this plan's phases.
 
-- **Compose** (`deployment/docker-compose/`): second ES service (env cluster) +
-  `compose.kinotic-app-gateway.yml` running the *same* kinotic-server image with
-  `SPRING_PROFILES_ACTIVE` including `app-gateway` (env=`development`, distinct STOMP/HTTP
-  ports). `compose.yml` wires: OS ES + env ES + migration + kinotic-server + one gateway.
-- **Helm/Terraform**: parameterize the existing `deployment/helm/kinotic` chart by profile
-  (profile + `KINOTIC_APPLICATIONGATEWAY_*` env vars for gateway releases) rather than cloning a
-  second chart — one gateway release per environment via values overlays. One eck-stack release
-  per environment. **Ignite bus isolation happens here, not in app config**: each release gets
-  its own Ignite discovery Service (the chart already templates one — `kinotic.cluster.*`
-  values), and Terraform places prod on a dedicated node pool or a separate k8s cluster;
-  membership is whatever each discovery Service selects. NetworkPolicy: env ES reachable from
-  its gateway namespace (data user) and the kinotic namespace (OS admin user,
-  index-management-only ES role); OS ES reachable from kinotic + gateway namespaces. Provision
-  the two distinct ES users per env cluster (Phase 5 least privilege) in the ECK/compose
-  setups.
-- **Cutover**: set `disablePersistence: true` and drop `app-api` from `kinotic.zones`
-  in `application-os-server.yml` (flagged in Phase 4), once the frontend
-  (Phase 7) talks to gateways for entity data. From here the OS bus carries no entity data
-  plane.
-- **Local dev without containers**: document running the same app twice from the IDE —
-  `KinoticServerApplication` with the default (OS) profile and again with `app-gateway` — against
-  one local ES playing both roles (both connection property sets default to `localhost:9200`).
-  That keeps a one-ES laptop workflow.
-- **Docs**: `website/content/**` — grep for `app-api`, `58503`, login routes, and anything
-  describing "the server" as the single endpoint; reconcile every hit. Any pages advertising the
-  GraphQL/OpenAPI/MCP HTTP endpoints describe dropped functionality — flag them to Navid (remove
-  vs mark unsupported) rather than silently leaving them. Add an environments concept page.
+- **Compose** (`deployment/docker-compose/`): stays single-ES, single-server. The one
+  kinotic-server runs with **no deployment profile** — the base defaults (all modules enabled,
+  `kinotic.zones` unset = unrestricted) *are* the all-in-one shape. The only addition:
+  `kinotic.environmentClusters.development` points at the same local ES, so dev auto-sync and
+  the deployment-record path work locally against one cluster playing both roles.
+- **Local dev without containers**: same picture from the IDE — one `KinoticServerApplication`,
+  no deployment profile, one local ES at `localhost:9200` serving as both OS and dev-env
+  cluster (both connection property sets default there). Running a second process with the
+  `app-gateway` profile is possible for gateway-specific work but is not the daily workflow.
+- **Docs**: `website/content/**` — grep for `app-api`, `58503`, login routes, and
+  anything describing "the server" as the single endpoint; reconcile every hit. Any pages
+  advertising the GraphQL/OpenAPI/MCP HTTP endpoints describe dropped functionality — flag them
+  to Navid (remove vs mark unsupported) rather than silently leaving them. Add an environments
+  concept page.
+
+The `application-os-server.yml` / `application-app-gateway.yml` profiles built in Phase 4 are
+exercised locally only by tests (the gateway boot test, the two-cluster and promotion
+integration tests run on Testcontainers, not compose) until the cloud deployment activates
+them.
 
 ## Phase 9 — Promotion (Develop → Prod)
 
@@ -702,8 +699,10 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
   assertion is the whole point of deployment records. Git steps against a test repo or stubbed
   at the GitHub client boundary (the flow logic, not GitHub, is under test).
 - **Existing e2e** (`compose.kinotic-e2e-test.yml`, `kinotic-js/workspace/packages/e2e-tests`):
-  extend the compose topology; the JS SDK tests should pass unmodified against a gateway — that
-  is the wire-compat check.
+  the compose topology stays all-in-one (Phase 8), so the suite must keep passing unmodified
+  throughout — that is the wire-compat check for every phase. JS-SDK-against-a-gateway coverage
+  comes from a Testcontainers-based run of the gateway profile (or waits for the cloud
+  deployment) — don't add a second compose stack for it.
 
 ## Decided (owner answers — no longer open)
 

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -32,14 +32,15 @@ applications:
 ```
                         ┌────────────────────────────────────────────┐
  kinotic-frontend ────► │ kinotic-server, profile "os-server"         │──► OS ES cluster
- kinotic-cli      ────► │ (Ignite cluster "os"): os-api/system zones, │    (kinotic_* domain
+ kinotic-cli      ────► │ (own Ignite cluster): os-api/system zones,  │    (kinotic_* domain
  VmManagers (STOMP)───► │ OIDC login, GitHub, orchestrator,           │     indices)
                         │ entity-definition mgmt                      │
                         └────────────────────────────────────────────┘
                                                                    ▲ read/write OS metadata
  customer UI  ─────────► ┌──────────────────────────────────────────┴─┐
  customer microservices─►│ kinotic-server, profile "app-gateway"      │──► env ES cluster
- (STOMP, per env)        │ (per env, Ignite cluster "env-<id>"):      │    (entity data only)
+ (STOMP, per env)        │ (per env, own Ignite cluster via k8s       │    (entity data only)
+                         │ Service discovery — Terraform-scoped):     │
                          │ app login, app.<org>.<app> + app-api       │
                          │ zones, entity data plane (RPC over STOMP)  │
                          └────────────────────────────────────────────┘
@@ -60,7 +61,11 @@ override):
   a *record* written by promotion, not an implicit property of existing (see Phase 9). The
   development environment is assumed to sync continuously on publish (open question).
 - **Event-bus topology: one Ignite/Vert.x cluster per environment**, separate from the
-  kinotic-server cluster. Gateways of the same environment cluster together (so a UI on replica
+  kinotic-server cluster. Isolation is **infrastructure-level, not app config** (owner
+  decision): Ignite discovers peers via Kubernetes-topology discovery resolving to a k8s
+  Service, and Terraform gives each environment its own discovery Service (prod: a dedicated
+  node pool or a separate k8s cluster) — membership is whatever the Service selects, so no
+  cluster naming in code. Gateways of the same environment cluster together (so a UI on replica
   A reaches a microservice on replica B). Because each environment has its own bus, the existing
   zone grammar (`app.<orgId>.<appId>`, `app-api`) is unchanged — no collisions between a dev and
   prod instance of the same app, and the `APP_API_ZONE` CRIs built by `@kinotic-ai/persistence`
@@ -445,11 +450,16 @@ Work items in this phase:
    token must not work against prod). Organization-participant tokens are minted at the OS
    server and carry no env claim — the gateway accepts them (their authorization is already
    narrowed to `app-api.**` by item 1); the OS server accepts only claimless tokens.
-4. **Ignite cluster identity.** A gateway deployment joins Ignite cluster
-   `env-<environmentId>`; verify how `KinoticIgniteConfig` names/discovers the cluster
-   (`kinotic.ignite.*`) and ensure two clusters on one network can't merge. Also audit what the
-   gateway actually uses Ignite for (session store, eventbus, caches in
-   `KinoticIgniteConfigCaches`) — anything OS-specific should not be created on env clusters.
+4. **Ignite bus isolation is infrastructure-level — no app-side cluster naming.** Per-env bus
+   separation comes from the Terraform deployment: Ignite uses Kubernetes-topology discovery
+   resolving to a k8s Service, so cluster membership is exactly the pods that Service selects —
+   each environment gets its own discovery Service (and prod gets a dedicated node pool or a
+   separate k8s cluster). Do not add cluster-name/merge-prevention machinery in code. What
+   remains app-side: audit what the gateway actually uses Ignite for (session store, eventbus,
+   caches in `KinoticIgniteConfigCaches`) — anything OS-specific should not be created on env
+   clusters — and for local dev/compose, running os-server + app-gateway on one machine must
+   not form one cluster (use the existing `kinotic.ignite.*` discovery settings per process, or
+   `kinotic.disableClustering` for single-replica local runs).
 5. **No entity HTTP surface.** The GraphQL/OpenAPI/MCP code stays dormant (see design
    decisions) — the gateway's only entity-data surface is the `app-api` RPC path.
 6. **No SPA in the gateway.** The app-gateway profile sets the web-server verticle
@@ -591,13 +601,17 @@ One image (`kinoticai/kinotic-server`) everywhere; the active profile decides wh
   `compose.kinotic-app-gateway.yml` running the *same* kinotic-server image with
   `SPRING_PROFILES_ACTIVE` including `app-gateway` (env=`development`, distinct STOMP/HTTP
   ports). `compose.yml` wires: OS ES + env ES + migration + kinotic-server + one gateway.
-- **Helm**: parameterize the existing `deployment/helm/kinotic` chart by role (profile +
-  `KINOTIC_APPLICATIONGATEWAY_*` env vars for gateway releases) rather than cloning a second
-  chart — one gateway release per environment via values overlays. One eck-stack release per
-  environment. NetworkPolicy: env ES reachable from its gateway namespace (data user) and the
-  kinotic namespace (OS admin user, index-management-only ES role); OS ES reachable from kinotic
-  + gateway namespaces. Provision the two distinct ES users per env cluster (Phase 5 least
-  privilege) in the ECK/compose setups.
+- **Helm/Terraform**: parameterize the existing `deployment/helm/kinotic` chart by profile
+  (profile + `KINOTIC_APPLICATIONGATEWAY_*` env vars for gateway releases) rather than cloning a
+  second chart — one gateway release per environment via values overlays. One eck-stack release
+  per environment. **Ignite bus isolation happens here, not in app config**: each release gets
+  its own Ignite discovery Service (the chart already templates one — `kinotic.cluster.*`
+  values), and Terraform places prod on a dedicated node pool or a separate k8s cluster;
+  membership is whatever each discovery Service selects. NetworkPolicy: env ES reachable from
+  its gateway namespace (data user) and the kinotic namespace (OS admin user,
+  index-management-only ES role); OS ES reachable from kinotic + gateway namespaces. Provision
+  the two distinct ES users per env cluster (Phase 5 least privilege) in the ECK/compose
+  setups.
 - **Cutover**: set `disablePersistence: true` and drop `app-api` from `kinotic.zones`
   in `application-os-server.yml` (flagged in Phase 4), once the frontend
   (Phase 7) talks to gateways for entity data. From here the OS bus carries no entity data

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -20,10 +20,10 @@ applications:
    (organizations, applications, projects, IAM, entity *definitions*, workloads, …).
 2. **One Elasticsearch cluster per environment** holds customer entity *data* only.
 3. **One application-gateway deployment per environment** — the *same* `kinotic-server` binary
-   running with `kinotic.role: APPLICATION_GATEWAY` (a Spring profile per role; **no new Gradle
-   module**). It is the edge for customer applications: UI ↔ backend-microservice RPC, and
-   entity-data reads/writes for that environment.
-4. **One `kinotic-server` cluster in the `OS_SERVER` role** remains the single edge for
+   running with the `app-gateway` Spring profile (**no new Gradle module, no role concept in
+   code** — the profile YAML is the whole difference). It is the edge for customer applications:
+   UI ↔ backend-microservice RPC, and entity-data reads/writes for that environment.
+4. **One `kinotic-server` cluster with the `os-server` profile** remains the single edge for
    `kinotic-frontend` — all OS configuration (orgs, apps, projects, members, entity definitions,
    environments) goes there.
 
@@ -31,20 +31,20 @@ applications:
 
 ```
                         ┌────────────────────────────────────────────┐
- kinotic-frontend ────► │ kinotic-server, role OS_SERVER              │──► OS ES cluster
+ kinotic-frontend ────► │ kinotic-server, profile "os-server"         │──► OS ES cluster
  kinotic-cli      ────► │ (Ignite cluster "os"): os-api/system zones, │    (kinotic_* domain
  VmManagers (STOMP)───► │ OIDC login, GitHub, orchestrator,           │     indices)
                         │ entity-definition mgmt                      │
                         └────────────────────────────────────────────┘
                                                                    ▲ read/write OS metadata
  customer UI  ─────────► ┌──────────────────────────────────────────┴─┐
- customer microservices─►│ kinotic-server, role APPLICATION_GATEWAY   │──► env ES cluster
+ customer microservices─►│ kinotic-server, profile "app-gateway"      │──► env ES cluster
  (STOMP, per env)        │ (per env, Ignite cluster "env-<id>"):      │    (entity data only)
                          │ app login, app.<org>.<app> + app-api       │
                          │ zones, entity data plane (RPC over STOMP)  │
                          └────────────────────────────────────────────┘
 
-One container image; the role decides what a process is.
+One container image; the active profile decides what a process is.
 ```
 
 Design decisions baked into this plan (each has an "open questions" entry if Navid may want to
@@ -107,23 +107,24 @@ override):
   stereotypes) so `DataInsightsService` is published nowhere; keep the classes. Its internals
   are already mostly commented out pending Spring AI 2 (`DataInsightsConfiguration`'s
   `ChatClient` bean is disabled), so this completes an unwiring that is half-done today.
-- **Single binary, two roles, explicit profiles** (owner decision). Every library module already
-  has a whole-module gate (`kinotic.disableOsApi`, `disableGithub`, `disablePersistence`,
-  `disableApiGateway`, `disableDomain` — see current state), so role composition is the
-  established idiom. Two profiles in `kinotic-server/src/main/resources` —
-  `application-os-server.yml` and `application-app-gateway.yml` — each set `kinotic.role` plus
-  the disable flags **explicitly in YAML** (no derivation mechanism, no hidden property
-  sources). `kinotic.role` is a required (`@NotNull`) enum — a roleless boot fails validation —
-  consumed at runtime by the publishable-zone allowlist (a field on the enum constants), role
-  conditions on beans, and the JWT env claim. The **allowlist startup guard is what makes this
-  safe**: any drift — a forgotten flag on a new module, a stray env var override — that lets an
-  `os-api`/`system` service register in a gateway kills the process at boot. Accepted
-  trade-offs of one image: the gateway jar carries the OS admin SPA and OS module bytecode
-  (never instantiated); image size is not optimized per role.
+- **Single binary, two profiles, no role concept in code** (owner decision). Every library
+  module already has a whole-module gate (`kinotic.disableOsApi`, `disableGithub`,
+  `disablePersistence`, `disableApiGateway`, `disableDomain` — see current state), so
+  composition-by-config is the established idiom. Two profiles in
+  `kinotic-server/src/main/resources` — `application-os-server.yml` and
+  `application-app-gateway.yml` — hold the *entire* per-deployment difference **explicitly in
+  YAML**: the disable flags and the publishable-zone allowlist
+  (`kinotic.publishableZones`). Beans that differ per deployment are selected with plain
+  `@Profile`; JWT env-claim behavior keys off whether `kinotic.applicationGateway.environmentId`
+  is set. No enum, no derivation, nothing spread through code. The **allowlist startup guard is
+  what makes this safe**: any drift — a forgotten flag on a new module, a stray env var
+  override — that lets an `os-api`/`system` service register in a gateway kills the process at
+  boot. Accepted trade-offs of one image: the gateway jar carries the OS admin SPA and OS
+  module bytecode (never instantiated); image size is not optimized per deployment shape.
 - **No OS service *bean* exists in a gateway process — absence, not just authorization.**
   Service publication is bean-driven (`ServiceRegistrationBeanPostProcessor` registers every
   Spring bean implementing a `@Publish` interface), so a bean the role gates keep out of the
-  context cannot be invoked no matter what the authorizer does. The per-role profile gates + the
+  context cannot be invoked no matter what the authorizer does. The per-profile gates + the
   Phase 3 split achieve this (see Phase 4 for the inventory and the startup allowlist that makes
   it a hard invariant instead of an emergent property), and the guards that don't depend on the
   process at all remain underneath: separate env bus (no `os-api` listener to reach), the
@@ -201,8 +202,9 @@ module depends on it, so `WorkloadOrchestrationService` is not currently wired i
 
 **Module gates:** every library module is wholly gated by a `kinotic.disable*` property on its
 `@Import`ed library class — the seams role composition builds on. Note the fail-open default
-(`matchIfMissing = true`: a *missing* flag means *enabled*), which is why the role mechanism
-(Phase 4) must set these explicitly rather than relying on profile YAML remembering to:
+(`matchIfMissing = true`: a *missing* flag means *enabled*), which is why the deployment
+profiles (Phase 4) set every flag explicitly and the publishable-zone guard backstops a
+forgotten one:
 
 ```java
 // kinotic-os-api/src/main/java/org/kinotic/os/KinoticOsApiLibrary.java:14
@@ -341,59 +343,27 @@ currently binds `` `${OS_API_ZONE}.org.kinotic.persistence.api.services.EntityDe
 Server and JS ship together at this phase boundary. Preserve authorship comments verbatim on
 every moved file.
 
-## Phase 4 — the `APPLICATION_GATEWAY` role (single binary, Spring profiles)
+## Phase 4 — the `app-gateway` profile (single binary, pure YAML)
 
-No new Gradle module. The role mechanism lives in kinotic-core; the role's runtime shape is a
-Spring profile in `kinotic-server/src/main/resources`.
-
-**The role mechanism.** A required enum on the `kinotic` prefix:
-
-```java
-// kinotic-core/.../api/config/KinoticRole.java  (new file)
-public enum KinoticRole { OS_SERVER, APPLICATION_GATEWAY }
-```
-
-`kinotic.role` has **no default** — declare it `@NotNull` on `KinoticProperties` so a roleless
-boot fails property validation with a clear message (the codebase already validates properties
-this way; verify `KinoticProperties` participates in validation the same way `DomainProperties`
-does). **No flag derivation, no `EnvironmentPostProcessor`** (owner decision — explicit YAML
-over hidden property sources): each role is a Spring profile in
-`kinotic-server/src/main/resources` that sets the role *and* the disable flags visibly, per the
-table below.
-
-The role property's runtime consumers:
-- **Publishable-zone allowlist** — a `Set<String>` field on each `KinoticRole` constant, read by
-  `ServiceRegistrationBeanPostProcessor` at registration time (`"app"` matching the leading
-  label of `app.<org>.<app>` zones). Never a property; nothing evaluates it via the
-  `Environment`.
-- **Zone policy + route gating** — plain
-  `@ConditionalOnProperty(name = "kinotic.role", havingValue = "...")` on the policy beans and
-  role-specific `SuppliesGatewayRoutes` beans; conditions can check the role directly, no
-  derived flags needed.
-- **JWT environment claim** behavior (item 3 below).
-
-Accepted trade, stated plainly: profile YAML can drift — a *new* module gate added later and
-forgotten in a profile is silently ON (`matchIfMissing = true`). The allowlist guard and the
-gateway-role boot test exist precisely to convert that drift into a **startup failure** (the
-new module's `os-api`/`system` services register → allowlist violation → the process dies
-loudly). The same guard neutralizes a stray `KINOTIC_DISABLE*` env var overriding profile YAML.
+No new Gradle module, and **no role concept in code**. The entire per-deployment difference
+lives in two Spring profiles in `kinotic-server/src/main/resources`; everything they set is an
+ordinary property, visible and greppable in one file per deployment shape.
 
 | profile sets | `application-os-server.yml` | `application-app-gateway.yml` |
 |---|---|---|
-| `kinotic.role` | `OS_SERVER` | `APPLICATION_GATEWAY` |
 | `kinotic.disableOsApi` (includes definition management after Phase 3) | false | **true** |
 | `kinotic.disableGithub` | false | **true** |
 | `kinotic.disablePersistence` (= the data plane after Phase 3) | false *(flips to true at the Phase 8 cutover)* | false |
-| publishable-zone allowlist *(in code, on the enum — not YAML)* | `os-api`, `system` (+ `app-api` until the Phase 8 cutover) | `app-api`, `app` |
+| `kinotic.publishableZones` | `os-api`, `system` (+ `app-api` until the Phase 8 cutover) | `app-api`, `app` |
 
 ```yaml
-# kinotic-server/src/main/resources/application-app-gateway.yml  (new profile — role, flags, and
-# per-deployment data, all visible in one place)
+# kinotic-server/src/main/resources/application-app-gateway.yml  (new profile — flags, allowlist,
+# and per-deployment data, all visible in one place)
 kinotic:
-  role: APPLICATION_GATEWAY
   disableOsApi: true
   disableGithub: true
   disablePersistence: false
+  publishableZones: [app-api, app]
   applicationGateway:
     environmentId: ${KINOTIC_ENVIRONMENT_ID}
     elastic-connections:
@@ -402,8 +372,28 @@ kinotic:
         scheme: http
 ```
 
-`application-os-server.yml` mirrors it with the `OS_SERVER` values; existing deployments add the
-new profile to their active set (e.g. `production,os-server`).
+`application-os-server.yml` mirrors it with the OS values; existing deployments add the new
+profile to their active set (e.g. `production,os-server`).
+
+The three mechanisms that consume this configuration:
+
+- **`kinotic.publishableZones`** (`List<String>` on `KinoticProperties`): when set,
+  `ServiceRegistrationBeanPostProcessor` fails startup for any `@Publish` registration whose
+  zone is outside the list (`app` matching the leading label of `app.<org>.<app>` zones), and
+  for **un-zoned** registrations. When unset, registration is unrestricted — today's behavior,
+  so plain dev/test contexts keep working; both deployment profiles always set it.
+- **`@Profile` on deployment-specific beans**: the zone-policy bean and the role-specific route
+  suppliers are selected by the active profile (`@Profile("app-gateway")` /
+  `@Profile("os-server")`) — standard Spring, no new mechanism.
+- **`kinotic.applicationGateway.environmentId` presence** drives the JWT env-claim behavior
+  (item 3 below): set ⇒ this deployment is an environment gateway.
+
+Accepted trade, stated plainly: profile YAML can drift — a *new* module gate added later and
+forgotten in a profile is silently ON (`matchIfMissing = true`), the same misconfiguration risk
+every env-specific property already carries. The allowlist guard and the gateway boot test
+exist precisely to convert the dangerous case into a **startup failure** (the new module's
+`os-api`/`system` services register → allowlist violation → the process dies loudly). The same
+guard neutralizes a stray `KINOTIC_DISABLE*` env var overriding profile YAML.
 
 `ApplicationGatewayProperties` (`environmentId`, env-cluster `elasticConnections`/credentials)
 binds under `kinotic.applicationGateway` and lives in kinotic-core next to `KinoticProperties`
@@ -417,55 +407,56 @@ path, replacing Phase 2's alias; the base `application.yml` defaults those conne
 Work items in this phase:
 
 1. **Zone policy per role.** `StompAuthorizerFactory` currently encodes one global policy. Make
-   the policy a bean selected by role: `APPLICATION_GATEWAY` — application participants keep
+   the policy a bean selected by profile: `app-gateway` — application participants keep
    today's rules (`app-api.**` + `app.<org>.<app>.**`), organization participants (frontend
    browsing data) get `app-api.**` send only, no participant reaches `os-api`/`system`;
-   `OS_SERVER` — conversely drops `app-api` for application participants (after the Phase 8
+   `os-server` — conversely drops `app-api` for application participants (after the Phase 8
    cutover; they have no business on the OS bus). Don't fork the class — check how
    `StompAuthorizerFactory` is constructed and pick the smallest seam.
 2. **Auth surface per role.** `SuppliesGatewayRoutes` beans are mounted by discovery
    (`ApiGatewayVertcleFactory` iterates all beans), so the REST surface follows which route
    beans exist in the context. GitHub routes disappear via the profile's `disableGithub`.
-   The kinotic-domain handlers need role gates: gateway role mounts app-scope routes only
+   The kinotic-domain handlers need profile gates: the gateway mounts app-scope routes only
    (`ApplicationLoginHandler`, `SessionEndpointHandler`, invite acceptance if app-scoped); org
-   login, signup, and CLI device-login handlers are OS_SERVER-only. Verify which module
+   login, signup, and CLI device-login handlers are os-server-only. Verify which module
    contributes each `SuppliesGatewayRoutes` bean and gate accordingly.
 3. **JWT environment binding.** `KinoticJwtIssuer` (kinotic-domain) mints platform JWTs; signing
-   keys come from `platformSecrets` shared across deployments. In the gateway role, add an
+   keys come from `platformSecrets` shared across deployments. When
+   `kinotic.applicationGateway.environmentId` is set, add an
    `environmentId` claim at mint and reject tokens whose claim doesn't match this deployment's
    `environmentId` in the `KinoticSecurityService` validation path (a dev token must not work
-   against prod). The OS role accepts only tokens without the claim (or ignores — decide during
+   against prod). The OS server accepts only tokens without the claim (or ignores — decide during
    implementation and document with the auth docs).
 4. **Ignite cluster identity.** A gateway deployment joins Ignite cluster
    `env-<environmentId>`; verify how `KinoticIgniteConfig` names/discovers the cluster
    (`kinotic.ignite.*`) and ensure two clusters on one network can't merge. Also audit what the
-   gateway role actually uses Ignite for (session store, eventbus, caches in
+   gateway actually uses Ignite for (session store, eventbus, caches in
    `KinoticIgniteConfigCaches`) — anything OS-specific should not be created on env clusters.
 5. **No entity HTTP surface.** The GraphQL/OpenAPI/MCP code stays dormant (see design
-   decisions) — the gateway role's only entity-data surface is the `app-api` RPC path.
-6. **No SPA in the gateway role.** The app-gateway profile sets the web-server verticle
+   decisions) — the gateway's only entity-data surface is the `app-api` RPC path.
+6. **No SPA in the gateway.** The app-gateway profile sets the web-server verticle
    disabled (`WebServerProperties`); the SPA files remain in the jar — accepted single-image
    trade-off — but are never served.
 7. **No OS services published — verified inventory + startup guard.** Everything is on the
-   classpath in a single binary, so what matters is which *beans* the role admits. The full
-   `@Publish` inventory and its fate in the gateway role:
+   classpath in a single binary, so what matters is which *beans* the profile admits. The full
+   `@Publish` inventory and its fate in a gateway process:
 
    | Service | Zone | In a gateway process? |
    |---|---|---|
    | `JsonEntitiesRepository`, `AdminJsonEntitiesRepository`, `NamedQueriesService` (persistence — its entire published surface after Phase 3) | `app-api` (explicit `@Zone`) | yes — the data plane |
    | `ApplicationService`, `ProjectService`, `MemberService`, `LogService`/`LogManager`, `DeviceApprovalService`, `InviteEmailTemplateService`, `KinoticClusterInfoService`, `EntityDefinitionService`/`NamedQueriesDefinitionService`/`MigrationService` (moved in Phase 3), `EnvironmentService` (Phase 1), `PromotionService` (Phase 9) — all os-api | `os-api` | no — `disableOsApi` (app-gateway profile) gates the whole `KinoticOsApiLibrary` |
    | `GitHubAppInstallationService`, `GitHubWebhookEventService`, `GitHubProjectRepoService` (github) | `os-api` | no — `disableGithub` (app-gateway profile) |
-   | `WorkloadOrchestrationService`, `VmNodeOrchestrationService` (orchestrator, once Phase 6 wires it in) | `system` (`@Zone` in `api/workload/package-info.java`) | no — verify the orchestrator library has (or add) the same `disable*` gate, driven by the role |
+   | `WorkloadOrchestrationService`, `VmNodeOrchestrationService` (orchestrator, once Phase 6 wires it in) | `system` (`@Zone` in `api/workload/package-info.java`) | no — verify the orchestrator library has (or add) the same `disable*` gate, set in the deployment profiles |
    | `DataInsightsService` | `os-api` (`insights/package-info.java`) | published nowhere — dropped from scope (see design decisions) |
 
    `kinotic-domain` publishes **nothing** (`LocalAuthenticationService` is deliberately not
    `@Publish` — raw passwords never travel over RPC). The **publishable-zone allowlist** turns
    this table from configuration into an invariant: `ServiceRegistrationBeanPostProcessor`
-   (kinotic-core) checks every registration's single `@Zone` against the role's allowlist (a field on the `KinoticRole` enum)
+   (kinotic-core) checks every registration's single `@Zone` against `kinotic.publishableZones`
    and **fails startup** on a violation — a future module gate that's forgotten, renamed, or
    fail-opens can never silently publish an OS service in a gateway process. A service with
    **no** `@Zone` registers at an un-zoned address (per the `Zone` javadoc): treat un-zoned
-   registrations as allowlist violations in the gateway role — every service a gateway publishes
+   registrations as allowlist violations whenever the allowlist is set — every service a gateway publishes
    must be deliberately zoned. Client-*hosted* services are
    already constrained by the authorizer (an `ApplicationParticipant` may only host inside its
    own `app.<org>.<app>` zone). Depth beneath all of this: even if the `StompAuthorizer` had a
@@ -497,13 +488,14 @@ public class ApplicationDeployment implements ApplicationScoped<String> {
 Whether the record embeds full definition snapshots (shown) or references immutable definition
 versions is open question 8 — resolve it with Navid before implementing this phase.
 
-- **Per-environment admin clients (OS role only).** Properties map the fixed environment set to
+- **Per-environment admin clients (OS server only).** Properties map the fixed environment set to
   cluster connections — `kinotic.environmentClusters.<envId>.{elastic-connections, username,
   password}` — and a bean (e.g. `EnvironmentClusterClients`, `Map<String, CrudServiceTemplate>`
-  built with the Phase 2 factory method) exposes one admin client per environment. Gated to the
-  `OS_SERVER` role. A publish/promotion targeting an environment with no configured cluster
+  built with the Phase 2 factory method) exposes one admin client per environment. The bean
+  exists only when `kinotic.environmentClusters` is configured — the app-gateway profile never
+  sets it. A publish/promotion targeting an environment with no configured cluster
   fails fast with a clear message.
-- **Mapping sync service (OS role, kinotic-domain internal).** The index/template/create/update
+- **Mapping sync service (OS server, kinotic-domain internal).** The index/template/create/update
   logic Phase 3 lifted out of `DefaultEntityDefinitionService` (mappings via the Elastic
   conversion moved to kinotic-domain, data-stream vs index decision by `isStream()`) becomes a
   domain-internal service — next to `EnvironmentClusterClients` and the repositories it reads —
@@ -575,7 +567,7 @@ versions is open question 8 — resolve it with Navid before implementing this p
 
 ## Phase 8 — deployment, cutover, local dev + docs
 
-One image (`kinoticai/kinotic-server`) everywhere; the role/profile decides what a container is.
+One image (`kinoticai/kinotic-server`) everywhere; the active profile decides what a container is.
 
 - **Compose** (`deployment/docker-compose/`): second ES service (env cluster) +
   `compose.kinotic-app-gateway.yml` running the *same* kinotic-server image with
@@ -588,8 +580,8 @@ One image (`kinoticai/kinotic-server`) everywhere; the role/profile decides what
   kinotic namespace (OS admin user, index-management-only ES role); OS ES reachable from kinotic
   + gateway namespaces. Provision the two distinct ES users per env cluster (Phase 5 least
   privilege) in the ECK/compose setups.
-- **Cutover**: set `disablePersistence: true` in `application-os-server.yml` and drop `app-api`
-  from `OS_SERVER`'s allowlist on the `KinoticRole` enum (flagged in Phase 4), once the frontend
+- **Cutover**: set `disablePersistence: true` and drop `app-api` from `kinotic.publishableZones`
+  in `application-os-server.yml` (flagged in Phase 4), once the frontend
   (Phase 7) talks to gateways for entity data. From here the OS bus carries no entity data
   plane.
 - **Local dev without containers**: document running the same app twice from the IDE —
@@ -604,8 +596,8 @@ One image (`kinoticai/kinotic-server`) everywhere; the role/profile decides what
 ## Phase 9 — Promotion (Develop → Prod)
 
 A Kinotic-managed, predefined flow that moves an application into a target environment. Runs
-entirely in the `OS_SERVER` role (it needs kinotic-github, the orchestrator, and OS data — all
-OS-role modules). Builds on Phase 5 (deployment records + mapping sync) and Phase 6 (env-scoped
+entirely on the OS server (it needs kinotic-github, the orchestrator, and OS data — all
+os-server modules). Builds on Phase 5 (deployment records + mapping sync) and Phase 6 (env-scoped
 workloads).
 
 **Service surface**: `PromotionService` (`@Publish`, zone `os-api`) in kinotic-os-api —
@@ -662,17 +654,16 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
   environment cluster B configured in `kinotic.environmentClusters`; assert the mapping-sync
   service creates the entity index only in B and `kinotic_*` domain indices exist only in A,
   then exercise `JsonEntitiesRepository` CRUD (data plane pointed at B) end-to-end.
-- **Gateway-role boot test**: start `KinoticServerApplication` with the `app-gateway` profile,
+- **Gateway boot test**: start `KinoticServerApplication` with the `app-gateway` profile,
   assert: the `ServiceRegistry` contains **zero** registrations in `os-api`/`system` zones (the
   no-OS-services invariant), os-api CRIs are rejected by the authorizer for an application
   participant, app login routes respond, org signup routes 404.
-- **Role guard**: booting with no `kinotic.role` fails startup with a clear message; booting the
-  gateway role with a context that registers a bean carrying an out-of-allowlist `@Publish` zone
-  fails startup (drive through `ServiceRegistrationBeanPostProcessor` with a real context, not a
-  mock).
+- **Allowlist guard**: with `kinotic.publishableZones` set, a context that registers a bean
+  carrying an out-of-list (or missing) `@Zone` fails startup (drive through
+  `ServiceRegistrationBeanPostProcessor` with a real context, not a mock).
 - **JWT env binding**: token minted with `environmentId=development` rejected by a gateway
   configured as `production` (drive through the real `SecurityService.authenticate`).
-- **Promotion end-to-end** (two ES containers, OS role + gateway role processes): publish a
+- **Promotion end-to-end** (two ES containers, os-server + app-gateway processes): publish a
   definition (dev auto-sync creates indices in the dev cluster), promote to `production`, assert
   the prod cluster gains the promoted mappings and the deployment record goes `ACTIVE`; then
   edit the definition *without* promoting and assert the prod cluster is untouched — that last
@@ -688,8 +679,8 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
   per-organization.
 - An application reaches an environment via explicit Promotion (Phase 9): definition-mapping
   sync to the target env cluster, artifact deployment, and predefined Git branching/tagging.
-- Single binary with roles (Phase 4); GraphQL/OpenAPI/MCP and Data Insights dropped as dormant
-  reference code.
+- Single binary with per-deployment Spring profiles, all differences in YAML (Phase 4);
+  GraphQL/OpenAPI/MCP and Data Insights dropped as dormant reference code.
 
 ## Open questions for Navid (answer before/at handoff)
 
@@ -730,7 +721,7 @@ Follow the repo rule: behavioral tests through real infrastructure over mocked u
 - CLAUDE.md rules apply in full: Lombok, enums over string constants, `api/` vs `internal/`
   layout, one top-level type per file, no version literals in module `build.gradle`, docs synced
   in the same change, and the smells catalog (in particular: no speculative config beyond the
-  role mechanism and per-role flags specified here, no test-only seams).
+  per-profile flags and allowlist specified here, no test-only seams).
 - `docs/future-prompts/Gateway ABAC.md` describes a planned authorization overhaul that will land
   in this same gateway — keep the authorizer seam (Phase 4 item 1) small and policy-shaped so
   ABAC can replace it without another restructuring.

--- a/docs/future-prompts/Multi-environment architecture.md
+++ b/docs/future-prompts/Multi-environment architecture.md
@@ -168,39 +168,42 @@ environments are platform infrastructure shared by all orgs.
 ## Phase 2 — split the ES client seam (no behavior change yet)
 
 Goal: make "which cluster" an explicit dependency while kinotic-server keeps today's behavior
-(both roles → same cluster) so this phase is a pure refactor.
+(both roles → same cluster) so this phase is a pure refactor. The mechanism is **two named
+`ElasticsearchAsyncClient` beans** (plus a `CrudServiceTemplate` per client) — no new abstraction.
 
 1. Demote `CrudServiceTemplate` from `@Component` to a plain class constructed per client.
-2. In `KinoticElasticsearchConfig`, build clients from a reusable factory method and expose named
-   beans:
+2. In `KinoticElasticsearchConfig`, extract the client construction into a reusable factory
+   method and expose the OS pair as `@Primary` named beans:
 
 ```java
 // kinotic-domain/.../internal/config/KinoticElasticsearchConfig.java  (target shape)
-@Bean @Primary
+@Bean(OS_ELASTIC_CLIENT) @Primary
 public ElasticsearchAsyncClient osElasticClient(JsonpMapper mapper) { ... }        // kinotic.domain.elastic-*
 
-@Bean @Primary
+@Bean(OS_CRUD_SERVICE_TEMPLATE) @Primary
 public CrudServiceTemplate osCrudServiceTemplate(ElasticsearchAsyncClient osElasticClient, ...) { ... }
 ```
 
    `@Primary` keeps every existing injection point (all OS repositories, `kinotic-github`,
-   secret storage, etc.) compiling and resolving to the OS cluster untouched.
-3. Introduce the entity-data-side abstraction in **kinotic-persistence**:
+   secret storage, etc.) compiling and resolving to the OS cluster untouched. Declare the bean
+   names as constants next to the config that defines them.
+3. Switch the entity-data path to qualified injection of a second pair,
+   `entityDataElasticClient` / `entityDataCrudServiceTemplate`:
 
 ```java
-// kinotic-persistence/.../api/services/EntityDataClients.java  (new)
-public interface EntityDataClients {
-    ElasticsearchAsyncClient client();
-    CrudServiceTemplate template();
-}
+// kinotic-persistence/.../internal/api/services/EntityServiceCache.java  (target shape)
+public EntityServiceCache(@Qualifier(ENTITY_DATA_CRUD_SERVICE_TEMPLATE) CrudServiceTemplate crudServiceTemplate,
+                          @Qualifier(ENTITY_DATA_ELASTIC_CLIENT) ElasticsearchAsyncClient esAsyncClient,
+                          ...)
 ```
 
-   Inject `EntityDataClients` (instead of the bare beans) into `EntityServiceCache`,
-   `DefaultEntityService` construction, `DefaultEntityDefinitionService`'s index-lifecycle calls,
-   and `PersistenceInitializer`'s health checks. In kinotic-server the default implementation
-   delegates to the OS client — identical behavior, one seam.
+   Same treatment for `DefaultEntityService` construction, `DefaultEntityDefinitionService`'s
+   index-lifecycle calls, and `PersistenceInitializer`'s health checks. The entity-data beans are
+   **supplied by the deployable**, not by kinotic-persistence: kinotic-server defines them as
+   aliases of the OS beans (identical behavior today); the gateway builds them from its own
+   connection properties (Phase 4).
 4. `EntityDefinitionRepository` / `NamedQueriesDefinitionRepository` are **metadata**, not entity
-   data — they stay on the OS template.
+   data — they stay on the OS (`@Primary`) template.
 
 Verify with a full `:kinotic-server:test` run; this phase must be invisible at runtime.
 
@@ -263,9 +266,10 @@ private String elasticUsername; private String elasticPassword;
 ```
 
 The OS cluster connection reuses the existing `kinotic.domain.elastic-*` properties (that's what
-all the domain repositories bind to). The gateway's `EntityDataClients` implementation builds the
-env-cluster client from `kinotic.applicationGateway.*` — this replaces the server's
-delegate-to-OS default from Phase 2.
+all the domain repositories bind to). The gateway defines the `entityDataElasticClient` /
+`entityDataCrudServiceTemplate` beans (Phase 2 qualifiers) from `kinotic.applicationGateway.*` —
+where kinotic-server aliases them to the OS beans, the gateway points them at its environment's
+cluster.
 
 Work items in this phase:
 

--- a/docs/future-prompts/Multi-environment cloud deployment.md
+++ b/docs/future-prompts/Multi-environment cloud deployment.md
@@ -1,0 +1,53 @@
+# Multi-environment cloud deployment (Kinotic Cloud)
+
+**Status: BLOCKED — do not start until Navid confirms the infra budget is secured.**
+
+Companion to `docs/future-prompts/Multi-environment architecture.md` (the code-side plan). That
+plan builds all capability against Testcontainers and an unchanged all-in-one local compose;
+this plan is the Terraform/Helm work that actually deploys the multi-environment topology to
+Kinotic Cloud, plus the production cutover. Prerequisite: the code plan complete through Phase 7
+(Phase 9 Promotion can land before or after — promotion is inert until a second environment
+exists).
+
+## Scope
+
+1. **Per-environment Elasticsearch clusters** — one eck-stack release per environment
+   (`values-<env>.yaml` overlays on `deployment/helm/eck-stack`), alongside the existing OS
+   cluster. Provision **two users per env cluster** (code plan, Phase 5): the gateway data user
+   (document CRUD on entity indices, no index management) and the OS admin user
+   (index/template/mapping management, no document read/write).
+2. **Gateway releases** — parameterize the existing `deployment/helm/kinotic` chart by profile
+   rather than cloning a second chart: one release per environment activating `app-gateway`
+   with `KINOTIC_APPLICATIONGATEWAY_*` env vars (environmentId, env-cluster connection); the OS
+   release activates `os-server`. Single image `kinoticai/kinotic-server` everywhere.
+3. **Ignite bus isolation** — infrastructure-level, no app config (owner decision): each
+   release gets its own Ignite discovery Service (the chart already templates one via
+   `kinotic.cluster.*`); Ignite's Kubernetes-topology discovery resolves membership to whatever
+   that Service selects. Terraform places production on a **dedicated node pool or a separate
+   k8s cluster**.
+4. **NetworkPolicy** — env ES reachable from its gateway namespace (data user) and the kinotic
+   namespace (OS admin user only); OS ES reachable from the kinotic and gateway namespaces
+   (gateways read OS metadata / write scoped IAM indices).
+5. **Environment records** — create/update the `Environment` documents (`gatewayUrl`, status)
+   for the deployed environments, and the OS server's `kinotic.environmentClusters.<envId>.*`
+   connection properties, as part of the rollout.
+6. **Cutover** (the one deliberate breaking step, only after the frontend talks to gateways for
+   entity data): in `application-os-server.yml`, set `disablePersistence: true` and drop
+   `app-api` from `kinotic.zones`. From then on the OS bus carries no entity data plane, and
+   the zones intersection automatically narrows organization participants on the OS server to
+   `os-api.**`.
+7. **Secrets/TLS** — extend the `platformSecrets` mounting (JWT signing keys are shared across
+   OS server and gateways — same Key Vault objects), per-gateway TLS, and the es-secret-sync
+   pattern for the new env clusters.
+
+## Non-goals
+
+- No changes to local docker-compose or the IDE workflow — local stays single-ES, single
+  all-in-one server, `development` environment only (code plan, Phase 8).
+- No new container images and no new Helm chart — one image, one chart, parameterized.
+
+## Open items to resolve when unblocked
+
+- Dedicated node pool vs separate k8s cluster for production (cost/failure-domain trade).
+- Which environments exist at launch beyond `development`/`production`, if any.
+- Public DNS/ingress shape for per-environment gateway URLs (feeds `Environment.gatewayUrl`).


### PR DESCRIPTION
Phased handoff plan for supporting multiple environments: single OS
Elasticsearch cluster for kinotic-managed domain objects, one
Elasticsearch cluster per environment for entity data, and a new
per-environment kinotic-application-gateway deployable serving customer
UI/microservice traffic while kinotic-server remains the single edge for
kinotic-frontend OS configuration.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TVm5RYGTJwsAYZyWLK8SVQ