### PR TITLE
Remove dashboard routes and saved widgets tab from application settings

### DIFF
--- a/kinotic-frontend/src/components/SideBar.vue
+++ b/kinotic-frontend/src/components/SideBar.vue
@@ -109,9 +109,6 @@ function resolvePath(path: string): string {
 }
 
 function isActive(path: string): boolean {
-  if (path.includes('/dashboards') && !path.includes('/dashboards/')) {
-    return route.path === path || route.path.startsWith(path + '/')
-  }
   return route.path === path
 }
 

--- a/kinotic-frontend/src/layouts/Header.vue
+++ b/kinotic-frontend/src/layouts/Header.vue
@@ -5,7 +5,7 @@
         <img src="@/assets/header-logo.svg" class="h-6 w-[27px]" alt="Kinotic" />
       </RouterLink>
 
-      <template v-if="isApplicationDetailsPage || isProjectStructuresPage || isApplicationSettingsPage || isDashboardsPage">
+      <template v-if="isApplicationDetailsPage || isProjectStructuresPage || isApplicationSettingsPage">
         <span class="text-lg text-surface-600">/</span>
 
         <div ref="appDropdownRef" class="relative inline-block mr-8">
@@ -40,7 +40,7 @@
           </div>
         </div>
 
-                 <template v-if="currentApp && !isApplicationSettingsPage && !isDashboardsPage">
+                 <template v-if="currentApp && !isApplicationSettingsPage">
            <span class="text-lg text-surface-600">/</span>
            <div ref="projectDropdownRef" class="relative inline-block">
             <button @click="toggleProjectDropdown"
@@ -143,7 +143,6 @@ const searchTextProject = ref('');
 const isApplicationDetailsPage = ref(false);
 const isProjectStructuresPage = ref(false);
 const isApplicationSettingsPage = ref(false);
-const isDashboardsPage = ref(false);
 
 const projectsForCurrentApp = ref<Project[]>([]);
 const currentApp = ref<Application | null>(null);
