### PR TITLE
Use CREATE_REPOSITORY scope for template repo generation

### DIFF
--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisioner.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisioner.java
@@ -68,8 +68,9 @@ public class GitHubProjectRepoProvisioner implements ProjectRepoProvisioner {
         return requireInstallation().compose(install -> {
             long installationId = install.getGithubInstallationId();
             // repoId is null — the repo doesn't exist yet, so we mint an
-            // installation-wide WRITE_CONTENTS token to create it.
-            return apiClient.getToken(installationId, null, GitHubApiClient.WRITE_CONTENTS)
+            // installation-wide CREATE_REPOSITORY token to create it. The generate
+            // endpoint 404s when the token lacks administration:write.
+            return apiClient.getToken(installationId, null, GitHubApiClient.CREATE_REPOSITORY)
                             .compose(token -> apiClient.createRepoFromTemplate(
                                     token.getToken(),
                                     properties.getGithub().getRepoTemplate(),

--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/client/GitHubApiClient.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/client/GitHubApiClient.java
@@ -17,6 +17,12 @@ public interface GitHubApiClient {
     /** Standard token scopes used in the platform. */
     Map<String, String> READ_CONTENTS = Map.of("contents", "read");
     Map<String, String> WRITE_CONTENTS = Map.of("contents", "write");
+    /**
+     * Scope for {@link #createRepoFromTemplate}: repo creation is an administration
+     * operation, and the generate endpoint additionally requires contents read.
+     */
+    Map<String, String> CREATE_REPOSITORY = Map.of("administration", "write",
+                                                   "contents", "read");
 
     /**
      * Creates a blob on {@code repoFullName} and returns its SHA, for binary
@@ -59,8 +65,9 @@ public interface GitHubApiClient {
      * The App must have {@code Administration: Write} permission on the target
      * owner. Fails if a repo with the given name already exists under the owner.
      *
-     * @param installationToken token scoped to the installation that has access to
-     *                          the template and the target owner
+     * @param installationToken token with {@link #CREATE_REPOSITORY} scope on an
+     *                          installation that has access to the template and the
+     *                          target owner
      * @param templateFullName  {@code owner/repo} of the template
      * @param owner             target account login (user or org)
      * @param name              new repo name (must satisfy GitHub's name rules)

--- a/kinotic-github/src/test/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisionerTest.java
+++ b/kinotic-github/src/test/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisionerTest.java
@@ -61,7 +61,7 @@ class GitHubProjectRepoProvisionerTest {
         install.setAccountLogin("acme");
         when(installationService.findForCurrentOrg())
                 .thenReturn(CompletableFuture.completedFuture(install));
-        when(apiClient.getToken(eq(42L), isNull(), eq(GitHubApiClient.WRITE_CONTENTS)))
+        when(apiClient.getToken(eq(42L), isNull(), eq(GitHubApiClient.CREATE_REPOSITORY)))
                 .thenReturn(Future.succeededFuture(new GitHubToken("install-token", Instant.now().plusSeconds(3600))));
         when(apiClient.getToken(eq(42L), eq(99L), eq(GitHubApiClient.WRITE_CONTENTS)))
                 .thenReturn(Future.succeededFuture(new GitHubToken("repo-token", Instant.now().plusSeconds(3600))));


### PR DESCRIPTION
The GitHub API's repository generation endpoint requires `administration:write` permission in addition to `contents:read`. The current code requests only `WRITE_CONTENTS` scope, which lacks the required administration permission and causes the endpoint to return 404.

**Changes:**

- Add `CREATE_REPOSITORY` scope constant to `GitHubApiClient` with both `administration:write` and `contents:read` permissions
- Update `GitHubProjectRepoProvisioner.provision()` to request `CREATE_REPOSITORY` scope instead of `WRITE_CONTENTS` when minting the installation-wide token for repository creation
- Update `GitHubProjectRepoProvisionerTest` to expect the new scope in the mock setup

The scope is scoped to the installation level (repoId is null) since the repository doesn't exist yet. This ensures the token has the necessary permissions for the generate endpoint to succeed.

https://claude.ai/code/session_01RjG42w2sjJrSxbxT78nqF8