### PR TITLE
Persist GitHub install with saveSync so findForCurrentOrg sees it

### DIFF
--- a/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/DefaultGitHubAppInstallationService.java
+++ b/kinotic-github/src/main/java/org/kinotic/github/internal/api/services/DefaultGitHubAppInstallationService.java
@@ -90,7 +90,9 @@ public class DefaultGitHubAppInstallationService
                 .setAccountType(details.accountType())
                 .setCreated(now)
                 .setUpdated(now);
-        return Future.fromCompletionStage(save(install));
+        // saveSync (not save) so the row is searchable before completeInstall resolves —
+        // the SPA reads it straight back via findForCurrentOrg(), which is a search.
+        return Future.fromCompletionStage(saveSync(install));
     }
 
     @Override


### PR DESCRIPTION
## Summary

`completeInstall` persisted the installation row with `save()`, which does not wait for the write to become visible in search. The SPA immediately reads it back via `findForCurrentOrg()` — a search — so whether the row was visible was a race against Elasticsearch's refresh interval. The new-project sidebar intermittently showed **Link GitHub** right after a successful link, and only a manual refresh (once ES had refreshed) showed it as linked.

```java
// DefaultGitHubAppInstallationService.persist
return Future.fromCompletionStage(saveSync(install));   // was: save(install)
```

`saveSync` waits for the row to be searchable before `completeInstall` resolves, so by the time the redirect lands and the sidebar re-checks via `findForCurrentOrg()`, the row is there.

## Context

Follow-up to #303 (popup → full-page redirect), which is already merged. That change made `completeInstall` run on the callback page followed by a navigation and a fresh `findForCurrentOrg()` read, which is where the read-your-writes race surfaced. This is the backend write side only — the frontend link-status read (moved into a reusable component in #302) is unaffected.

## Testing

- `:kinotic-github:compileJava` builds clean (JDK 25 toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014E1wrfGVuNea8hGANCx2tA)_