@@ -219,10 +218,9 @@ function updateRouteState() {
   isApplicationDetailsPage.value = /^\/application\/[^/]+$/.test(path);
   isProjectStructuresPage.value = /^\/application\/[^/]+\/project\/[^/]+\/structures$/.test(path);
   isApplicationSettingsPage.value = /^\/application\/[^/]+\/settings$/.test(path);
-  isDashboardsPage.value = /^\/application\/[^/]+\/dashboards(\/.*)?$/.test(path);
 
   // Set current application based on route
-  if (isApplicationDetailsPage.value || isProjectStructuresPage.value || isApplicationSettingsPage.value || isDashboardsPage.value) {
+  if (isApplicationDetailsPage.value || isProjectStructuresPage.value || isApplicationSettingsPage.value) {
     const applicationId = route.params.applicationId as string;
     if (applicationId && currentApp.value?.id !== applicationId) {
       setActiveAppById(applicationId);
@@ -238,7 +236,7 @@ function updateRouteState() {
       setCurrentProjectById(projectId);
     }
   }
-  else if (isApplicationSettingsPage.value || isDashboardsPage.value) {
+  else if (isApplicationSettingsPage.value) {
     currentProject.value = null;
   }
 }

--- a/kinotic-frontend/src/pages/ApplicationSettings.vue
+++ b/kinotic-frontend/src/pages/ApplicationSettings.vue
@@ -2,168 +2,60 @@
   <div :class="['application-settings', isDark ? 'application-settings--dark' : 'application-settings--light']">
     <h1 class="application-settings__title">Application settings</h1>
 
-    <Tabs class="application-settings__tabs" :value="activeTab" @update:value="(value: string | number) => activeTab = Number(value)">
-      <TabList>
-        <Tab :value="0">General</Tab>
-        <Tab :value="1">Saved widgets</Tab>
-      </TabList>
-      <TabPanels class="!p-0">
-        <TabPanel :value="0">
-          <div v-show="activeTab === 0">
-            <div class="application-settings__general-shell">
-              <form @submit.prevent="saveSettings" class="application-settings__form">
-                <div class="application-settings__fields">
-                  <div class="application-settings__field">
-                    <label class="application-settings__label">Name</label>
-                    <InputText 
-                      v-model="appName" 
-                      type="text" 
-                      class="application-settings__input w-full" 
-                      disabled
-                    />
-                  </div>
-                  <div class="application-settings__field">
-                    <label class="application-settings__label">Description</label>
-                    <Textarea
-                      v-model="appDescription"
-                      class="application-settings__input application-settings__textarea w-full h-[100px]"
-                      rows="3"
-                    />
-                  </div>
-                  <div class="application-settings__field">
-                    <label class="application-settings__label">Tenant per user</label>
-                    <div class="flex items-center gap-3">
-                      <ToggleSwitch v-model="tenantPerUser" />
-                      <span class="text-sm text-muted-color">
-                        Each user of this application gets their own isolated tenant.
-                        Applies to users created after enabling.
-                      </span>
-                    </div>
-                  </div>
-                </div>
-                <div class="application-settings__actions">
-                  <Button 
-                    class="application-settings__save-btn"
-                    type="submit" 
-                    :disabled="loading" 
-                    severity="primary" 
-                    label="Save changes" 
-                  />
-                </div>
-              </form>
+    <div class="application-settings__general-shell">
+      <form @submit.prevent="saveSettings" class="application-settings__form">
+        <div class="application-settings__fields">
+          <div class="application-settings__field">
+            <label class="application-settings__label">Name</label>
+            <InputText
+              v-model="appName"
+              type="text"
+              class="application-settings__input w-full"
+              disabled
+            />
+          </div>
+          <div class="application-settings__field">
+            <label class="application-settings__label">Description</label>
+            <Textarea
+              v-model="appDescription"
+              class="application-settings__input application-settings__textarea w-full h-[100px]"
+              rows="3"
+            />
+          </div>
+          <div class="application-settings__field">
+            <label class="application-settings__label">Tenant per user</label>
+            <div class="flex items-center gap-3">
+              <ToggleSwitch v-model="tenantPerUser" />
+              <span class="text-sm text-muted-color">
+                Each user of this application gets their own isolated tenant.
+                Applies to users created after enabling.
+              </span>
             </div>
           </div>
-        </TabPanel>
-        <TabPanel :value="1">
-          <div v-show="activeTab === 1">
-            <!-- Loading state -->
-            <div v-if="loadingWidgets" class="flex justify-center py-12">
-              <i class="pi pi-spin pi-spinner text-3xl text-primary-500"></i>
-            </div>
-
-            <!-- Empty state -->
-            <div v-else-if="savedWidgets.length === 0" class="text-center py-12">
-              <div class="mb-4">
-                <i class="pi pi-chart-bar text-6xl text-surface-300"></i>
-              </div>
-              <h3 class="text-lg font-semibold text-surface-800 mb-2">No saved widgets yet</h3>
-              <p class="text-surface-500">
-                Create data insights in the Data Insights page to save widgets here.
-              </p>
-            </div>
-
-            <div v-else class="">
-              <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 py-4">
-                <div class="w-full sm:w-auto flex items-center gap-2">
-                  <IconField icon-position="left" class="w-full sm:w-80">
-                    <InputIcon class="pi pi-search" />
-                    <InputText 
-                      v-model="widgetSearchText" 
-                      placeholder="Search widgets..." 
-                      class="w-full"
-                    />
-                  </IconField>
-                  <Button 
-                    v-if="widgetSearchText"
-                    icon="pi pi-times" 
-                    severity="secondary"
-                    text
-                    rounded
-                    @click="widgetSearchText = ''"
-                    aria-label="Clear search"
-                  />
-                </div>
-              </div>
-              
-              <!-- No search results -->
-              <div v-if="filteredWidgets.length === 0 && widgetSearchText" class="text-center py-12">
-                <div class="mb-4">
-                  <i class="pi pi-search text-4xl text-surface-300"></i>
-                </div>
-                <h3 class="text-lg font-semibold text-surface-800 mb-2">No widgets found</h3>
-                <p class="text-surface-500">
-                  No widgets match your search "{{ widgetSearchText }}"
-                </p>
-              </div>
-              
-              <!-- Widgets grid -->
-              <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                <SavedWidgetItem
-                  v-for="widget in filteredWidgets"
-                  :key="widget.id || 'unknown'"
-                  :widget="widget"
-                  @delete="confirmDelete"
-                />
-              </div>
-            </div>
-          </div>
-        </TabPanel>
-      </TabPanels>
-    </Tabs>
-
-    <!-- Delete Confirmation Dialog -->
-    <Dialog
-      v-model:visible="showDeleteDialog"
-      modal
-      header="Delete Widget"
-      :style="{ width: '450px' }"
-    >
-      <div class="flex items-start gap-3">
-        <i class="pi pi-exclamation-triangle text-3xl text-orange-500"></i>
-        <div>
-          <p class="text-surface-700">
-            Are you sure you want to delete this widget? This action cannot be undone.
-          </p>
         </div>
-      </div>
-      <template #footer>
-        <Button
-          label="Cancel"
-          severity="secondary"
-          @click="showDeleteDialog = false"
-        />
-        <Button
-          label="Delete"
-          severity="danger"
-          @click="deleteWidget"
-        />
-      </template>
-    </Dialog>
+        <div class="application-settings__actions">
+          <Button
+            class="application-settings__save-btn"
+            type="submit"
+            :disabled="loading"
+            severity="primary"
+            label="Save changes"
+          />
+        </div>
+      </form>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 // @ts-ignore
-import { ref, defineProps, onMounted, watch, computed } from 'vue'
+import { ref, defineProps, onMounted, watch } from 'vue'
 import { showErrorToast } from '@/util/helpers'
-import { InputText, Textarea, Button, Tabs, TabList, Tab, TabPanels, TabPanel, Dialog, IconField, InputIcon, ToggleSwitch } from 'primevue'
+import { InputText, Textarea, Button, ToggleSwitch } from 'primevue'
 import { APPLICATION_STATE } from '@/states/IApplicationState'
 import { USER_STATE } from '@/states/IUserState'
 import { Kinotic } from '@kinotic-ai/core'
 import { useToast } from 'primevue/usetoast'
-import { DataInsightsWidgetEntityRepository } from '@/services/DataInsightsWidgetEntityRepository'
-import type { DataInsightsWidget } from '@/domain/DataInsightsWidget'
-import SavedWidgetItem from '@/components/SavedWidgetItem.vue'
 import { isDark as darkMode } from '@/composables/useTheme'
 
 defineProps({
@@ -178,14 +70,6 @@ const appName = ref('')
 const appDescription = ref('')
 const tenantPerUser = ref(false)
 const loading = ref(false)
-const activeTab = ref(0)
-
-const widgetService = new DataInsightsWidgetEntityRepository()
-const savedWidgets = ref<DataInsightsWidget[]>([])
-const loadingWidgets = ref(false)
-const showDeleteDialog = ref(false)
-const widgetToDelete = ref<string | null>(null)
-const widgetSearchText = ref('')
 const isDark = darkMode
 
 watch(() => APPLICATION_STATE.currentApplication, (newApp) => {
@@ -241,88 +125,6 @@ const saveSettings = async () => {
     loading.value = false
   }
 }
-
-const loadSavedWidgets = async () => {
-  if (!APPLICATION_STATE.currentApplication?.id) {
-    savedWidgets.value = []
-    return
-  }
-
-  loadingWidgets.value = true
-  try {
-    const widgets = await widgetService.findByApplicationId(APPLICATION_STATE.currentApplication.id)
-    savedWidgets.value = widgets
-  } catch (error) {
-    showErrorToast(toast, 'Failed to load saved widgets', error)
-  } finally {
-    loadingWidgets.value = false
-  }
-}
-
-const confirmDelete = (widgetId: string) => {
-  widgetToDelete.value = widgetId
-  showDeleteDialog.value = true
-}
-
-const deleteWidget = async () => {
-  if (!widgetToDelete.value) return
-
-  try {
-    await widgetService.deleteById(widgetToDelete.value)
-    savedWidgets.value = savedWidgets.value.filter(w => w.id !== widgetToDelete.value)
-    
-    toast.add({
-      severity: 'success',
-      summary: 'Success',
-      detail: 'Widget deleted successfully',
-      life: 3000
-    })
-  } catch (error) {
-    showErrorToast(toast, 'Failed to delete widget', error)
-  } finally {
-    showDeleteDialog.value = false
-    widgetToDelete.value = null
-  }
-}
-
-watch(activeTab, (newTab) => {
-  if (newTab === 1) {
-    loadSavedWidgets()
-  }
-})
-
-watch(() => APPLICATION_STATE.currentApplication, () => {
-  if (activeTab.value === 1) {
-    loadSavedWidgets()
-  }
-})
-
-const filteredWidgets = computed(() => {
-  if (!widgetSearchText.value) return savedWidgets.value
-  
-  const searchLower = widgetSearchText.value.toLowerCase()
-  return savedWidgets.value.filter(widget => {
-    const name = (widget as any).name?.toLowerCase() || ''
-    const description = (widget as any).description?.toLowerCase() || ''
-    const widgetType = (widget as any).widgetType?.toLowerCase() || ''
-      
-    try {
-      const config = JSON.parse((widget as any).config || '{}')
-      const aiTitle = config.aiTitle?.toLowerCase() || ''
-      const aiSubtitle = config.aiSubtitle?.toLowerCase() || ''
-      
-      return name.includes(searchLower) || 
-             description.includes(searchLower) || 
-             widgetType.includes(searchLower) ||
-             aiTitle.includes(searchLower) ||
-             aiSubtitle.includes(searchLower)
-    } catch {
-      return name.includes(searchLower) || 
-             description.includes(searchLower) || 
-             widgetType.includes(searchLower)
-    }
-  })
-})
 </script>
 
 <style scoped>
@@ -392,57 +194,6 @@ const filteredWidgets = computed(() => {
   display: flex;
   justify-content: flex-start;
   padding-top: 1.5rem;
-}
-
-.application-settings--dark :deep(.p-tablist) {
-  border-bottom: 1px solid #525252;
-  background: transparent;
-}
-
-.application-settings--light :deep(.p-tablist) {
-  border-bottom: 1px solid #e6e7eb;
-  background: transparent;
-}
-
-.application-settings :deep(.p-tablist-tab-list) {
-  background: transparent;
-}
-
-.application-settings--dark :deep(.p-tab) {
-  min-height: 47px;
-  padding: 14px 15px;
-  color: #a3a3a3;
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  font-size: 0.875rem;
-  font-weight: 500;
-  line-height: 1;
-}
-
-.application-settings--light :deep(.p-tab) {
-  min-height: 47px;
-  padding: 14px 15px;
-  color: #71717a;
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  font-size: 0.875rem;
-  font-weight: 500;
-  line-height: 1;
-}
-
-.application-settings :deep(.p-tab-active) {
-  color: #ffffff;
-}
-
-.application-settings--light :deep(.p-tab-active) {
-  color: #101010;
-}
-
-.application-settings :deep(.p-tablist-active-bar) {
-  height: 2px;
-  background: var(--p-primary-500);
 }
 
 .application-settings--dark :deep(.p-inputtext),

--- a/kinotic-frontend/src/pages/routes.ts
+++ b/kinotic-frontend/src/pages/routes.ts
@@ -96,9 +96,6 @@ const pageRoutes: RouteRecordRaw[] = [
       {
         name: 'application-dashboards',
         path: 'dashboards',
-        meta: {
-          sidebar: { group: 'application', label: 'Dashboards', icon: 'pi pi-chart-line', order: 20 } as SidebarItemMeta
-        } as RouteMeta,
         component: () => import('@/pages/Dashboards.vue'),
         props: (route) => ({ applicationId: route.params.applicationId })
       },

--- a/kinotic-frontend/src/pages/routes.ts
+++ b/kinotic-frontend/src/pages/routes.ts
@@ -79,8 +79,8 @@ const pageRoutes: RouteRecordRaw[] = [
       showInMainNav: false,
       label: 'Application Details',
       icon: 'microchip.svg',
-      // Children declare their own sidebar items; detail routes without one (dashboard
-      // view/edit) still render this group's sidebar.
+      // Children declare their own sidebar items; any without one still render
+      // this group's sidebar.
       sidebarGroup: 'application'
     }  as RouteMeta,
     children: [
@@ -92,45 +92,6 @@ const pageRoutes: RouteRecordRaw[] = [
         } as RouteMeta,
         component: () => import('@/pages/ApplicationDetails.vue'),
         props: (route) => ({ applicationId: route.params.applicationId })
-      },
-      {
-        name: 'application-dashboards',
-        path: 'dashboards',
-        component: () => import('@/pages/Dashboards.vue'),
-        props: (route) => ({ applicationId: route.params.applicationId })
-      },
-      {
-        name: 'dashboard-view',
-        path: 'dashboards/:dashboardId',
-        meta: { fullWidth: true } as RouteMeta,
-        component: () => import('@/pages/DashboardDetails.vue'),
-        props: (route) => ({ 
-          applicationId: route.params.applicationId,
-          dashboardId: route.params.dashboardId,
-          mode: 'view'
-        })
-      },
-      {
-        name: 'dashboard-edit',
-        path: 'dashboards/:dashboardId/edit',
-        meta: { fullWidth: true } as RouteMeta,
-        component: () => import('@/pages/DashboardDetails.vue'),
-        props: (route) => ({ 
-          applicationId: route.params.applicationId,
-          dashboardId: route.params.dashboardId,
-          mode: 'edit'
-        })
-      },
-      {
-        name: 'dashboard-new',
-        path: 'dashboards/new',
-        meta: { fullWidth: true } as RouteMeta,
-        component: () => import('@/pages/DashboardDetails.vue'),
-        props: (route) => ({ 
-          applicationId: route.params.applicationId,
-          dashboardId: 'new',
-          mode: 'edit'
-        })
       },
       {
         name: 'application-members',


### PR DESCRIPTION
Removes the dashboard management feature and the "Saved widgets" tab from the Application Settings page, simplifying the settings interface to focus on core application configuration.

## Changes

- **ApplicationSettings.vue**: Removed the tabbed interface and deleted the entire "Saved widgets" tab, including:
  - Widget search and filtering functionality
  - Widget grid display and `SavedWidgetItem` component integration
  - Delete confirmation dialog for widgets
  - All related state management (`activeTab`, `savedWidgets`, `loadingWidgets`, `widgetSearchText`, etc.)
  - Associated watchers and computed properties for widget loading and filtering
  - Tab-related PrimeVue component imports and styling

- **routes.ts**: Removed four dashboard-related routes:
  - `application-dashboards` (dashboards list page)
  - `dashboard-view` (view mode)
  - `dashboard-edit` (edit mode)
  - `dashboard-new` (create new dashboard)

- **Header.vue**: Removed dashboard page detection logic (`isDashboardsPage` ref and related conditionals) from the application dropdown and project dropdown rendering

- **SideBar.vue**: Removed dashboard-specific path matching logic from the `isActive()` function

The Application Settings page now displays only the General tab content (application name, description, and tenant-per-user configuration) without the tabbed interface.

https://claude.ai/code/session_01YQzZBMve13yW6M6fLPRFkv