### PR TITLE
kinotic-frontend: bump to 3.1.0 and surface real errors in toasts

### DIFF
--- a/kinotic-frontend/package.json
+++ b/kinotic-frontend/package.json
@@ -15,10 +15,10 @@
   "dependencies": {
     "@headlessui/vue": "^1.7.23",
     "@heroicons/vue": "^2.2.0",
-    "@kinotic-ai/core": "^2.0.0",
+    "@kinotic-ai/core": "^3.1.0",
     "@kinotic-ai/idl": "^1.0.9",
-    "@kinotic-ai/os-api": "^2.0.0",
-    "@kinotic-ai/persistence": "^2.0.0",
+    "@kinotic-ai/os-api": "^3.1.0",
+    "@kinotic-ai/persistence": "^3.1.0",
     "@mdi/js": "^7.4.47",
     "@primeuix/themes": "^2.0.3",
     "@vue-flow/background": "^1.3.2",

--- a/kinotic-frontend/pnpm-lock.yaml
+++ b/kinotic-frontend/pnpm-lock.yaml
@@ -15,17 +15,17 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(vue@3.5.34(typescript@5.8.3))
       '@kinotic-ai/core':
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.8.3)
+        specifier: ^3.1.0
+        version: 3.1.0(typescript@5.8.3)
       '@kinotic-ai/idl':
         specifier: ^1.0.9
         version: 1.0.9(typescript@5.8.3)
       '@kinotic-ai/os-api':
-        specifier: ^2.0.0
-        version: 2.0.0(@kinotic-ai/core@2.0.0(typescript@5.8.3))(typescript@5.8.3)
+        specifier: ^3.1.0
+        version: 3.1.0(@kinotic-ai/core@3.1.0(typescript@5.8.3))(typescript@5.8.3)
       '@kinotic-ai/persistence':
-        specifier: ^2.0.0
-        version: 2.0.0(@kinotic-ai/core@2.0.0(typescript@5.8.3))(typescript@5.8.3)
+        specifier: ^3.1.0
+        version: 3.1.0(@kinotic-ai/core@3.1.0(typescript@5.8.3))(typescript@5.8.3)
       '@mdi/js':
         specifier: ^7.4.47
         version: 7.4.47
