### PR TITLE
Simplify event consumer/subscription to single instance

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/service/invoker/ServiceInvocationSupervisor.java
@@ -28,7 +28,6 @@ import reactor.core.publisher.SignalType;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -56,8 +55,8 @@ public class ServiceInvocationSupervisor {
     private final Vertx vertx;
 
 
-    // One consumer per zone address the service is addressable by
-    private List<EventConsumer> methodInvocationEventConsumers = List.of();
+    // Consumer for the address the service is addressable by
+    private EventConsumer methodInvocationEventConsumer;
 
 
     public ServiceInvocationSupervisor(ServiceDescriptor serviceDescriptor,
@@ -103,25 +102,20 @@ public class ServiceInvocationSupervisor {
     public Future<Void> start(){
         if(active.compareAndSet(false, true)){
             // begin listening on the event bus for service invocation requests
-            methodInvocationEventConsumers = List.of(eventBusService.listen(serviceDescriptor.serviceIdentifier().cri()));
+            methodInvocationEventConsumer = eventBusService.listen(serviceDescriptor.serviceIdentifier().cri());
 
-            for (EventConsumer eventConsumer : methodInvocationEventConsumers) {
-                eventConsumer
-                        .handler(event -> vertx.executeBlocking(() -> {
-                            processEvent(event);
-                            return null;
-                        }))
-                        .exceptionHandler(throwable -> log.error("Event listener error", throwable))
-                        .endHandler(_ -> {
-                            log.error("Should not happen! Event listener stopped for some reason!! Changing supervisor state to inactive");
-                            active.set(false);
-                        });
-            }
+            methodInvocationEventConsumer
+                    .handler(event -> vertx.executeBlocking(() -> {
+                        processEvent(event);
+                        return null;
+                    }))
+                    .exceptionHandler(throwable -> log.error("Event listener error", throwable))
+                    .endHandler(_ -> {
+                        log.error("Should not happen! Event listener stopped for some reason!! Changing supervisor state to inactive");
+                        active.set(false);
+                    });
 
-            return Future.all(methodInvocationEventConsumers.stream()
-                                                            .map(EventConsumer::completion)
-                                                            .toList())
-                         .mapEmpty();
+            return methodInvocationEventConsumer.completion();
         }else{
             return Future.failedFuture(new IllegalStateException("Service already started"));
         }
@@ -137,10 +131,7 @@ public class ServiceInvocationSupervisor {
                 streamSubscribers.getValue().cancel();
             }
 
-            return Future.all(methodInvocationEventConsumers.stream()
-                                                            .map(EventConsumer::unregister)
-                                                            .toList())
-                         .mapEmpty();
+            return methodInvocationEventConsumer.unregister();
         }else{
             return Future.failedFuture(new IllegalStateException("Service already stopped"));
         }

--- a/kinotic-js/workspace/packages/core/src/api/ServiceRegistry.ts
+++ b/kinotic-js/workspace/packages/core/src/api/ServiceRegistry.ts
@@ -8,7 +8,7 @@ import {
 } from '@opentelemetry/semantic-conventions'
 import { Observable } from 'rxjs'
 import { first, map } from 'rxjs/operators'
-import info from '../../package.json' assert { type: 'json' }
+import info from '../../package.json' with { type: 'json' }
 import { Event } from './event/EventBus'
 import { EventConstants, type IEvent, type IEventBus } from './event/IEventBus'
 import type {IEventFactory, IServiceProxy, IServiceRegistry} from './IServiceRegistry'

--- a/kinotic-js/workspace/packages/core/src/api/security/BasicAuthProvider.ts
+++ b/kinotic-js/workspace/packages/core/src/api/security/BasicAuthProvider.ts
@@ -9,8 +9,13 @@ export class BasicAuthProvider implements IAuthProvider {
     private readonly authHeader: string
 
     constructor(login: string, passcode: string) {
-        const encoded: string = Buffer.from(`${login}:${passcode}`).toString('base64')
-        this.authHeader = `Basic ${encoded}`
+        // btoa only handles Latin1, so encode the credentials as UTF-8 bytes before base64
+        const bytes = new TextEncoder().encode(`${login}:${passcode}`)
+        let binary = ''
+        for (const byte of bytes) {
+            binary += String.fromCharCode(byte)
+        }
+        this.authHeader = `Basic ${btoa(binary)}`
     }
 
     public getAuthHeaders(): Record<string, string> {

--- a/kinotic-js/workspace/packages/core/src/internal/api/Logger.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/Logger.ts
@@ -1,3 +1,5 @@
+import debug from 'debug'
+
 /**
  * Logging utilities for the Kinoitc library.
  *
@@ -21,18 +23,12 @@ export class NoOpLogger implements Logger {
 }
 
 export function createDebugLogger(namespace: string): Logger {
-    let debug: any
-    try {
-        debug = require("debug")(namespace)
-    } catch (e) {
-        debug = (...args: any[]) => console.debug(`[${namespace}]`, ...args)
-    }
-
+    const debugLogger = debug(namespace)
     return {
-        trace: (...args) => debug("TRACE", ...args),
-        debug: (...args) => debug("DEBUG", ...args),
-        info: (...args) => debug("INFO", ...args),
-        warn: (...args) => debug("WARN", ...args),
-        error: (...args) => debug("ERROR", ...args),
+        trace: (...args) => debugLogger("TRACE", ...args),
+        debug: (...args) => debugLogger("DEBUG", ...args),
+        info: (...args) => debugLogger("INFO", ...args),
+        warn: (...args) => debugLogger("WARN", ...args),
+        error: (...args) => debugLogger("ERROR", ...args),
     }
 }

--- a/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
+++ b/kinotic-js/workspace/packages/core/src/internal/api/ServiceInvocationSupervisor.ts
@@ -24,8 +24,8 @@ export class ServiceInvocationSupervisor {
     private readonly returnValueConverter: ReturnValueConverter
     private readonly serviceIdentifier: ServiceIdentifier
     private readonly serviceInstance: any
-    // One subscription per zone address the service is addressable by
-    private methodSubscriptions: Subscription[] = []
+    // Subscription for the address the service is addressable by
+    private methodSubscription: Subscription | null = null
     private readonly methodMap: Record<string, (...args: any[]) => any>
 
     constructor(
@@ -83,21 +83,21 @@ export class ServiceInvocationSupervisor {
 
         // Subscribe at the service's zone address, dispatching to the invocation machinery
         const criBase = this.serviceIdentifier.cri().baseResource()
-        this.methodSubscriptions.push(this._eventBus
-                                          .observe(criBase)
-                                          .subscribe({
-                                                         next: async (event: IEvent) => {
-                                                             await this.processEvent(event);
-                                                         },
-                                                         error: (error: Error) => {
-                                                             this.log.error("Event listener error", error)
-                                                             this.active = false
-                                                         },
-                                                         complete: () => {
-                                                             this.log.error("Event listener stopped unexpectedly. Setting supervisor inactive.")
-                                                             this.active = false
-                                                         },
-                                                     }))
+        this.methodSubscription = this._eventBus
+                                      .observe(criBase)
+                                      .subscribe({
+                                                     next: async (event: IEvent) => {
+                                                         await this.processEvent(event);
+                                                     },
+                                                     error: (error: Error) => {
+                                                         this.log.error("Event listener error", error)
+                                                         this.active = false
+                                                     },
+                                                     complete: () => {
+                                                         this.log.error("Event listener stopped unexpectedly. Setting supervisor inactive.")
+                                                         this.active = false
+                                                     },
+                                                 })
 
         this.log.info(`ServiceInvocationSupervisor started for ${criBase}`)
     }
@@ -108,10 +108,8 @@ export class ServiceInvocationSupervisor {
         }
         this.active = false
 
-        for (const subscription of this.methodSubscriptions) {
-            subscription.unsubscribe()
-        }
-        this.methodSubscriptions = []
+        this.methodSubscription?.unsubscribe()
+        this.methodSubscription = null
 
         this.log.info("ServiceInvocationSupervisor stopped")
     }

--- a/kinotic-js/workspace/packages/core/tsconfig.json
+++ b/kinotic-js/workspace/packages/core/tsconfig.json
@@ -3,6 +3,8 @@
 	"compilerOptions": {
 		"declaration": true,
 		"isolatedDeclarations": true,
+		// bunup resolves the "@/*" alias through baseUrl, so it must stay; silence the TS 6 baseUrl deprecation
+		"ignoreDeprecations": "6.0",
 		"baseUrl": ".",
 		"paths": {
 			"@/*": [


### PR DESCRIPTION
Refactor `ServiceInvocationSupervisor` in both Java and TypeScript implementations to use a single event consumer/subscription instead of maintaining a list. The service listens on one address per invocation supervisor, so the list wrapper was unnecessary overhead.

**Changes:**

- **Java** (`ServiceInvocationSupervisor.java`):
  - Replace `List<EventConsumer> methodInvocationEventConsumers` with single `EventConsumer methodInvocationEventConsumer`
  - Remove loop over consumers in `start()` and `stop()` methods
  - Simplify `Future.all()` chains to direct `completion()` and `unregister()` calls
  - Remove unused `java.util.List` import

- **TypeScript** (`ServiceInvocationSupervisor.ts`):
  - Replace `Subscription[] methodSubscriptions` with single `Subscription | null methodSubscription`
  - Simplify subscription setup in `start()` to direct assignment
  - Replace loop in `stop()` with optional chaining unsubscribe and null assignment
  - Update comments to reflect single subscription model

- **Logger.ts**: Refactor debug logger creation to import `debug` at module level and remove try-catch fallback, simplifying the implementation.

- **BasicAuthProvider.ts**: Fix UTF-8 encoding for base64 credentials by using `TextEncoder` instead of `Buffer.from()`, ensuring proper handling of non-Latin1 characters.

- **ServiceRegistry.ts**: Update JSON import assertion syntax from `assert` to `with` (ES2024 standard).

- **tsconfig.json**: Add `ignoreDeprecations: "6.0"` to suppress TypeScript 6 baseUrl deprecation warning while maintaining required alias resolution.

https://claude.ai/code/session_01VH5YnUG3kQ8rXBPEcujgVV