### PR TITLE
Fix multi-second white page on first visit after a gateway restart

### DIFF
--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/config/ApiGatewayConfiguration.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/config/ApiGatewayConfiguration.java
@@ -2,6 +2,8 @@ package org.kinotic.gateway.internal.config;
 
 import io.vertx.core.Vertx;
 import io.vertx.ext.healthchecks.HealthChecks;
+import io.vertx.ext.web.sstore.ClusteredSessionStore;
+import io.vertx.ext.web.sstore.LocalSessionStore;
 import io.vertx.ext.web.sstore.SessionStore;
 import org.kinotic.core.api.config.KinoticProperties;
 import org.kinotic.core.api.security.ConnectedInfo;
@@ -19,6 +21,8 @@ import tools.jackson.databind.json.JsonMapper;
 @Configuration
 public class ApiGatewayConfiguration {
 
+    private static final long SESSION_RETRY_TIMEOUT_MILLIS = 1000;
+
     @Bean
     public HealthChecks healthChecks(Vertx vertx) {
         return HealthChecks.create(vertx);
@@ -34,6 +38,19 @@ public class ApiGatewayConfiguration {
         // ConnectedInfo is stored in the SessionStore and is marshalled by this store when clustered.
         // Vert.x rebuilds it reflectively on read, so the jsonMapper cannot be injected, so we use a static field.
         ConnectedInfo.setSerializationMapper(jsonMapper);
-        return SessionStore.create(vertx);
+
+        if(vertx.isClustered()){
+            // SessionHandler retries a session id it cannot find until the store's retryTimeout elapses,
+            // to cover a session written on another node that has not propagated yet. With the 5s default,
+            // a browser presenting a stale cookie (its session gone, e.g. a restart cleared the Ignite map)
+            // stalls its first /api request for the full 5 seconds before being treated as session-less.
+            // One second still covers the propagation race without a user-visible hang on stale cookies.
+            ClusteredSessionStore store = ClusteredSessionStore.create(vertx, SESSION_RETRY_TIMEOUT_MILLIS);
+            // The backing cluster-wide map is created lazily on first access; touch it now so the first
+            // request after boot does not pay for the Ignite cache creation.
+            store.get("noop");
+            return store;
+        }
+        return LocalSessionStore.create(vertx);
     }
 }

--- a/kinotic-frontend/src/KinoticPreset.ts
+++ b/kinotic-frontend/src/KinoticPreset.ts
@@ -1,10 +1,10 @@
 import { definePreset } from '@primeuix/themes'
-import StructuresTheme from '@/theme'
+import KinoticTheme from '@/theme'
 
 /**
  * This is kinda a hack since the Theme Designer does not allow colors to be defined properly.
  */
-export const StructuresPreset = definePreset(StructuresTheme, {
+export const KinoticPreset = definePreset(KinoticTheme, {
     primitive:{
         brand: {
             50:  "#FFF0F4",

--- a/kinotic-frontend/src/components/Breadcrumb.vue
+++ b/kinotic-frontend/src/components/Breadcrumb.vue
@@ -10,13 +10,13 @@
 </template>
 
 <script setup lang="ts">
-import { StructuresStates } from '@/states/index.js'
+import { KinoticStates } from '@/states/index.js'
 import { computed } from 'vue'
 import Breadcrumb from 'primevue/breadcrumb'
 import type { MenuItem } from 'primevue/menuitem'
 import { NavItem } from '@/components/NavItem'
 
-const breadcrumbModel = computed<NavItem[]>(() => StructuresStates.getApplicationState().breadcrumbItems)
+const breadcrumbModel = computed<NavItem[]>(() => KinoticStates.getApplicationState().breadcrumbItems)
 
 // The #item slot types its argument as PrimeVue's MenuItem, but breadcrumbModel
 // only ever holds NavItems.

--- a/kinotic-frontend/src/layouts/MainLayout.vue
+++ b/kinotic-frontend/src/layouts/MainLayout.vue
@@ -45,7 +45,7 @@
 // import SideNav from '@/components/SideNav.vue'
 import Header from '@/layouts/Header.vue'
 import { isDark as darkMode } from '@/composables/useTheme'
-// import { StructuresStates } from '@/states/index.js'
+// import { KinoticStates } from '@/states/index.js'
 // import Avatar from 'primevue/avatar'
 // import MainLayoutBreadcrumb from './MainLayoutBreadcrumb.vue'
 // import { ref } from 'vue'
@@ -54,6 +54,6 @@ import { isDark as darkMode } from '@/composables/useTheme'
 
 const isDark = darkMode
 
-// const applicationState = StructuresStates.getApplicationState()
+// const applicationState = KinoticStates.getApplicationState()
 
 </script>

--- a/kinotic-frontend/src/main.ts
+++ b/kinotic-frontend/src/main.ts
@@ -1,9 +1,9 @@
-import { createStructuresUI } from '@/plugins/StructuresUI.js'
+import { createKinoticUI } from '@/plugins/KinoticUI.js'
 import './style.css'
 import './theme.css'
 import PrimeVue from 'primevue/config'
 import StyleClass from 'primevue/styleclass'
-import { StructuresPreset } from '@/StructuresPreset'
+import { KinoticPreset } from '@/KinoticPreset'
 import router from '@/router'
 import ToastService from 'primevue/toastservice'
 import ConfirmationService from 'primevue/confirmationservice'
@@ -11,7 +11,7 @@ import { CONTINUUM_UI } from '@/IContinuumUI'
 import 'primeicons/primeicons.css'
 import { createApp } from 'vue'
 import App from './App.vue'
-import { StructuresStates } from '@/states'
+import { KinoticStates } from '@/states'
 
 import { Kinotic } from '@kinotic-ai/core'
 import { OsApiPlugin } from '@kinotic-ai/os-api'
@@ -66,7 +66,7 @@ const app = createApp(App)
 
 app.use(PrimeVue, {
     theme: {
-        preset: StructuresPreset,
+        preset: KinoticPreset,
         options: {
             darkModeSelector: '.dark',
             cssLayer: false,
@@ -80,11 +80,11 @@ CONTINUUM_UI.initialize(router);
 // Probe for an existing browser session in the background. The auth guard awaits this promise
 // before checking auth state, so protected routes wait for the real result while public routes
 // (login, signup, verify) render immediately instead of blanking until the probe settles.
-const sessionProbe = StructuresStates.getUserState().login().catch(() => {})
+const sessionProbe = KinoticStates.getUserState().login().catch(() => {})
 
 app.directive('styleclass', StyleClass)
 app.use(ToastService)
 app.use(ConfirmationService)
-app.use(createStructuresUI(), { router, sessionProbe })
+app.use(createKinoticUI(), { router, sessionProbe })
 app.use(router)
 app.mount('#app')

--- a/kinotic-frontend/src/main.ts
+++ b/kinotic-frontend/src/main.ts
@@ -77,16 +77,14 @@ app.use(PrimeVue, {
 
 CONTINUUM_UI.initialize(router);
 
+// Probe for an existing browser session in the background. The auth guard awaits this promise
+// before checking auth state, so protected routes wait for the real result while public routes
+// (login, signup, verify) render immediately instead of blanking until the probe settles.
+const sessionProbe = StructuresStates.getUserState().login().catch(() => {})
+
 app.directive('styleclass', StyleClass)
 app.use(ToastService)
 app.use(ConfirmationService)
-app.use(createStructuresUI(), { router })
-
-// Installing the router fires its initial navigation, which runs the auth guard. Do that after the
-// session probe resolves, so the guard sees the real auth state.
-StructuresStates.getUserState().login()
-    .catch(() => {})
-    .finally(() => {
-        app.use(router)
-        app.mount('#app')
-    })
+app.use(createStructuresUI(), { router, sessionProbe })
+app.use(router)
+app.mount('#app')

--- a/kinotic-frontend/src/pages/MembersPage.vue
+++ b/kinotic-frontend/src/pages/MembersPage.vue
@@ -98,7 +98,7 @@ import type { IamUser, PendingInviteSummary } from '@kinotic-ai/os-api'
 import CrudTable from '@/components/CrudTable.vue'
 import type { CrudHeader } from '@/types/CrudHeader'
 import type { DescriptiveIdentifiable } from '@/types/DescriptiveIdentifiable'
-import { StructuresStates } from '@/states'
+import { KinoticStates } from '@/states'
 import { apiUrl, showErrorToast } from '@/util/helpers'
 import { createDebug } from '@/util/debug'
 
@@ -144,7 +144,7 @@ const tableSearch = ref('')
 
 const toast = useToast()
 const confirm = useConfirm()
-const userState = StructuresStates.getUserState()
+const userState = KinoticStates.getUserState()
 
 const crudTable = ref<InstanceType<typeof CrudTable>>()
 

--- a/kinotic-frontend/src/pages/login/Login.vue
+++ b/kinotic-frontend/src/pages/login/Login.vue
@@ -94,7 +94,7 @@ import IconField from 'primevue/iconfield'
 import { useToast } from 'primevue/usetoast'
 
 import { CONTINUUM_UI } from '@/IContinuumUI'
-import { StructuresStates } from '@/states'
+import { KinoticStates } from '@/states'
 import { type IUserState } from '@/states/IUserState'
 import { createDebug } from '@/util/debug'
 import { apiUrl } from '@/util/helpers'
@@ -120,7 +120,7 @@ const emailInput = ref<any>()
 const passwordInput = ref<any>()
 
 const toast = useToast()
-const userState: IUserState = StructuresStates.getUserState()
+const userState: IUserState = KinoticStates.getUserState()
 
 const route = useRoute()
 const router = useRouter()

--- a/kinotic-frontend/src/pages/signup/AcceptInvitation.vue
+++ b/kinotic-frontend/src/pages/signup/AcceptInvitation.vue
@@ -83,7 +83,7 @@ import AuthPageShell from '@/components/auth/AuthPageShell.vue'
 import SetPasswordFields from '@/components/auth/SetPasswordFields.vue'
 import SocialAuthButton from '@/components/SocialAuthButton.vue'
 import { CONTINUUM_UI } from '@/IContinuumUI'
-import { StructuresStates } from '@/states'
+import { KinoticStates } from '@/states'
 import { apiUrl } from '@/util/helpers'
 
 interface InviteProvider {
@@ -121,7 +121,7 @@ const invalidMessage = ref('Open this page from the link in your invitation emai
 
 const token = ref('')
 const toast = useToast()
-const userState = StructuresStates.getUserState()
+const userState = KinoticStates.getUserState()
 
 const passwordFields = ref<InstanceType<typeof SetPasswordFields>>()
 

--- a/kinotic-frontend/src/pages/signup/CompleteOrg.vue
+++ b/kinotic-frontend/src/pages/signup/CompleteOrg.vue
@@ -53,7 +53,7 @@ import Button from 'primevue/button'
 import { useToast } from 'primevue/usetoast'
 
 import { CONTINUUM_UI } from '@/IContinuumUI'
-import { StructuresStates } from '@/states/index'
+import { KinoticStates } from '@/states/index'
 import { type IUserState } from '@/states/IUserState'
 import { apiUrl } from '@/util/helpers'
 import AuthPageShell from '@/components/auth/AuthPageShell.vue'
@@ -70,7 +70,7 @@ const orgDescription = ref('')
 const loading = ref(false)
 
 const toast = useToast()
-const userState: IUserState = StructuresStates.getUserState()
+const userState: IUserState = KinoticStates.getUserState()
 const route = useRoute()
 
 const orgNameInput = useTemplateRef<any>('orgName')

--- a/kinotic-frontend/src/pages/signup/VerifyEmail.vue
+++ b/kinotic-frontend/src/pages/signup/VerifyEmail.vue
@@ -52,11 +52,11 @@ import AuthPageShell from '@/components/auth/AuthPageShell.vue'
 import SetPasswordFields from '@/components/auth/SetPasswordFields.vue'
 import { apiUrl } from '@/util/helpers'
 import { CONTINUUM_UI } from '@/IContinuumUI'
-import { StructuresStates } from '@/states/index'
+import { KinoticStates } from '@/states/index'
 import { type IUserState } from '@/states/IUserState'
 
 const toast = useToast()
-const userState: IUserState = StructuresStates.getUserState()
+const userState: IUserState = KinoticStates.getUserState()
 const route = useRoute()
 
 const request = ref<SignUpCompleteRequest>({

--- a/kinotic-frontend/src/plugins/KinoticUI.ts
+++ b/kinotic-frontend/src/plugins/KinoticUI.ts
@@ -1,8 +1,8 @@
 import type { NavigationGuardNext, RouteLocationNormalized, Router } from 'vue-router'
 import type { App, Plugin } from 'vue'
-import {StructuresStates} from '@/states/index'
+import {KinoticStates} from '@/states/index'
 
-export function createStructuresUI(): Plugin {
+export function createKinoticUI(): Plugin {
     return {
         install(_: App, options: {router: Router, sessionProbe: Promise<void>}) {
             options.router.beforeEach(async (to: RouteLocationNormalized, _: RouteLocationNormalized, next: NavigationGuardNext) => {
@@ -12,7 +12,7 @@ export function createStructuresUI(): Plugin {
                     // Settles once the session-cookie connect attempt finishes, so the guard sees
                     // the real auth state on the initial navigation.
                     await options.sessionProbe
-                    if (!StructuresStates.getUserState().isAuthenticated()) {
+                    if (!KinoticStates.getUserState().isAuthenticated()) {
                         next({ path: '/login', query: { referer: to.fullPath } })
                         return
                     }
@@ -20,7 +20,7 @@ export function createStructuresUI(): Plugin {
                 next()
             })
 
-            StructuresStates.getApplicationState().initialize(options.router)
+            KinoticStates.getApplicationState().initialize(options.router)
         }
     }
 }

--- a/kinotic-frontend/src/plugins/StructuresUI.ts
+++ b/kinotic-frontend/src/plugins/StructuresUI.ts
@@ -4,16 +4,20 @@ import {StructuresStates} from '@/states/index'
 
 export function createStructuresUI(): Plugin {
     return {
-        install(_: App, options: {router: Router}) {
-            options.router.beforeEach((to: RouteLocationNormalized, _: RouteLocationNormalized, next: NavigationGuardNext) => {
+        install(_: App, options: {router: Router, sessionProbe: Promise<void>}) {
+            options.router.beforeEach(async (to: RouteLocationNormalized, _: RouteLocationNormalized, next: NavigationGuardNext) => {
 
                 const { authenticationRequired } = to.meta
-                if ((authenticationRequired === undefined || authenticationRequired)
-                    && !StructuresStates.getUserState().isAuthenticated()){
-                    next({ path: '/login', query: { referer: to.fullPath } })
-                } else {
-                    next()
+                if (authenticationRequired === undefined || authenticationRequired) {
+                    // Settles once the session-cookie connect attempt finishes, so the guard sees
+                    // the real auth state on the initial navigation.
+                    await options.sessionProbe
+                    if (!StructuresStates.getUserState().isAuthenticated()) {
+                        next({ path: '/login', query: { referer: to.fullPath } })
+                        return
+                    }
                 }
+                next()
             })
 
             StructuresStates.getApplicationState().initialize(options.router)

--- a/kinotic-frontend/src/states/IUserState.ts
+++ b/kinotic-frontend/src/states/IUserState.ts
@@ -42,6 +42,16 @@ export class UserState implements IUserState {
                 debug('No existing connection to disconnect')
             }
 
+            this.connectedInfo = null
+
+            // Reject immediately when the backend is unreachable or there is no valid session,
+            // rather than letting Kinotic.connect retry the websocket indefinitely — callers
+            // (the auth guard on app start) need a settled answer to route to /login.
+            const sessionCheck = await fetch(apiUrl('/api/auth/me'), { credentials: 'include' })
+            if (!sessionCheck.ok) {
+                throw new Error('Session authentication failed')
+            }
+
             try {
                 this.connectedInfo = await Kinotic.connect(createConnectionInfo())
             } catch (reason: any) {

--- a/kinotic-frontend/src/states/index.ts
+++ b/kinotic-frontend/src/states/index.ts
@@ -3,7 +3,7 @@ import {APPLICATION_STATE, type IApplicationState} from './IApplicationState'
 import {USER_STATE, type IUserState} from './IUserState'
 import {INSIGHTS_STATE, type IInsightsState} from './IInsightsState'
 
-export namespace StructuresStates {
+export namespace KinoticStates {
 
     export function getApplicationState(): Reactive<IApplicationState> {
         return APPLICATION_STATE


### PR DESCRIPTION
## Problem

First visit to a page (reported on `/signup/verify?token=…`) hung on a white screen for several seconds before rendering. Two causes stacked:

**1. Backend: stale session cookies stall for 5 seconds.** Vert.x's `SessionHandler` retries a session id it can't find until the store's `retryTimeout` elapses:

```java
// vertx-web SessionHandlerImpl — retries every 5ms for up to sessionStore.retryTimeout()
if (System.currentTimeMillis() - startTime < sessionStore.retryTimeout()) {
    vertx.setTimer(5L, v -> doGetSession(vertx, startTime, sessionID, resultHandler));
```

`ClusteredSessionStore`'s default is **5 seconds**. A browser holding a cookie whose session is gone (a restart cleared the Ignite map) stalled its first `/api` request for the full window before being treated as session-less. The first request after boot also paid Ignite cache creation, since the store's backing map is created lazily.

**2. Frontend: everything blocked on the session probe.** `main.ts` deferred `app.mount()` until the realtime-connect probe settled, so nothing rendered — public signup pages included — until the backend answered (or the stalls above played out).

## Changes

**`ApiGatewayConfiguration.java`** — bound the retry window to 1s (still orders of magnitude above real Ignite write propagation, which the retry exists to cover) and touch the store at bean creation so the Ignite map exists before the first request:

```java
ClusteredSessionStore store = ClusteredSessionStore.create(vertx, SESSION_RETRY_TIMEOUT_MILLIS); // 1000
store.get("noop"); // create the lazy cluster-wide map at boot
```

**`main.ts` / `StructuresUI.ts`** — mount immediately; the probe runs concurrently and only the auth guard awaits it, so public routes render as soon as their chunk loads while protected routes still see the real auth state on the initial navigation.

**`IUserState.ts`** — `login()` preflights `/api/auth/me` and rejects immediately on an unreachable backend or missing session, instead of letting `Kinotic.connect` retry the websocket indefinitely:

```java
const sessionCheck = await fetch(apiUrl('/api/auth/me'), { credentials: 'include' })
if (!sessionCheck.ok) {
    throw new Error('Session authentication failed')
}
```

With this, a dead backend drops protected routes onto the login page (which shows its own loading state during sign-in) rather than a blank screen.

## Verification

- Frontend driven with Playwright against `vite dev` plus a stub backend: `/signup/verify` renders in ~600ms with the backend down entirely (previously blank indefinitely); `/applications` redirects to `/login?referer=/applications` in ~650ms against a 401 backend; the verify form submits and surfaces errors normally.
- `:kinotic-api-gateway:compileJava` passes. The gateway wasn't run end-to-end here (needs Ignite + Elasticsearch); the runtime check is: restart the gateway with a logged-in browser, first `/api/auth/me` should answer within ~1s worst case instead of ~5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014713WrTV8wRoqx9NwqovQY

---
_Generated by [Claude Code](https://claude.ai/code/session_014713WrTV8wRoqx9NwqovQY)_