@@ -213,8 +213,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kinotic-ai/core@2.0.0':
-    resolution: {integrity: sha512-uy9c/5Pk+oGpUDIybXDr5y0AdzT7xKdjdWKVQ4rJcvA1HFD3f06JLlbWGw85OfwDMWiRNDxzpPSxsgZ9H4LBnA==}
+  '@kinotic-ai/core@3.1.0':
+    resolution: {integrity: sha512-EGmQ3HlOiZpPAl8udICk8iHqTMCzmtVrRA7gMMgfC7u6GQUDPCQnuiVWrOkDfrg7VrAmuwN95HbnrrFcqpTZuA==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -237,19 +237,19 @@ packages:
       typescript:
         optional: true
 
-  '@kinotic-ai/os-api@2.0.0':
-    resolution: {integrity: sha512-cEuZihG3UcwltUtIJ7zz8o40ROhhJxDnBnpzQI6ZOqBfbeAhInhPf4EGDEi8x650JDpHQPQnEJ8rihatPi01SA==}
+  '@kinotic-ai/os-api@3.1.0':
+    resolution: {integrity: sha512-al2PJCHtSSySwqIuYCrwrf1uXKxLxDc1idV6GPbxzAkjJiDTODP3GyeTB2kwLNHwcCi9dCktvhoQNBCN6+P1/w==}
     peerDependencies:
-      '@kinotic-ai/core': '>=2.0.0'
+      '@kinotic-ai/core': '>=3.1.0'
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@kinotic-ai/persistence@2.0.0':
-    resolution: {integrity: sha512-wrPa82zbtzROL4qSg8jOmWcZkVOTYdfiOIwjZTPt/ceRBukRolN/yvA4EVBNqEHtPwoHH53/0kNLjogrKsKvng==}
+  '@kinotic-ai/persistence@3.1.0':
+    resolution: {integrity: sha512-QXIVOATahEkFMZh4CFQVeUotajpXP9VFYrXrOf7tav7BT8r1vi/BmCPUNQnVH4L+Wan3ifSSER/yk3KrmLksNQ==}
     peerDependencies:
-      '@kinotic-ai/core': '>=2.0.0'
+      '@kinotic-ai/core': '>=3.1.0'
       typescript: '*'
     peerDependenciesMeta:
       typescript:
@@ -1513,7 +1513,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@kinotic-ai/core@2.0.0(typescript@5.8.3)':
+  '@kinotic-ai/core@3.1.0(typescript@5.8.3)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -1540,18 +1540,18 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@kinotic-ai/os-api@2.0.0(@kinotic-ai/core@2.0.0(typescript@5.8.3))(typescript@5.8.3)':
+  '@kinotic-ai/os-api@3.1.0(@kinotic-ai/core@3.1.0(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
-      '@kinotic-ai/core': 2.0.0(typescript@5.8.3)
+      '@kinotic-ai/core': 3.1.0(typescript@5.8.3)
       '@kinotic-ai/idl': 1.0.10(typescript@5.8.3)
-      '@kinotic-ai/persistence': 2.0.0(@kinotic-ai/core@2.0.0(typescript@5.8.3))(typescript@5.8.3)
+      '@kinotic-ai/persistence': 3.1.0(@kinotic-ai/core@3.1.0(typescript@5.8.3))(typescript@5.8.3)
       rxjs: 7.8.2
     optionalDependencies:
       typescript: 5.8.3
 
-  '@kinotic-ai/persistence@2.0.0(@kinotic-ai/core@2.0.0(typescript@5.8.3))(typescript@5.8.3)':
+  '@kinotic-ai/persistence@3.1.0(@kinotic-ai/core@3.1.0(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
-      '@kinotic-ai/core': 2.0.0(typescript@5.8.3)
+      '@kinotic-ai/core': 3.1.0(typescript@5.8.3)
       '@kinotic-ai/idl': 1.0.10(typescript@5.8.3)
       rxjs: 7.8.2
     optionalDependencies:

--- a/kinotic-frontend/pnpm-workspace.yaml
+++ b/kinotic-frontend/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ allowBuilds:
 # First-party packages are trusted; exclude them from the minimumReleaseAge
 # supply-chain policy so a freshly-published release doesn't block the build.
 minimumReleaseAgeExclude:
-  - '@kinotic-ai/core@2.0.0'
+  - '@kinotic-ai/core@3.1.0'
   - '@kinotic-ai/idl@1.0.10'
-  - '@kinotic-ai/os-api@2.0.0'
-  - '@kinotic-ai/persistence@2.0.0'
+  - '@kinotic-ai/os-api@3.1.0'
+  - '@kinotic-ai/persistence@3.1.0'

--- a/kinotic-frontend/src/components/ApplicationSidebar.vue
+++ b/kinotic-frontend/src/components/ApplicationSidebar.vue
@@ -69,9 +69,9 @@ async function handleSubmit(): Promise<void> {
     debug('Failed to create application: %O', error)
     toast.add({
       severity: 'error',
-      summary: 'Error',
-      detail: 'Failed to create application. Please check name validity.',
-      life: 3000
+      summary: 'Failed to create application',
+      detail: error instanceof Error ? error.message : 'An unexpected error occurred',
+      life: 5000
     })
   } finally {
     loading.value = false

--- a/kinotic-frontend/src/components/ApplicationSidebar.vue
+++ b/kinotic-frontend/src/components/ApplicationSidebar.vue
@@ -5,6 +5,7 @@ import Textarea from 'primevue/textarea'
 import Button from 'primevue/button'
 import { useToast } from 'primevue/usetoast'
 import { createDebug } from '@/util/debug'
+import { errorMessage } from '@/util/helpers'
 import type {Application} from "@kinotic-ai/os-api";
 import {Kinotic} from "@kinotic-ai/core";
 import { USER_STATE } from '@/states/IUserState'
@@ -70,7 +71,7 @@ async function handleSubmit(): Promise<void> {
     toast.add({
       severity: 'error',
       summary: 'Failed to create application',
-      detail: error instanceof Error ? error.message : 'An unexpected error occurred',
+      detail: errorMessage(error, 'An unexpected error occurred'),
       life: 5000
     })
   } finally {

--- a/kinotic-frontend/src/components/ApplicationSidebar.vue
+++ b/kinotic-frontend/src/components/ApplicationSidebar.vue
@@ -44,9 +44,8 @@ function resetForm(): void {
 async function handleSubmit(): Promise<void> {
   loading.value = true
   try {
-    // The server mints the id from the slugified name; the cast bridges the 2.x typings,
-    // which lack the name field until the os-api 3.x bump
-    const applicationData = {
+    // The server mints the id from the slugified name, so send an empty id.
+    const applicationData: Application = {
       id: '',
       name: form.name.trim(),
       organizationId: USER_STATE.getOrganizationId(),
@@ -55,7 +54,7 @@ async function handleSubmit(): Promise<void> {
       updated: null
     }
 
-    const createdApplication = await Kinotic.applications.createSync(applicationData as Application)
+    const createdApplication = await Kinotic.applications.createSync(applicationData)
 
     toast.add({
       severity: 'success',

--- a/kinotic-frontend/src/components/ApplicationSidebar.vue
+++ b/kinotic-frontend/src/components/ApplicationSidebar.vue
@@ -5,7 +5,7 @@ import Textarea from 'primevue/textarea'
 import Button from 'primevue/button'
 import { useToast } from 'primevue/usetoast'
 import { createDebug } from '@/util/debug'
-import { errorMessage } from '@/util/helpers'
+import { showErrorToast } from '@/util/helpers'
 import type {Application} from "@kinotic-ai/os-api";
 import {Kinotic} from "@kinotic-ai/core";
 import { USER_STATE } from '@/states/IUserState'
@@ -68,12 +68,7 @@ async function handleSubmit(): Promise<void> {
     emit('submit', createdApplication)
   } catch (error) {
     debug('Failed to create application: %O', error)
-    toast.add({
-      severity: 'error',
-      summary: 'Failed to create application',
-      detail: errorMessage(error, 'An unexpected error occurred'),
-      life: 5000
-    })
+    showErrorToast(toast, 'Failed to create application', error)
   } finally {
     loading.value = false
   }

--- a/kinotic-frontend/src/components/NewProjectSidebar.vue
+++ b/kinotic-frontend/src/components/NewProjectSidebar.vue
@@ -2,6 +2,7 @@
 import { onBeforeUnmount, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useToast } from 'primevue/usetoast';
+import { showErrorToast } from '@/util/helpers';
 import { Kinotic } from '@kinotic-ai/core';
 import { Project, ProjectType } from '@kinotic-ai/os-api';
 import { APPLICATION_STATE } from '@/states/IApplicationState';
@@ -112,12 +113,7 @@ async function handleSubmit(): Promise<void> {
         if (message.includes('GitHub is not linked')) {
             githubLinked.value = false;
         } else {
-            toast.add({
-                severity: 'error',
-                summary: 'Failed to create project',
-                detail: message || 'An unexpected error occurred',
-                life: 3000
-            });
+            showErrorToast(toast, 'Failed to create project', error);
         }
     } finally {
         loading.value = false;

--- a/kinotic-frontend/src/components/NewProjectSidebar.vue
+++ b/kinotic-frontend/src/components/NewProjectSidebar.vue
@@ -114,8 +114,8 @@ async function handleSubmit(): Promise<void> {
         } else {
             toast.add({
                 severity: 'error',
-                summary: 'Error',
-                detail: 'Failed to create project.',
+                summary: 'Failed to create project',
+                detail: message || 'An unexpected error occurred',
                 life: 3000
             });
         }

--- a/kinotic-frontend/src/components/ProjectList.vue
+++ b/kinotic-frontend/src/components/ProjectList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { errorMessage } from '@/util/helpers'
+import { showErrorToast } from '@/util/helpers'
 import { useToast } from 'primevue/usetoast'
 import CrudTable from '@/components/CrudTable.vue'
 import NewProjectSidebar from '@/components/NewProjectSidebar.vue'
@@ -123,12 +123,7 @@ async function onProjectSubmit(): Promise<void> {
     refreshTable()
   } catch (error) {
     debug('Refresh after project creation failed: %O', error)
-    toast.add({
-      severity: 'error',
-      summary: 'Failed to refresh project list',
-      detail: errorMessage(error, 'An unexpected error occurred'),
-      life: 3000
-    })
+    showErrorToast(toast, 'Failed to refresh project list', error)
   } finally {
     showProjectSidebar.value = false
   }
@@ -179,12 +174,7 @@ async function retryRepoInit(project: Project): Promise<void> {
     refreshTable()
   } catch (error) {
     debug('Retry repo initialization failed for %s: %O', project.id, error)
-    toast.add({
-      severity: 'error',
-      summary: 'Retry failed',
-      detail: errorMessage(error, `Repository initialization failed again for ${project.name}.`),
-      life: 5000
-    })
+    showErrorToast(toast, 'Retry failed', error, { fallback: `Repository initialization failed again for ${project.name}.` })
   } finally {
     retryingIds.value = retryingIds.value.filter(id => id !== project.id)
   }

--- a/kinotic-frontend/src/components/ProjectList.vue
+++ b/kinotic-frontend/src/components/ProjectList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { errorMessage } from '@/util/helpers'
 import { useToast } from 'primevue/usetoast'
 import CrudTable from '@/components/CrudTable.vue'
 import NewProjectSidebar from '@/components/NewProjectSidebar.vue'
@@ -124,8 +125,8 @@ async function onProjectSubmit(): Promise<void> {
     debug('Refresh after project creation failed: %O', error)
     toast.add({
       severity: 'error',
-      summary: 'Error',
-      detail: 'Failed to refresh project list.',
+      summary: 'Failed to refresh project list',
+      detail: errorMessage(error, 'An unexpected error occurred'),
       life: 3000
     })
   } finally {
@@ -181,7 +182,7 @@ async function retryRepoInit(project: Project): Promise<void> {
     toast.add({
       severity: 'error',
       summary: 'Retry failed',
-      detail: `Repository initialization failed again for ${project.name}.`,
+      detail: errorMessage(error, `Repository initialization failed again for ${project.name}.`),
       life: 5000
     })
   } finally {

--- a/kinotic-frontend/src/pages/ApplicationSettings.vue
+++ b/kinotic-frontend/src/pages/ApplicationSettings.vue
@@ -155,7 +155,7 @@
 <script setup lang="ts">
 // @ts-ignore
 import { ref, defineProps, onMounted, watch, computed } from 'vue'
-import { errorMessage } from '@/util/helpers'
+import { showErrorToast } from '@/util/helpers'
 import { InputText, Textarea, Button, Tabs, TabList, Tab, TabPanels, TabPanel, Dialog, IconField, InputIcon, ToggleSwitch } from 'primevue'
 import { APPLICATION_STATE } from '@/states/IApplicationState'
 import { USER_STATE } from '@/states/IUserState'
@@ -236,12 +236,7 @@ const saveSettings = async () => {
       life: 3000
     })
   } catch (error) {
-    toast.add({
-      severity: 'error',
-      summary: 'Failed to save application settings',
-      detail: errorMessage(error, 'An unexpected error occurred'),
-      life: 3000
-    })
+    showErrorToast(toast, 'Failed to save application settings', error)
   } finally {
     loading.value = false
   }
@@ -258,12 +253,7 @@ const loadSavedWidgets = async () => {
     const widgets = await widgetService.findByApplicationId(APPLICATION_STATE.currentApplication.id)
     savedWidgets.value = widgets
   } catch (error) {
-    toast.add({
-      severity: 'error',
-      summary: 'Failed to load saved widgets',
-      detail: errorMessage(error, 'An unexpected error occurred'),
-      life: 3000
-    })
+    showErrorToast(toast, 'Failed to load saved widgets', error)
   } finally {
     loadingWidgets.value = false
   }
@@ -288,12 +278,7 @@ const deleteWidget = async () => {
       life: 3000
     })
   } catch (error) {
-    toast.add({
-      severity: 'error',
-      summary: 'Failed to delete widget',
-      detail: errorMessage(error, 'An unexpected error occurred'),
-      life: 3000
-    })
+    showErrorToast(toast, 'Failed to delete widget', error)
   } finally {
     showDeleteDialog.value = false
     widgetToDelete.value = null

--- a/kinotic-frontend/src/pages/ApplicationSettings.vue
+++ b/kinotic-frontend/src/pages/ApplicationSettings.vue
@@ -155,6 +155,7 @@
 <script setup lang="ts">
 // @ts-ignore
 import { ref, defineProps, onMounted, watch, computed } from 'vue'
+import { errorMessage } from '@/util/helpers'
 import { InputText, Textarea, Button, Tabs, TabList, Tab, TabPanels, TabPanel, Dialog, IconField, InputIcon, ToggleSwitch } from 'primevue'
 import { APPLICATION_STATE } from '@/states/IApplicationState'
 import { USER_STATE } from '@/states/IUserState'
@@ -237,8 +238,8 @@ const saveSettings = async () => {
   } catch (error) {
     toast.add({
       severity: 'error',
-      summary: 'Error',
-      detail: 'Failed to save application settings',
+      summary: 'Failed to save application settings',
+      detail: errorMessage(error, 'An unexpected error occurred'),
       life: 3000
     })
   } finally {
@@ -259,8 +260,8 @@ const loadSavedWidgets = async () => {
   } catch (error) {
     toast.add({
       severity: 'error',
-      summary: 'Error',
-      detail: 'Failed to load saved widgets',
+      summary: 'Failed to load saved widgets',
+      detail: errorMessage(error, 'An unexpected error occurred'),
       life: 3000
     })
   } finally {
@@ -289,8 +290,8 @@ const deleteWidget = async () => {
   } catch (error) {
     toast.add({
       severity: 'error',
-      summary: 'Error',
-      detail: 'Failed to delete widget',
+      summary: 'Failed to delete widget',
+      detail: errorMessage(error, 'An unexpected error occurred'),
       life: 3000
     })
   } finally {

--- a/kinotic-frontend/src/pages/DashboardDetails.vue
+++ b/kinotic-frontend/src/pages/DashboardDetails.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { ref, onMounted, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { errorMessage } from '@/util/helpers'
+import { showErrorToast } from '@/util/helpers'
 import { GridStack } from 'gridstack'
 import 'gridstack/dist/gridstack.min.css'
 import { DashboardEntityRepository } from '@/services/DashboardEntityRepository'
@@ -817,12 +817,7 @@ const createDashboard = async () => {
       router.push(`/application/${props.applicationId}/dashboards/${savedDashboard.id}`)
     }, 500)
   } catch (error: any) {
-    toast.add({ 
-      severity: 'error', 
-      summary: 'Failed to create dashboard',
-      detail: errorMessage(error, 'An unexpected error occurred'),
-      life: 3000
-    })
+    showErrorToast(toast, 'Failed to create dashboard', error)
   }
 }
 
@@ -861,7 +856,7 @@ const updateDashboard = async () => {
       router.push(`/application/${props.applicationId}/dashboards/${props.dashboardId}`)
     }, 500)
   } catch (error) {
-    toast.add({ severity: 'error', summary: 'Failed to update dashboard', detail: errorMessage(error, 'An unexpected error occurred'), life: 3000 })
+    showErrorToast(toast, 'Failed to update dashboard', error)
   }
 }
 

--- a/kinotic-frontend/src/pages/DashboardDetails.vue
+++ b/kinotic-frontend/src/pages/DashboardDetails.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { ref, onMounted, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
+import { errorMessage } from '@/util/helpers'
 import { GridStack } from 'gridstack'
 import 'gridstack/dist/gridstack.min.css'
 import { DashboardEntityRepository } from '@/services/DashboardEntityRepository'
@@ -818,8 +819,8 @@ const createDashboard = async () => {
   } catch (error: any) {
     toast.add({ 
       severity: 'error', 
-      summary: 'Error', 
-      detail: error?.message || 'Failed to create dashboard',
+      summary: 'Failed to create dashboard',
+      detail: errorMessage(error, 'An unexpected error occurred'),
       life: 3000
     })
   }
@@ -860,7 +861,7 @@ const updateDashboard = async () => {
       router.push(`/application/${props.applicationId}/dashboards/${props.dashboardId}`)
     }, 500)
   } catch (error) {
-    toast.add({ severity: 'error', summary: 'Error', detail: 'Failed to update dashboard', life: 3000 })
+    toast.add({ severity: 'error', summary: 'Failed to update dashboard', detail: errorMessage(error, 'An unexpected error occurred'), life: 3000 })
   }
 }
 

--- a/kinotic-frontend/src/pages/DashboardView.vue
+++ b/kinotic-frontend/src/pages/DashboardView.vue
@@ -62,6 +62,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { errorMessage } from '@/util/helpers'
 // import { GridStack } from 'gridstack'
 import 'gridstack/dist/gridstack.min.css'
 import { DashboardEntityRepository } from '@/services/DashboardEntityRepository'
@@ -258,8 +259,8 @@ const loadDashboard = async () => {
     debug('Error loading dashboard: %O', error)
     toast.add({
       severity: 'error',
-      summary: 'Error',
-      detail: 'Failed to load dashboard',
+      summary: 'Failed to load dashboard',
+      detail: errorMessage(error, 'An unexpected error occurred'),
       life: 3000
     })
   } finally {

--- a/kinotic-frontend/src/pages/DashboardView.vue
+++ b/kinotic-frontend/src/pages/DashboardView.vue
@@ -62,7 +62,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { errorMessage } from '@/util/helpers'
+import { showErrorToast } from '@/util/helpers'
 // import { GridStack } from 'gridstack'
 import 'gridstack/dist/gridstack.min.css'
 import { DashboardEntityRepository } from '@/services/DashboardEntityRepository'
@@ -257,12 +257,7 @@ const loadDashboard = async () => {
     }
   } catch (error) {
     debug('Error loading dashboard: %O', error)
-    toast.add({
-      severity: 'error',
-      summary: 'Failed to load dashboard',
-      detail: errorMessage(error, 'An unexpected error occurred'),
-      life: 3000
-    })
+    showErrorToast(toast, 'Failed to load dashboard', error)
   } finally {
     loading.value = false
   }

--- a/kinotic-frontend/src/pages/InviteEmailTemplatePage.vue
+++ b/kinotic-frontend/src/pages/InviteEmailTemplatePage.vue
@@ -67,6 +67,7 @@ import { useToast } from 'primevue/usetoast'
 
 import { Kinotic } from '@kinotic-ai/core'
 import { InviteEmailTemplate } from '@kinotic-ai/os-api'
+import { errorMessage } from '@/util/helpers'
 
 /**
  * Editor for an application's customized invitation email. Without a saved template the
@@ -99,7 +100,7 @@ onMounted(async () => {
       customizing.value = true
     }
   } catch (err) {
-    toast.add({ severity: 'error', summary: 'Error', detail: message(err, 'Failed to load template'), life: 8000 })
+    toast.add({ severity: 'error', summary: 'Error', detail: errorMessage(err, 'Failed to load template'), life: 8000 })
   } finally {
     loading.value = false
   }
@@ -140,7 +141,7 @@ async function save() {
     toast.add({ severity: 'success', summary: 'Template saved', life: 4000 })
   } catch (err) {
     // Server-side Handlebars validation messages carry the parse position.
-    toast.add({ severity: 'error', summary: 'Error', detail: message(err, 'Failed to save template'), life: 10000 })
+    toast.add({ severity: 'error', summary: 'Error', detail: errorMessage(err, 'Failed to save template'), life: 10000 })
   } finally {
     saving.value = false
   }
@@ -168,13 +169,10 @@ async function revert() {
     customizing.value = false
     toast.add({ severity: 'success', summary: 'Reverted to the built-in email', life: 4000 })
   } catch (err) {
-    toast.add({ severity: 'error', summary: 'Error', detail: message(err, 'Failed to revert'), life: 8000 })
+    toast.add({ severity: 'error', summary: 'Error', detail: errorMessage(err, 'Failed to revert'), life: 8000 })
   }
 }
 
-function message(err: unknown, fallback: string): string {
-  return err instanceof Error && err.message ? err.message : fallback
-}
 </script>
 
 <style scoped>

--- a/kinotic-frontend/src/pages/InviteEmailTemplatePage.vue
+++ b/kinotic-frontend/src/pages/InviteEmailTemplatePage.vue
@@ -67,7 +67,7 @@ import { useToast } from 'primevue/usetoast'
 
 import { Kinotic } from '@kinotic-ai/core'
 import { InviteEmailTemplate } from '@kinotic-ai/os-api'
-import { errorMessage } from '@/util/helpers'
+import { showErrorToast } from '@/util/helpers'
 
 /**
  * Editor for an application's customized invitation email. Without a saved template the
@@ -100,7 +100,7 @@ onMounted(async () => {
       customizing.value = true
     }
   } catch (err) {
-    toast.add({ severity: 'error', summary: 'Error', detail: errorMessage(err, 'Failed to load template'), life: 8000 })
+    showErrorToast(toast, 'Failed to load template', err, { life: 8000 })
   } finally {
     loading.value = false
   }
@@ -141,7 +141,7 @@ async function save() {
     toast.add({ severity: 'success', summary: 'Template saved', life: 4000 })
   } catch (err) {
     // Server-side Handlebars validation messages carry the parse position.
-    toast.add({ severity: 'error', summary: 'Error', detail: errorMessage(err, 'Failed to save template'), life: 10000 })
+    showErrorToast(toast, 'Failed to save template', err, { life: 10000 })
   } finally {
     saving.value = false
   }
@@ -169,7 +169,7 @@ async function revert() {
     customizing.value = false
     toast.add({ severity: 'success', summary: 'Reverted to the built-in email', life: 4000 })
   } catch (err) {
-    toast.add({ severity: 'error', summary: 'Error', detail: errorMessage(err, 'Failed to revert'), life: 8000 })
+    showErrorToast(toast, 'Failed to revert', err, { life: 8000 })
   }
 }
 

--- a/kinotic-frontend/src/pages/MembersPage.vue
+++ b/kinotic-frontend/src/pages/MembersPage.vue
@@ -99,7 +99,7 @@ import CrudTable from '@/components/CrudTable.vue'
 import type { CrudHeader } from '@/types/CrudHeader'
 import type { DescriptiveIdentifiable } from '@/types/DescriptiveIdentifiable'
 import { StructuresStates } from '@/states'
-import { apiUrl } from '@/util/helpers'
+import { apiUrl, errorMessage } from '@/util/helpers'
 import { createDebug } from '@/util/debug'
 
 const debug = createDebug('members')
@@ -347,9 +347,5 @@ async function run(action: () => Promise<void>, successMessage: string, failureM
 
 function refreshTable() {
   crudTable.value?.find()
-}
-
-function errorMessage(err: unknown, fallback: string): string {
-  return err instanceof Error && err.message ? err.message : fallback
 }
 </script>

--- a/kinotic-frontend/src/pages/MembersPage.vue
+++ b/kinotic-frontend/src/pages/MembersPage.vue
@@ -99,7 +99,7 @@ import CrudTable from '@/components/CrudTable.vue'
 import type { CrudHeader } from '@/types/CrudHeader'
 import type { DescriptiveIdentifiable } from '@/types/DescriptiveIdentifiable'
 import { StructuresStates } from '@/states'
-import { apiUrl, errorMessage } from '@/util/helpers'
+import { apiUrl, showErrorToast } from '@/util/helpers'
 import { createDebug } from '@/util/debug'
 
 const debug = createDebug('members')
@@ -290,7 +290,7 @@ async function sendInvite() {
       refreshTable()
     }
   } catch (err) {
-    toast.add({ severity: 'error', summary: 'Error', detail: errorMessage(err, 'Failed to send invitation'), life: 8000 })
+    showErrorToast(toast, 'Failed to send invitation', err, { life: 8000 })
   } finally {
     inviting.value = false
   }
@@ -341,7 +341,7 @@ async function run(action: () => Promise<void>, successMessage: string, failureM
     toast.add({ severity: 'success', summary: successMessage, life: 4000 })
     refreshTable()
   } catch (err) {
-    toast.add({ severity: 'error', summary: 'Error', detail: errorMessage(err, failureMessage), life: 8000 })
+    showErrorToast(toast, failureMessage, err, { life: 8000 })
   }
 }
 

--- a/kinotic-frontend/src/pages/SavedWidgets.vue
+++ b/kinotic-frontend/src/pages/SavedWidgets.vue
@@ -97,7 +97,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
-import { errorMessage } from '@/util/helpers'
+import { showErrorToast } from '@/util/helpers'
 import { InputText, Button, Dialog, IconField, InputIcon } from 'primevue'
 import { useToast } from 'primevue/usetoast'
 import { DataInsightsWidgetEntityRepository } from '@/services/DataInsightsWidgetEntityRepository'
@@ -136,12 +136,7 @@ const loadSavedWidgets = async () => {
     savedWidgets.value = widgets
   } catch (error) {
     debug('Failed to load saved widgets: %O', error)
-    toast.add({
-      severity: 'error',
-      summary: 'Failed to load saved widgets',
-      detail: errorMessage(error, 'An unexpected error occurred'),
-      life: 3000
-    })
+    showErrorToast(toast, 'Failed to load saved widgets', error)
   } finally {
     loadingWidgets.value = false
   }
@@ -168,12 +163,7 @@ const deleteWidget = async () => {
     })
   } catch (error) {
     debug('Failed to delete widget: %O', error)
-    toast.add({
-      severity: 'error',
-      summary: 'Failed to delete widget',
-      detail: errorMessage(error, 'An unexpected error occurred'),
-      life: 3000
-    })
+    showErrorToast(toast, 'Failed to delete widget', error)
   } finally {
     showDeleteDialog.value = false
     widgetToDelete.value = null

--- a/kinotic-frontend/src/pages/SavedWidgets.vue
+++ b/kinotic-frontend/src/pages/SavedWidgets.vue
@@ -97,6 +97,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
+import { errorMessage } from '@/util/helpers'
 import { InputText, Button, Dialog, IconField, InputIcon } from 'primevue'
 import { useToast } from 'primevue/usetoast'
 import { DataInsightsWidgetEntityRepository } from '@/services/DataInsightsWidgetEntityRepository'
@@ -137,8 +138,8 @@ const loadSavedWidgets = async () => {
     debug('Failed to load saved widgets: %O', error)
     toast.add({
       severity: 'error',
-      summary: 'Error',
-      detail: 'Failed to load saved widgets',
+      summary: 'Failed to load saved widgets',
+      detail: errorMessage(error, 'An unexpected error occurred'),
       life: 3000
     })
   } finally {
@@ -169,8 +170,8 @@ const deleteWidget = async () => {
     debug('Failed to delete widget: %O', error)
     toast.add({
       severity: 'error',
-      summary: 'Error',
-      detail: 'Failed to delete widget',
+      summary: 'Failed to delete widget',
+      detail: errorMessage(error, 'An unexpected error occurred'),
       life: 3000
     })
   } finally {

--- a/kinotic-frontend/src/util/helpers.ts
+++ b/kinotic-frontend/src/util/helpers.ts
@@ -25,6 +25,14 @@ export function createConnectionInfo(): ConnectionInfo {
  * same-origin production deployment — SPA served from kinotic-server's webroot —
  * still works).
  */
+/**
+ * Extracts a human-readable message from a caught error, falling back to the
+ * given text when the value is not an Error or carries no message.
+ */
+export function errorMessage(err: unknown, fallback: string): string {
+    return err instanceof Error && err.message ? err.message : fallback
+}
+
 export function apiUrl(path: string): string {
     const host = import.meta.env.VITE_KINOTIC_HOST
     const suffix = path.startsWith('/') ? path : `/${path}`

--- a/kinotic-frontend/src/util/helpers.ts
+++ b/kinotic-frontend/src/util/helpers.ts
@@ -43,14 +43,6 @@ export function apiUrl(path: string): string {
 }
 
 /**
- * Extracts a human-readable message from a caught error, falling back to the
- * given text when the value is not an Error or carries no message.
- */
-function errorMessage(err: unknown, fallback: string): string {
-    return err instanceof Error && err.message ? err.message : fallback
-}
-
-/**
  * Shows an error toast whose summary names the failed operation and whose detail is the
  * caught error's message. Falls back to {@link opts.fallback} (default "An unexpected error
  * occurred") when the value is not an Error or carries no message.
@@ -67,7 +59,7 @@ export function showErrorToast(toast: ToastServiceMethods,
     toast.add({
         severity: 'error',
         summary,
-        detail: errorMessage(err, opts.fallback ?? 'An unexpected error occurred'),
+        detail: err instanceof Error && err.message ? err.message : (opts.fallback ?? 'An unexpected error occurred'),
         life: opts.life ?? 5000
     })
 }

--- a/kinotic-frontend/src/util/helpers.ts
+++ b/kinotic-frontend/src/util/helpers.ts
@@ -1,4 +1,5 @@
 import {ConnectionInfo} from "@kinotic-ai/core";
+import type {ToastServiceMethods} from "primevue/toastservice";
 
 export function createConnectionInfo(): ConnectionInfo {
     // Use build time variable if available, otherwise use default
@@ -25,14 +26,6 @@ export function createConnectionInfo(): ConnectionInfo {
  * same-origin production deployment — SPA served from kinotic-server's webroot —
  * still works).
  */
-/**
- * Extracts a human-readable message from a caught error, falling back to the
- * given text when the value is not an Error or carries no message.
- */
-export function errorMessage(err: unknown, fallback: string): string {
-    return err instanceof Error && err.message ? err.message : fallback
-}
-
 export function apiUrl(path: string): string {
     const host = import.meta.env.VITE_KINOTIC_HOST
     const suffix = path.startsWith('/') ? path : `/${path}`
@@ -47,4 +40,34 @@ export function apiUrl(path: string): string {
 
     const protocol = useSSL ? 'https' : 'http'
     return `${protocol}://${host}:${port}${suffix}`
+}
+
+/**
+ * Extracts a human-readable message from a caught error, falling back to the
+ * given text when the value is not an Error or carries no message.
+ */
+function errorMessage(err: unknown, fallback: string): string {
+    return err instanceof Error && err.message ? err.message : fallback
+}
+
+/**
+ * Shows an error toast whose summary names the failed operation and whose detail is the
+ * caught error's message. Falls back to {@link opts.fallback} (default "An unexpected error
+ * occurred") when the value is not an Error or carries no message.
+ *
+ * @param toast the PrimeVue toast service from {@code useToast()}
+ * @param summary the operation that failed, shown as the toast title
+ * @param err the caught error
+ * @param opts optional fallback detail and toast lifetime in milliseconds (default 5000)
+ */
+export function showErrorToast(toast: ToastServiceMethods,
+                               summary: string,
+                               err: unknown,
+                               opts: { fallback?: string; life?: number } = {}): void {
+    toast.add({
+        severity: 'error',
+        summary,
+        detail: errorMessage(err, opts.fallback ?? 'An unexpected error occurred'),
+        life: opts.life ?? 5000
+    })
 }


### PR DESCRIPTION
## Symptom

Creating an application in the UI failed with `Failed to create application. Please check name validity.` — for any name (e.g. `Todo`).

## Root cause

The frontend was the last consumer still on the 2.x client (`core`/`os-api` pinned at `^2.0.0`) against a 3.x zoned server:

1. **2.x has no zone concept.** The 3.x server registers `ApplicationService` under the `os-api` zone (`srv://os-api.…ApplicationService`); the 2.x plugin addresses the un-zoned `srv://…ApplicationService`. An organization participant may only send to `os-api.**`/`app-api.**`, so the un-zoned send has no handler and is denied — every os-api call fails; create is just where a toast surfaced it.
2. **2.x `Application` has no `name`** (only `id`, `organizationId`, `description`), which is why the code cast `as Application`. The 3.x server slugifies `name` into the id (`"Todo"` → `todo`, valid), so the name was never the problem.

The real error was hidden by a hardcoded toast — which turned out to be a broader pattern.

## Changes

**1. Bump to 3.1.0**
- `@kinotic-ai/core|os-api|persistence` → `^3.1.0`; `minimumReleaseAgeExclude` pins refreshed; lockfile regenerated.
- Dropped the now-unnecessary `as Application` cast in `ApplicationSidebar.vue` (3.x `Application` carries `name`) and corrected its stale comment.
- The source already targeted 3.x semantics, so no other bump-related code changes were needed.

**2. Honest error toasts via a shared `showErrorToast` helper**
- Added `showErrorToast(toast, summary, err, opts?)` to `util/helpers.ts`: it names the failed operation in the `summary` and puts the caught error's message (or `opts.fallback` / a generic message) in the `detail`. `errorMessage` is a private detail of it. An audit confirmed every error-message use fed a toast, so one helper — not a separate message helper — is warranted.
- Converted the `catch` handlers that hardcoded a `detail` and dropped the caught error — across `ApplicationSidebar`, `ApplicationSettings` (×3), `DashboardView`, `DashboardDetails` (×2), `SavedWidgets` (×2), `ProjectList` (×2), `NewProjectSidebar`, plus the two that had their own duplicated message helpers (`MembersPage` ×2, `InviteEmailTemplatePage` ×3) — to a single `showErrorToast` call. So a transport/server failure now shows its actual cause instead of e.g. a misleading "check name validity" or "Failed to load dashboard".
- Left the legitimate pre-flight validation guards (`No application selected`, etc.) and the parameterized `displayError`/`displayAlert` helpers untouched.

## Testing

- `vue-tsc -b --force` — clean (0 errors) against 3.1.0.
- `pnpm build` (`vue-tsc` + `vite build`) — clean.
- Runtime (UI against a live 3.1.0 server) can't be exercised in the sandbox; the addressing fix is the same one that greened e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7K3YohrPTLZu1jXf4KPjx