### PR TITLE
Make the zone a first-class CRI component with a folded identity

### DIFF
--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
@@ -24,14 +24,30 @@ public class StompAuthorizer {
     private final String replyToId;
     private final LinkedList<String> temporarySendGrants = new LinkedList<>();
 
-    public StompAuthorizer(boolean sendAnyZone,
-                           Set<String> sendZones,
-                           Set<String> hostZones,
-                           String replyToId) {
+    private StompAuthorizer(boolean sendAnyZone,
+                            Set<String> sendZones,
+                            Set<String> hostZones,
+                            String replyToId) {
         this.sendAnyZone = sendAnyZone;
         this.sendZones = sendZones;
         this.hostZones = hostZones;
         this.replyToId = replyToId;
+    }
+
+    /**
+     * An authorizer that may send to every zone, including un-zoned addresses, and host in the
+     * given zones.
+     */
+    public static StompAuthorizer allZoneSender(Set<String> hostZones, String replyToId) {
+        return new StompAuthorizer(true, Set.of(), hostZones, replyToId);
+    }
+
+    /**
+     * An authorizer restricted to the given zones: sends require a zone in {@code sendZones} and
+     * hosting requires one in {@code hostZones}, each matching exactly or as a sub-zone.
+     */
+    public static StompAuthorizer zoneRestricted(Set<String> sendZones, Set<String> hostZones, String replyToId) {
+        return new StompAuthorizer(false, sendZones, hostZones, replyToId);
     }
 
     /**

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
@@ -4,91 +4,97 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.Validate;
 import org.kinotic.core.api.event.CRI;
 import org.kinotic.core.api.event.EventConstants;
-import org.springframework.http.server.PathContainer;
-import org.springframework.web.util.pattern.PathPattern;
 
 import java.util.LinkedList;
-import java.util.List;
-import java.util.function.Function;
+import java.util.Set;
 
 /**
- * Authorizes STOMP sends and subscriptions for a connected participant.
+ * Authorizes STOMP sends and subscriptions for a connected participant against the zones the
+ * participant may address. Zones come from the CRI itself, so an un-zoned address is only ever
+ * reachable by a participant that may send to any zone.
  */
 @Slf4j
 public class StompAuthorizer {
 
-    private static final int MAX_TEMPORARY_PATTERNS = 1000;
+    private static final int MAX_TEMPORARY_GRANTS = 1000;
 
-    private final PathContainer.Options parseOptions;
-    private final List<PathPattern> sendPathPatterns;
-    private final List<PathPattern> subscribePathPatterns;
-    private final Function<String, PathPattern> pathPatternResolver;
-    private final LinkedList<PathPattern> temporarySendPathPatterns = new LinkedList<>();
+    private final boolean sendAnyZone;
+    private final Set<String> sendZones;
+    private final Set<String> hostZones;
+    private final String replyToId;
+    private final LinkedList<String> temporarySendGrants = new LinkedList<>();
 
-    public StompAuthorizer(PathContainer.Options parseOptions,
-                           List<PathPattern> sendPathPatterns,
-                           List<PathPattern> subscribePathPatterns,
-                           Function<String, PathPattern> pathPatternResolver) {
-        this.parseOptions = parseOptions;
-        this.sendPathPatterns = sendPathPatterns;
-        this.subscribePathPatterns = subscribePathPatterns;
-        this.pathPatternResolver = pathPatternResolver;
+    public StompAuthorizer(boolean sendAnyZone,
+                           Set<String> sendZones,
+                           Set<String> hostZones,
+                           String replyToId) {
+        this.sendAnyZone = sendAnyZone;
+        this.sendZones = sendZones;
+        this.hostZones = hostZones;
+        this.replyToId = replyToId;
     }
 
-    public void addTemporarySendAllowed(String criPattern) {
-        if (temporarySendPathPatterns.size() == MAX_TEMPORARY_PATTERNS) {
-            temporarySendPathPatterns.removeFirst();
-            log.warn("Reached Max Temporary patterns some messages may be dropped");
+    /**
+     * Grants one send to the given destination, consumed by the next matching {@link #sendAllowed(CRI)}.
+     * @param rawCri the destination to allow, matched exactly after normalization
+     */
+    public void addTemporarySendAllowed(String rawCri) {
+        if (temporarySendGrants.size() == MAX_TEMPORARY_GRANTS) {
+            temporarySendGrants.removeFirst();
+            log.warn("Reached max temporary grants some messages may be dropped");
         }
-        temporarySendPathPatterns.add(pathPatternResolver.apply(criPattern));
+        // normalizing through CRI folds the identity, so the grant compares equal to the folded
+        // raw() of the send it authorizes
+        temporarySendGrants.add(CRI.create(rawCri).raw());
     }
 
     public boolean sendAllowed(CRI cri) {
         Validate.notNull(cri, "The CRI must not be null");
-        int result = -1;
-
-        if (!temporarySendPathPatterns.isEmpty()) {
-            result = checkMatches(cri, temporarySendPathPatterns);
-            if (result != -1) {
-                temporarySendPathPatterns.remove(result);
-            }
-        }
-
-        if (result == -1) {
-            result = checkMatches(cri, sendPathPatterns);
-        }
-        return result != -1;
-    }
-
-    public boolean subscribeAllowed(CRI cri) {
-        Validate.notNull(cri, "The CRI must not be null");
-        return checkMatches(cri, subscribePathPatterns) != -1;
-    }
-
-    private int checkMatches(CRI cri, List<PathPattern> patterns) {
-        // A srv/stream scope is a node-targeting id (possibly a dotted FQDN a MESSAGE_ROUTE '*'
-        // cannot span), so it is stripped and the message is authorized on the zone it routes to.
-        // Matching the raw form for these would let a crafted scope prefix the string with an
-        // allowed zone and target another zone after the '@'. Reply CRIs are the exception: their
-        // scope carries the replyToId the reply pattern authorizes against, so they match raw.
-        boolean deScope = cri.hasScope()
-                && !EventConstants.REPLY_DESTINATION_SCHEME.equals(cri.scheme());
-        PathContainer target = PathContainer.parsePath(deScope ? deScope(cri) : cri.raw(), parseOptions);
-        int ret = -1;
-        for (int i = 0; i < patterns.size(); i++) {
-            if (patterns.get(i).matches(target)) {
-                ret = i;
-                break;
-            }
+        boolean ret;
+        if (temporarySendGrants.remove(cri.raw())) {
+            ret = true;
+        } else if (isRoutableScheme(cri.scheme())) {
+            ret = sendAnyZone || zoneAllowed(cri.zone(), sendZones);
+        } else {
+            ret = false;
         }
         return ret;
     }
 
-    // Removes the leading "scope@" from a scoped CRI without a per-call regex compile
-    private static String deScope(CRI cri) {
-        String raw = cri.raw();
-        String prefix = cri.scheme() + "://" + cri.scope() + "@";
-        return raw.startsWith(prefix) ? cri.scheme() + "://" + raw.substring(prefix.length()) : raw;
+    public boolean subscribeAllowed(CRI cri) {
+        Validate.notNull(cri, "The CRI must not be null");
+        boolean ret;
+        if (EventConstants.REPLY_DESTINATION_SCHEME.equals(cri.scheme())) {
+            // a reply destination is scoped to the connection: the scope carries the replyToId
+            // followed by ':' and the subscription discriminator
+            String scope = cri.scope();
+            ret = scope != null && scope.startsWith(replyToId + ":");
+        } else if (isRoutableScheme(cri.scheme())) {
+            ret = zoneAllowed(cri.zone(), hostZones);
+        } else {
+            ret = false;
+        }
+        return ret;
+    }
+
+    private static boolean isRoutableScheme(String scheme) {
+        return EventConstants.SERVICE_DESTINATION_SCHEME.equals(scheme)
+                || EventConstants.STREAM_DESTINATION_SCHEME.equals(scheme);
+    }
+
+    // A zone is allowed when it is an allowed zone or a sub-zone of one; the dot boundary keeps
+    // 'app.acme-org.orders-app-2' from matching 'app.acme-org.orders-app'
+    private static boolean zoneAllowed(String zone, Set<String> allowedZones) {
+        boolean ret = false;
+        if (zone != null) {
+            for (String allowed : allowedZones) {
+                if (zone.equals(allowed) || zone.startsWith(allowed + ".")) {
+                    ret = true;
+                    break;
+                }
+            }
+        }
+        return ret;
     }
 
 }

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
@@ -20,34 +20,34 @@ public class StompAuthorizer {
 
     private final boolean sendAnyZone;
     private final Set<String> sendZones;
-    private final Set<String> hostZones;
+    private final Set<String> subscribableZones;
     private final String replyToId;
     private final LinkedList<String> temporarySendGrants = new LinkedList<>();
 
     private StompAuthorizer(boolean sendAnyZone,
                             Set<String> sendZones,
-                            Set<String> hostZones,
+                            Set<String> subscribableZones,
                             String replyToId) {
         this.sendAnyZone = sendAnyZone;
         this.sendZones = sendZones;
-        this.hostZones = hostZones;
+        this.subscribableZones = subscribableZones;
         this.replyToId = replyToId;
     }
 
     /**
-     * An authorizer that may send to every zone, including un-zoned addresses, and host in the
-     * given zones.
+     * An authorizer that may send to every zone, including un-zoned addresses, and subscribe in
+     * the given zones.
      */
-    public static StompAuthorizer allZoneSender(Set<String> hostZones, String replyToId) {
-        return new StompAuthorizer(true, Set.of(), hostZones, replyToId);
+    public static StompAuthorizer allZoneSender(Set<String> subscribableZones, String replyToId) {
+        return new StompAuthorizer(true, Set.of(), subscribableZones, replyToId);
     }
 
     /**
      * An authorizer restricted to the given zones: sends require a zone in {@code sendZones} and
-     * hosting requires one in {@code hostZones}, each matching exactly or as a sub-zone.
+     * subscriptions one in {@code subscribableZones}, each matching exactly or as a sub-zone.
      */
-    public static StompAuthorizer zoneRestricted(Set<String> sendZones, Set<String> hostZones, String replyToId) {
-        return new StompAuthorizer(false, sendZones, hostZones, replyToId);
+    public static StompAuthorizer zoneRestricted(Set<String> sendZones, Set<String> subscribableZones, String replyToId) {
+        return new StompAuthorizer(false, sendZones, subscribableZones, replyToId);
     }
 
     /**
@@ -86,7 +86,7 @@ public class StompAuthorizer {
             String scope = cri.scope();
             ret = scope != null && scope.startsWith(replyToId + ":");
         } else if (isRoutableScheme(cri.scheme())) {
-            ret = zoneAllowed(cri.zone(), hostZones);
+            ret = zoneAllowed(cri.zone(), subscribableZones);
         } else {
             ret = false;
         }

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
@@ -43,8 +43,8 @@ public class StompAuthorizer {
             temporarySendGrants.removeFirst();
             log.warn("Reached max temporary grants some messages may be dropped");
         }
-        // normalizing through CRI folds the identity, so the grant compares equal to the folded
-        // raw() of the send it authorizes
+        // normalizing through CRI lowercases the identity, so the grant compares equal to the
+        // normalized raw() of the send it authorizes
         temporarySendGrants.add(CRI.create(rawCri).raw());
     }
 

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
@@ -93,9 +93,9 @@ public class StompAuthorizer {
         return ret;
     }
 
+    // only srv addresses route through the gateway; stream routing is not yet supported
     private static boolean isRoutableScheme(String scheme) {
-        return EventConstants.SERVICE_DESTINATION_SCHEME.equals(scheme)
-                || EventConstants.STREAM_DESTINATION_SCHEME.equals(scheme);
+        return EventConstants.SERVICE_DESTINATION_SCHEME.equals(scheme);
     }
 
     // A zone is allowed when it is an allowed zone or a sub-zone of one; the dot boundary keeps

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
@@ -15,11 +15,12 @@ import java.util.Set;
 /**
  * Creates STOMP authorizers using the gateway's current participant routing rules.
  *
- * A participant may only address zones its type allows: application participants reach the
+ * A participant may only address zones its type allows. Application participants send to the
  * {@code app-api} data plane and their own {@code app.<organizationId>.<applicationId>} zone and
- * may subscribe only inside their own zone, organization participants reach the {@code os-api}
- * management surface and subscribe to nothing, and system participants reach everything and
- * subscribe in the platform zones.
+ * subscribe only to reply destinations. Organization participants send to the {@code os-api}
+ * management surface and {@code app-api}, and subscribe within their own {@code app.<organizationId>}
+ * zones — an application's runtime authenticates as an organization participant to host its
+ * services. System participants send everywhere and subscribe in the {@code system} zone.
  */
 @Component
 public class StompAuthorizerFactory {
@@ -32,8 +33,9 @@ public class StompAuthorizerFactory {
         Participant participant = connectedInfo.getParticipant();
         StompAuthorizer ret;
         if (participant instanceof SystemParticipant) {
-
-            ret = StompAuthorizer.allZoneSender(Set.of(DomainUtil.OS_API_ZONE, DomainUtil.APP_API_ZONE, DomainUtil.SYSTEM_ZONE),
+            // os-api and app-api are hosted in-process only, so no connection may ever subscribe
+            // to them; the system zone stays subscribable for the vm-manager nodes that host there
+            ret = StompAuthorizer.allZoneSender(Set.of(DomainUtil.SYSTEM_ZONE),
                                                 connectedInfo.getReplyToId());
 
         } else if (participant instanceof ApplicationParticipant applicationParticipant) {
@@ -42,13 +44,15 @@ public class StompAuthorizerFactory {
             String appZone = appZone(applicationParticipant.getOrganizationId(),
                                      applicationParticipant.getApplicationId());
             ret = StompAuthorizer.zoneRestricted(Set.of(DomainUtil.APP_API_ZONE, appZone),
-                                                 Set.of(appZone),
+                                                 Set.of(),
                                                  connectedInfo.getReplyToId());
 
-        } else if (participant instanceof OrganizationParticipant) {
-
+        } else if (participant instanceof OrganizationParticipant organizationParticipant) {
+            // the organization id becomes a zone label, so it is validated the same way
+            ZoneUtil.validateLabel(organizationParticipant.getOrganizationId());
+            String orgAppsZone = DomainUtil.APP_ZONE_PREFIX + "." + organizationParticipant.getOrganizationId();
             ret = StompAuthorizer.zoneRestricted(Set.of(DomainUtil.OS_API_ZONE, DomainUtil.APP_API_ZONE),
-                                                 Set.of(),
+                                                 Set.of(orgAppsZone),
                                                  connectedInfo.getReplyToId());
 
         } else {

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
@@ -17,9 +17,9 @@ import java.util.Set;
  *
  * A participant may only address zones its type allows: application participants reach the
  * {@code app-api} data plane and their own {@code app.<organizationId>.<applicationId>} zone and
- * may host services only inside their own zone, organization participants reach the {@code os-api}
- * management surface and host nothing, and system participants reach everything and host in the
- * platform zones.
+ * may subscribe only inside their own zone, organization participants reach the {@code os-api}
+ * management surface and subscribe to nothing, and system participants reach everything and
+ * subscribe in the platform zones.
  */
 @Component
 public class StompAuthorizerFactory {

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
@@ -1,7 +1,6 @@
 package org.kinotic.gateway.internal.endpoints.stomp;
 
 import org.apache.commons.lang3.Validate;
-import org.kinotic.core.api.event.EventConstants;
 import org.kinotic.core.api.security.ConnectedInfo;
 import org.kinotic.core.api.security.Participant;
 import org.kinotic.core.api.utils.ZoneUtil;
@@ -9,15 +8,9 @@ import org.kinotic.domain.api.utils.DomainUtil;
 import org.kinotic.domain.api.security.ApplicationParticipant;
 import org.kinotic.domain.api.security.OrganizationParticipant;
 import org.kinotic.domain.api.security.SystemParticipant;
-import org.springframework.http.server.PathContainer;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.pattern.PathPattern;
-import org.springframework.web.util.pattern.PathPatternParser;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Set;
 
 /**
  * Creates STOMP authorizers using the gateway's current participant routing rules.
@@ -31,99 +24,58 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class StompAuthorizerFactory {
 
-    private final PathPatternParser parser;
-    private final Map<String, PathPattern> pathPatternCache = new ConcurrentHashMap<>();
-
-    public StompAuthorizerFactory() {
-        this.parser = new PathPatternParser();
-        this.parser.setPathOptions(PathContainer.Options.MESSAGE_ROUTE);
-    }
-
     public StompAuthorizer create(ConnectedInfo connectedInfo) {
         Validate.notNull(connectedInfo, "connectedInfo must not be null");
         Validate.notNull(connectedInfo.getParticipant(), "participant must not be null");
         Validate.notEmpty(connectedInfo.getReplyToId(), "replyToId must not be empty");
 
-        ParticipantPathPatterns participantPathPatterns = new ParticipantPathPatterns(connectedInfo.getParticipant(),
-                                                                                      connectedInfo.getReplyToId());
-        return new StompAuthorizer(parser.getPathOptions(),
-                                   participantPathPatterns.sendPatterns,
-                                   participantPathPatterns.subscriptionPatterns,
-                                   this::getPathPattern);
+        Participant participant = connectedInfo.getParticipant();
+        StompAuthorizer ret;
+        if (participant instanceof SystemParticipant) {
+
+            ret = new StompAuthorizer(true,
+                                      Set.of(),
+                                      Set.of(DomainUtil.OS_API_ZONE, DomainUtil.APP_API_ZONE, DomainUtil.SYSTEM_ZONE),
+                                      connectedInfo.getReplyToId());
+
+        } else if (participant instanceof ApplicationParticipant applicationParticipant) {
+            // appZone validates the ids, so an id that could shift the zone's label structure
+            // fails the connection instead of widening access
+            String appZone = appZone(applicationParticipant.getOrganizationId(),
+                                     applicationParticipant.getApplicationId());
+            ret = new StompAuthorizer(false,
+                                      Set.of(DomainUtil.APP_API_ZONE, appZone),
+                                      Set.of(appZone),
+                                      connectedInfo.getReplyToId());
+
+        } else if (participant instanceof OrganizationParticipant) {
+
+            ret = new StompAuthorizer(false,
+                                      Set.of(DomainUtil.OS_API_ZONE, DomainUtil.APP_API_ZONE),
+                                      Set.of(),
+                                      connectedInfo.getReplyToId());
+
+        } else {
+            throw new IllegalArgumentException("Unknown participant type " + participant.getClass().getName()
+                                                       + ", no zone routing rules exist for it");
+        }
+        return ret;
     }
 
-    private PathPattern getPathPattern(String pattern) {
-        return pathPatternCache.computeIfAbsent(pattern, parser::parse);
-    }
-
-    private class ParticipantPathPatterns {
-        private final List<PathPattern> sendPatterns = new LinkedList<>();
-        private final List<PathPattern> subscriptionPatterns = new LinkedList<>();
-
-        public ParticipantPathPatterns(Participant participant, String replyToId) {
-
-            if (participant instanceof SystemParticipant) {
-
-                addAllZones(sendPatterns);
-                addZone(subscriptionPatterns, DomainUtil.OS_API_ZONE);
-                addZone(subscriptionPatterns, DomainUtil.APP_API_ZONE);
-                addZone(subscriptionPatterns, DomainUtil.SYSTEM_ZONE);
-
-            } else if (participant instanceof ApplicationParticipant applicationParticipant) {
-                // appZone validates the ids, so an id that could act as a wildcard or extra
-                // label inside a pattern fails the connection instead of widening access
-                String appZone = appZone(applicationParticipant.getOrganizationId(),
-                                         applicationParticipant.getApplicationId());
-                addZone(sendPatterns, DomainUtil.APP_API_ZONE);
-                addZone(sendPatterns, appZone);
-                addZone(subscriptionPatterns, appZone);
-
-            } else if (participant instanceof OrganizationParticipant) {
-
-                addZone(sendPatterns, DomainUtil.OS_API_ZONE);
-                addZone(sendPatterns, DomainUtil.APP_API_ZONE);
-
-            } else {
-                throw new IllegalArgumentException("Unknown participant type " + participant.getClass().getName()
-                                                           + ", no zone routing rules exist for it");
-            }
-
-            subscriptionPatterns.add(getPathPattern(EventConstants.REPLY_DESTINATION_SCHEME + "://"
-                                                            + replyToId
-                                                            + ":*@*.**"));
-        }
-
-        private void addZone(List<PathPattern> target, String zone) {
-            // A CRI's scope (e.g. srv://node1@system...) is stripped before matching in
-            // StompAuthorizer, so only the un-scoped zone pattern is needed here
-            for (String scheme : List.of(EventConstants.SERVICE_DESTINATION_SCHEME,
-                                         EventConstants.STREAM_DESTINATION_SCHEME)) {
-                target.add(getPathPattern(scheme + "://" + zone + ".**"));
-            }
-        }
-
-        private void addAllZones(List<PathPattern> target) {
-            for (String scheme : List.of(EventConstants.SERVICE_DESTINATION_SCHEME,
-                                         EventConstants.STREAM_DESTINATION_SCHEME)) {
-                target.add(getPathPattern(scheme + "://*.**"));
-            }
-        }
-
-        /**
-         * Builds the zone that all of an application's services live in
-         *
-         * @param organizationId the id of the organization that owns the application
-         * @param applicationId the id of the application
-         * @return the application zone, app.&lt;organizationId&gt;.&lt;applicationId&gt;
-         */
-        private String appZone(String organizationId, String applicationId) {
-            // Each id must be a single dot-free label: a dot inside an id would shift the
-            // app.<organizationId>.<applicationId> label structure, letting one (org, app) pair
-            // produce the same zone as a different pair plus a sub zone
-            ZoneUtil.validateLabel(organizationId);
-            ZoneUtil.validateLabel(applicationId);
-            return DomainUtil.APP_ZONE_PREFIX + "." + organizationId + "." + applicationId;
-        }
+    /**
+     * Builds the zone that all of an application's services live in
+     *
+     * @param organizationId the id of the organization that owns the application
+     * @param applicationId the id of the application
+     * @return the application zone, app.&lt;organizationId&gt;.&lt;applicationId&gt;
+     */
+    private String appZone(String organizationId, String applicationId) {
+        // Each id must be a single dot-free label: a dot inside an id would shift the
+        // app.<organizationId>.<applicationId> label structure, letting one (org, app) pair
+        // produce the same zone as a different pair plus a sub zone
+        ZoneUtil.validateLabel(organizationId);
+        ZoneUtil.validateLabel(applicationId);
+        return DomainUtil.APP_ZONE_PREFIX + "." + organizationId + "." + applicationId;
     }
 
 }

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
@@ -18,9 +18,10 @@ import java.util.Set;
  * A participant may only address zones its type allows. Application participants send to the
  * {@code app-api} data plane and their own {@code app.<organizationId>.<applicationId>} zone and
  * subscribe only to reply destinations. Organization participants send to the {@code os-api}
- * management surface and {@code app-api}, and subscribe within their own {@code app.<organizationId>}
- * zones — an application's runtime authenticates as an organization participant to host its
- * services. System participants send everywhere and subscribe in the {@code system} zone.
+ * management surface, {@code app-api}, and their own {@code app.<organizationId>} zones, and
+ * subscribe within those same app zones — an application's runtime authenticates as an
+ * organization participant to host and call its services. System participants send everywhere
+ * and subscribe in the {@code system} zone.
  */
 @Component
 public class StompAuthorizerFactory {
@@ -51,7 +52,7 @@ public class StompAuthorizerFactory {
             // the organization id becomes a zone label, so it is validated the same way
             ZoneUtil.validateLabel(organizationParticipant.getOrganizationId());
             String orgAppsZone = DomainUtil.APP_ZONE_PREFIX + "." + organizationParticipant.getOrganizationId();
-            ret = StompAuthorizer.zoneRestricted(Set.of(DomainUtil.OS_API_ZONE, DomainUtil.APP_API_ZONE),
+            ret = StompAuthorizer.zoneRestricted(Set.of(DomainUtil.OS_API_ZONE, DomainUtil.APP_API_ZONE, orgAppsZone),
                                                  Set.of(orgAppsZone),
                                                  connectedInfo.getReplyToId());
 

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactory.java
@@ -33,27 +33,23 @@ public class StompAuthorizerFactory {
         StompAuthorizer ret;
         if (participant instanceof SystemParticipant) {
 
-            ret = new StompAuthorizer(true,
-                                      Set.of(),
-                                      Set.of(DomainUtil.OS_API_ZONE, DomainUtil.APP_API_ZONE, DomainUtil.SYSTEM_ZONE),
-                                      connectedInfo.getReplyToId());
+            ret = StompAuthorizer.allZoneSender(Set.of(DomainUtil.OS_API_ZONE, DomainUtil.APP_API_ZONE, DomainUtil.SYSTEM_ZONE),
+                                                connectedInfo.getReplyToId());
 
         } else if (participant instanceof ApplicationParticipant applicationParticipant) {
             // appZone validates the ids, so an id that could shift the zone's label structure
             // fails the connection instead of widening access
             String appZone = appZone(applicationParticipant.getOrganizationId(),
                                      applicationParticipant.getApplicationId());
-            ret = new StompAuthorizer(false,
-                                      Set.of(DomainUtil.APP_API_ZONE, appZone),
-                                      Set.of(appZone),
-                                      connectedInfo.getReplyToId());
+            ret = StompAuthorizer.zoneRestricted(Set.of(DomainUtil.APP_API_ZONE, appZone),
+                                                 Set.of(appZone),
+                                                 connectedInfo.getReplyToId());
 
         } else if (participant instanceof OrganizationParticipant) {
 
-            ret = new StompAuthorizer(false,
-                                      Set.of(DomainUtil.OS_API_ZONE, DomainUtil.APP_API_ZONE),
-                                      Set.of(),
-                                      connectedInfo.getReplyToId());
+            ret = StompAuthorizer.zoneRestricted(Set.of(DomainUtil.OS_API_ZONE, DomainUtil.APP_API_ZONE),
+                                                 Set.of(),
+                                                 connectedInfo.getReplyToId());
 
         } else {
             throw new IllegalArgumentException("Unknown participant type " + participant.getClass().getName()

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
@@ -62,7 +62,6 @@ public class StompAuthorizerFactoryTest {
         assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService/create#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.billing~InvoiceService/pay#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app~OrderEvents")));
 
         // the organization management surface, other applications, other organizations, the
         // platform internals, and un-zoned addresses
@@ -127,7 +126,6 @@ public class StompAuthorizerFactoryTest {
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://node1@app.acme-org.orders-app~OrderService#1.0.0")));
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.billing~InvoiceService#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("stream://app.acme-org.other-app~OrderEvents")));
 
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.other-org.orders-app~OrderService#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
@@ -144,7 +142,6 @@ public class StompAuthorizerFactoryTest {
         assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService/create#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app~OrderEvents")));
 
         // never another organization's applications or the platform internals
         assertFalse(authorizer.sendAllowed(CRI.create("srv://app.other-org.orders-app~OrderService/create#1.0.0")));
@@ -200,6 +197,15 @@ public class StompAuthorizerFactoryTest {
         assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app@os-api~org.kinotic.os.api.services.iam.MemberService/inviteMember#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.x@app.acme-org.other-app~OrderService#1.0.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app.x@app.acme-org.other-app~OrderEvents")));
+    }
+
+    @Test
+    public void streamSchemeIsNotRoutable() {
+        // stream routing is not yet supported by the gateway, so every participant is denied
+        assertFalse(systemAuthorizer().sendAllowed(CRI.create("stream://app.acme-org.orders-app~OrderEvents")));
+        assertFalse(organizationAuthorizer("acme-org").sendAllowed(CRI.create("stream://app.acme-org.orders-app~OrderEvents")));
+        assertFalse(organizationAuthorizer("acme-org").subscribeAllowed(CRI.create("stream://app.acme-org.orders-app~OrderEvents")));
+        assertFalse(applicationAuthorizer("acme-org", "orders-app").sendAllowed(CRI.create("stream://app.acme-org.orders-app~OrderEvents")));
     }
 
     @Test

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
@@ -136,16 +136,18 @@ public class StompAuthorizerFactoryTest {
     }
 
     @Test
-    public void organizationParticipantReachesTheOsApiAndAppApiZones() {
+    public void organizationParticipantSendRules() {
         StompAuthorizer authorizer = organizationAuthorizer("acme-org");
 
-        // the management surface and the data plane
+        // the management surface, the data plane, and its own applications' zones
         assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api~org.kinotic.persistence.api.services.EntityDefinitionService/publish#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService/create#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app~OrderEvents")));
 
-        // sends stay off an application's own services and the platform internals
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService/create#1.0.0")));
+        // never another organization's applications or the platform internals
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.other-org.orders-app~OrderService/create#1.0.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("srv://system~org.kinotic.os.api.services.LogManager/query#1.0.0")));
     }
 

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
@@ -103,7 +103,7 @@ public class StompAuthorizerFactoryTest {
     }
 
     @Test
-    public void applicationParticipantHostsOnlyItsOwnZone() {
+    public void applicationParticipantSubscribesOnlyToItsOwnZone() {
         StompAuthorizer authorizer = applicationAuthorizer("acme-org", "orders-app");
 
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
@@ -126,7 +126,7 @@ public class StompAuthorizerFactoryTest {
         assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
 
-        // not an application's own services, the platform internals, and hosts nothing
+        // not an application's own services, the platform internals, and subscribes to nothing
         assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService/create#1.0.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("srv://system~org.kinotic.os.api.services.LogManager/query#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService#1.0.0")));
@@ -135,7 +135,7 @@ public class StompAuthorizerFactoryTest {
     }
 
     @Test
-    public void systemParticipantSendsAnywhereAndHostsPlatformZones() {
+    public void systemParticipantSendsAnywhereAndSubscribesToPlatformZones() {
         StompAuthorizer authorizer = systemAuthorizer();
 
         assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
@@ -151,7 +151,7 @@ public class StompAuthorizerFactoryTest {
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app-api~org.kinotic.some.DataService#1.0.0")));
 
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
-        // hosting requires a zone: an un-zoned address is never subscribable, even for system
+        // subscribing requires a zone: an un-zoned address is never subscribable, even for system
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://org.kinotic.server.clienttest.SomeLegacyService#1.0.0")));
     }
 

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
@@ -200,7 +200,7 @@ public class StompAuthorizerFactoryTest {
 
         assertFalse(authorizer.sendAllowed(CRI.create(replyDestination)));
 
-        // the grant and the send normalize to the same folded identity regardless of input case
+        // the grant and the send normalize to the same lowercase identity regardless of input case
         authorizer.addTemporarySendAllowed(replyDestination);
         assertTrue(authorizer.sendAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@kinoitc.js.EventBus/replyHandler")));
 

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
@@ -85,36 +85,54 @@ public class StompAuthorizerFactoryTest {
 
     @Test
     public void slugifiedIdsWithUnderscoresFormValidZones() {
-        StompAuthorizer authorizer = applicationAuthorizer("acme-corp", "orders-app");
-
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-corp.orders-app~OrderService/create#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-corp.orders-app~OrderService#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-corp.other_app~OrderService/create#1.0.0")));
+        assertTrue(applicationAuthorizer("acme-corp", "orders-app")
+                           .sendAllowed(CRI.create("srv://app.acme-corp.orders-app~OrderService/create#1.0.0")));
+        assertTrue(organizationAuthorizer("acme-corp")
+                           .subscribeAllowed(CRI.create("srv://app.acme-corp.orders-app~OrderService#1.0.0")));
+        assertFalse(applicationAuthorizer("acme-corp", "orders-app")
+                            .sendAllowed(CRI.create("srv://app.acme-corp.other_app~OrderService/create#1.0.0")));
     }
 
     @Test
-    public void applicationZoneMatchingRespectsDotBoundaries() {
-        StompAuthorizer authorizer = applicationAuthorizer("acme-org", "orders-app");
+    public void zoneMatchingRespectsDotBoundaries() {
+        // a zone that merely starts with the allowed zone text must not match
+        StompAuthorizer application = applicationAuthorizer("acme-org", "orders-app");
+        assertFalse(application.sendAllowed(CRI.create("srv://app.acme-org.orders-app-2~OrderService/create#1.0.0")));
+        assertFalse(application.sendAllowed(CRI.create("srv://app.acme-org-2.orders-app~OrderService/create#1.0.0")));
 
-        // a zone that merely starts with the app's zone text must not match
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app-2~OrderService/create#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org-2.orders-app~OrderService/create#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app-2~OrderService#1.0.0")));
+        StompAuthorizer organization = organizationAuthorizer("acme-org");
+        assertFalse(organization.subscribeAllowed(CRI.create("srv://app.acme-org-2.orders-app~OrderService#1.0.0")));
     }
 
     @Test
-    public void applicationParticipantSubscribesOnlyToItsOwnZone() {
+    public void applicationParticipantSubscribesOnlyToReplyDestinations() {
         StompAuthorizer authorizer = applicationAuthorizer("acme-org", "orders-app");
 
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://node1@app.acme-org.orders-app~OrderService#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.billing~InvoiceService#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("stream://app.acme-org.orders-app~OrderEvents")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@kinoitc.js.EventBus/replyHandler")));
 
+        // not even its own zone: an application's services are hosted by its runtime, which
+        // authenticates as an organization participant
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("stream://app.acme-org.orders-app~OrderEvents")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://system~kinotic-ai.vm-manager.VmManager#0.1.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.other-app~OrderService#1.0.0")));
+    }
+
+    @Test
+    public void organizationParticipantSubscribesWithinItsOwnAppZones() {
+        StompAuthorizer authorizer = organizationAuthorizer("acme-org");
+
+        // every application zone under the organization, sub-zones included, srv and stream
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://node1@app.acme-org.orders-app~OrderService#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.billing~InvoiceService#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("stream://app.acme-org.other-app~OrderEvents")));
+
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.other-org.orders-app~OrderService#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://system~kinotic-ai.vm-manager.VmManager#0.1.0")));
     }
 
     @Test
@@ -126,16 +144,13 @@ public class StompAuthorizerFactoryTest {
         assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
 
-        // not an application's own services, the platform internals, and subscribes to nothing
+        // sends stay off an application's own services and the platform internals
         assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService/create#1.0.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("srv://system~org.kinotic.os.api.services.LogManager/query#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
     }
 
     @Test
-    public void systemParticipantSendsAnywhereAndSubscribesToPlatformZones() {
+    public void systemParticipantSendsAnywhereAndSubscribesToTheSystemZone() {
         StompAuthorizer authorizer = systemAuthorizer();
 
         assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
@@ -147,9 +162,10 @@ public class StompAuthorizerFactoryTest {
 
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://system~kinotic-ai.vm-manager.VmManager#0.1.0")));
         assertTrue(authorizer.subscribeAllowed(CRI.create("srv://node1@system~kinotic-ai.vm-manager.VmManager#0.1.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://os-api~org.kinotic.some.PlatformService#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app-api~org.kinotic.some.DataService#1.0.0")));
 
+        // os-api and app-api are hosted in-process only, so not even system may subscribe to them
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os-api~org.kinotic.some.PlatformService#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api~org.kinotic.some.DataService#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
         // subscribing requires a zone: an un-zoned address is never subscribable, even for system
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://org.kinotic.server.clienttest.SomeLegacyService#1.0.0")));
@@ -163,9 +179,9 @@ public class StompAuthorizerFactoryTest {
         assertTrue(system.subscribeAllowed(CRI.create("srv://vm1.example.com@system~kinotic-ai.vm-manager.VmManager#0.1.0")));
         assertTrue(system.sendAllowed(CRI.create("srv://vm1.example.com@system~kinotic-ai.vm-manager.VmManager/start#0.1.0")));
 
-        StompAuthorizer app = applicationAuthorizer("acme-org", "orders-app");
-        assertTrue(app.subscribeAllowed(CRI.create("srv://node.1.2@app.acme-org.orders-app~OrderService#1.0.0")));
-        assertFalse(app.subscribeAllowed(CRI.create("srv://node.1.2@app.acme-org.other-app~OrderService#1.0.0")));
+        StompAuthorizer organization = organizationAuthorizer("acme-org");
+        assertTrue(organization.subscribeAllowed(CRI.create("srv://node.1.2@app.acme-org.orders-app~OrderService#1.0.0")));
+        assertFalse(organization.subscribeAllowed(CRI.create("srv://node.1.2@app.other-org.orders-app~OrderService#1.0.0")));
     }
 
     @Test

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
@@ -176,7 +176,9 @@ public class StompAuthorizerFactoryTest {
         // the raw string with its own allowed zone and target another app after the '@'. Zone
         // authorization must run against the resource the message actually routes to, not the scope.
         assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.x@app.acme-org.other-app~OrderService/create#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app~x@app.acme-org.other-app~OrderService/create#1.0.0")));
+        // a scope carrying the zone delimiter cannot even be constructed (see CRITests)
+        assertThrows(IllegalArgumentException.class,
+                     () -> CRI.create("srv://app.acme-org.orders-app~x@app.acme-org.other-app~OrderService/create#1.0.0"));
         assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app@os-api~org.kinotic.os.api.services.iam.MemberService/inviteMember#1.0.0")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.x@app.acme-org.other-app~OrderService#1.0.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app.x@app.acme-org.other-app~OrderEvents")));

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
@@ -59,27 +59,37 @@ public class StompAuthorizerFactoryTest {
         StompAuthorizer authorizer = applicationAuthorizer("acme-org", "orders-app");
 
         // the app-api data plane and the app's own zone, including app declared sub zones
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService/create#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.billing.InvoiceService/pay#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app.OrderEvents")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService/create#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.billing~InvoiceService/pay#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app~OrderEvents")));
 
         // the organization management surface, other applications, other organizations, the
-        // platform internals, and legacy un-zoned addresses
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://os-api.org.kinotic.os.api.services.iam.MemberService/inviteMember#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.other-app.OrderService/create#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.other-org.orders-app.OrderService/create#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://system.org.kinotic.orchestrator.api.workload.WorkloadOrchestrationService/startWorkload#0.1.0")));
+        // platform internals, and un-zoned addresses
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService/inviteMember#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.other-app~OrderService/create#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.other-org.orders-app~OrderService/create#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://system~org.kinotic.orchestrator.api.workload.WorkloadOrchestrationService/startWorkload#0.1.0")));
         assertFalse(authorizer.sendAllowed(CRI.create("srv://org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
+    }
+
+    @Test
+    public void legacyDottedZoneFormCarriesNoZoneAndIsDenied() {
+        StompAuthorizer authorizer = applicationAuthorizer("acme-org", "orders-app");
+
+        // the app's own zone written in the pre '~' dotted form is just an un-zoned resourceName
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService/create#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app.OrderEvents")));
     }
 
     @Test
     public void slugifiedIdsWithUnderscoresFormValidZones() {
         StompAuthorizer authorizer = applicationAuthorizer("acme-corp", "orders-app");
 
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-corp.orders-app.OrderService/create#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-corp.orders-app.OrderService#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-corp.other_app.OrderService/create#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-corp.orders-app~OrderService/create#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-corp.orders-app~OrderService#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-corp.other_app~OrderService/create#1.0.0")));
     }
 
     @Test
@@ -87,23 +97,24 @@ public class StompAuthorizerFactoryTest {
         StompAuthorizer authorizer = applicationAuthorizer("acme-org", "orders-app");
 
         // a zone that merely starts with the app's zone text must not match
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app-2.OrderService/create#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org-2.orders-app.OrderService/create#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app-2.OrderService#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app-2~OrderService/create#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org-2.orders-app~OrderService/create#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app-2~OrderService#1.0.0")));
     }
 
     @Test
     public void applicationParticipantHostsOnlyItsOwnZone() {
         StompAuthorizer authorizer = applicationAuthorizer("acme-org", "orders-app");
 
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://node1@app.acme-org.orders-app.OrderService#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("stream://app.acme-org.orders-app.OrderEvents")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://node1@app.acme-org.orders-app~OrderService#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.billing~InvoiceService#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("stream://app.acme-org.orders-app~OrderEvents")));
 
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os-api.org.kinotic.os.api.services.iam.MemberService#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://system.kinotic-ai.vm-manager.VmManager#0.1.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.other-app.OrderService#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://system~kinotic-ai.vm-manager.VmManager#0.1.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.other-app~OrderService#1.0.0")));
     }
 
     @Test
@@ -111,47 +122,50 @@ public class StompAuthorizerFactoryTest {
         StompAuthorizer authorizer = organizationAuthorizer("acme-org");
 
         // the management surface and the data plane
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api.org.kinotic.persistence.api.services.EntityDefinitionService/publish#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api.org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api~org.kinotic.persistence.api.services.EntityDefinitionService/publish#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
 
         // not an application's own services, the platform internals, and hosts nothing
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService/create#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://system.org.kinotic.os.api.services.LogManager/query#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os-api.org.kinotic.os.api.services.iam.MemberService#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService/create#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://system~org.kinotic.os.api.services.LogManager/query#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
     }
 
     @Test
     public void systemParticipantSendsAnywhereAndHostsPlatformZones() {
         StompAuthorizer authorizer = systemAuthorizer();
 
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api.org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://system.org.kinotic.orchestrator.api.workload.WorkloadOrchestrationService/startWorkload#0.1.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService/create#1.0.0")));
-        assertTrue(authorizer.sendAllowed(CRI.create("srv://node1@system.kinotic-ai.vm-manager.VmManager/startWorkload#0.1.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://os-api~org.kinotic.os.api.services.iam.MemberService/findMembers#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository/save#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://system~org.kinotic.orchestrator.api.workload.WorkloadOrchestrationService/startWorkload#0.1.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService/create#1.0.0")));
+        assertTrue(authorizer.sendAllowed(CRI.create("srv://node1@system~kinotic-ai.vm-manager.VmManager/startWorkload#0.1.0")));
         assertTrue(authorizer.sendAllowed(CRI.create("srv://org.kinotic.server.clienttest.SomeLegacyService/method#1.0.0")));
 
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://system.kinotic-ai.vm-manager.VmManager#0.1.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://node1@system.kinotic-ai.vm-manager.VmManager#0.1.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://os-api.org.kinotic.some.PlatformService#1.0.0")));
-        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app-api.org.kinotic.some.DataService#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://system~kinotic-ai.vm-manager.VmManager#0.1.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://node1@system~kinotic-ai.vm-manager.VmManager#0.1.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://os-api~org.kinotic.some.PlatformService#1.0.0")));
+        assertTrue(authorizer.subscribeAllowed(CRI.create("srv://app-api~org.kinotic.some.DataService#1.0.0")));
 
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.OrderService#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app~OrderService#1.0.0")));
+        // hosting requires a zone: an un-zoned address is never subscribable, even for system
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://org.kinotic.server.clienttest.SomeLegacyService#1.0.0")));
     }
 
     @Test
     public void dottedScopesAreAuthorizedByTheirZone() {
-        // a node id may be an FQDN; the scope is stripped before zone matching so it still routes
+        // a node id may be an FQDN; the zone comes from the CRI's zone component so the scope
+        // cannot influence the decision
         StompAuthorizer system = systemAuthorizer();
-        assertTrue(system.subscribeAllowed(CRI.create("srv://vm1.example.com@system.kinotic-ai.vm-manager.VmManager#0.1.0")));
-        assertTrue(system.sendAllowed(CRI.create("srv://vm1.example.com@system.kinotic-ai.vm-manager.VmManager/start#0.1.0")));
+        assertTrue(system.subscribeAllowed(CRI.create("srv://vm1.example.com@system~kinotic-ai.vm-manager.VmManager#0.1.0")));
+        assertTrue(system.sendAllowed(CRI.create("srv://vm1.example.com@system~kinotic-ai.vm-manager.VmManager/start#0.1.0")));
 
         StompAuthorizer app = applicationAuthorizer("acme-org", "orders-app");
-        assertTrue(app.subscribeAllowed(CRI.create("srv://node.1.2@app.acme-org.orders-app.OrderService#1.0.0")));
-        assertFalse(app.subscribeAllowed(CRI.create("srv://node.1.2@app.acme-org.other-app.OrderService#1.0.0")));
+        assertTrue(app.subscribeAllowed(CRI.create("srv://node.1.2@app.acme-org.orders-app~OrderService#1.0.0")));
+        assertFalse(app.subscribeAllowed(CRI.create("srv://node.1.2@app.acme-org.other-app~OrderService#1.0.0")));
     }
 
     @Test
@@ -161,10 +175,11 @@ public class StompAuthorizerFactoryTest {
         // The scope precedes the resourceName in the raw CRI, so an attacker could try to prefix
         // the raw string with its own allowed zone and target another app after the '@'. Zone
         // authorization must run against the resource the message actually routes to, not the scope.
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.x@app.acme-org.other-app.OrderService/create#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app@os-api.org.kinotic.os.api.services.iam.MemberService/inviteMember#1.0.0")));
-        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.x@app.acme-org.other-app.OrderService#1.0.0")));
-        assertFalse(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app.x@app.acme-org.other-app.OrderEvents")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app.x@app.acme-org.other-app~OrderService/create#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app~x@app.acme-org.other-app~OrderService/create#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("srv://app.acme-org.orders-app@os-api~org.kinotic.os.api.services.iam.MemberService/inviteMember#1.0.0")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("srv://app.acme-org.orders-app.x@app.acme-org.other-app~OrderService#1.0.0")));
+        assertFalse(authorizer.sendAllowed(CRI.create("stream://app.acme-org.orders-app.x@app.acme-org.other-app~OrderEvents")));
     }
 
     @Test
@@ -173,11 +188,27 @@ public class StompAuthorizerFactoryTest {
 
         assertTrue(authorizer.subscribeAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@kinoitc.js.EventBus/replyHandler")));
         assertFalse(authorizer.subscribeAllowed(CRI.create("reply://other-id:sub-1@kinoitc.js.EventBus/replyHandler")));
+        assertFalse(authorizer.subscribeAllowed(CRI.create("reply://kinoitc.js.EventBus/replyHandler")));
+    }
+
+    @Test
+    public void temporaryGrantsAllowOneNormalizedSend() {
+        StompAuthorizer authorizer = organizationAuthorizer("acme-org");
+        String replyDestination = "reply://" + REPLY_TO_ID + ":sub-1@Kinoitc.js.EventBus/replyHandler";
+
+        assertFalse(authorizer.sendAllowed(CRI.create(replyDestination)));
+
+        // the grant and the send normalize to the same folded identity regardless of input case
+        authorizer.addTemporarySendAllowed(replyDestination);
+        assertTrue(authorizer.sendAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@kinoitc.js.EventBus/replyHandler")));
+
+        // a grant authorizes exactly one send
+        assertFalse(authorizer.sendAllowed(CRI.create(replyDestination)));
     }
 
     @Test
     public void applicationIdsThatCannotFormAValidZoneAreRejected() {
-        // an id containing a wildcard or dot could widen the connection's patterns, so creation must fail
+        // an id containing a dot or uppercase could shift the zone's label structure, so creation must fail
         assertThrows(IllegalArgumentException.class, () -> applicationAuthorizer("acme-org", "orders.*"));
         assertThrows(IllegalArgumentException.class, () -> applicationAuthorizer("acme-org", "Orders-App"));
         assertThrows(IllegalArgumentException.class, () -> applicationAuthorizer("acme.org", "orders-app"));

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/CRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/CRI.java
@@ -9,9 +9,12 @@ package org.kinotic.core.api.event;
  *
  * Will be in a format as follows where anything surrounded with [] is optional
  *
- *      scheme://[scope@]resourceName[/path][#version]
+ *      scheme://[scope@][zone~]resourceName[/path][#version]
  *
  * NOTE: If scope needs to be used to identify a sub-scope it will follow the form scope = scope:sub-scope
+ *
+ * The scheme, scope, zone, and resourceName are the CRI's identity and are always lowercase; the
+ * path and version keep the case they were written with.
  *
  * This format can have varied meanings based upon the scheme used.
  *
@@ -43,14 +46,33 @@ public interface CRI {
     boolean hasScope();
 
     /**
-     * The name of the resource represented by this {@link CRI}
+     * The zone this {@link CRI} is addressed in, or null if un-zoned
+     *
+     * The zone is the isolation boundary routing is validated against, such as
+     * {@code app.acme-org.orders-app} or {@code os-api}.
+     *
+     * For the following CRI zone would be the portion specified by zone
+     *
+     * scheme://[scope@][zone~]resourceName/path
+     *
+     * @return the string containing the zone if provided or null if not set
+     */
+    String zone();
+
+    /**
+     * @return true if the {@link CRI#zone()} is set
+     */
+    boolean hasZone();
+
+    /**
+     * The name of the resource represented by this {@link CRI}, excluding any zone
      *
      * In the case of a srv {@link CRI} this will be the service name.
      * In the case of a stream {@link CRI} this will be the name of the event type that the stream expects
      *
      * For the following CRI resourceName would be the portion specified by resourceName
      *
-     * scheme://[scope@]resourceName/path
+     * scheme://[scope@][zone~]resourceName/path
      *
      * @return the string containing the name of this resource
      */
@@ -87,7 +109,7 @@ public interface CRI {
     /**
      * Base Resource is a portion of the fully qualified {@link CRI} containing the following
      *
-     * scheme://[scope@]resourceName
+     * scheme://[scope@][zone~]resourceName
      *
      * @return string containing the baseResource
      */

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
@@ -31,7 +31,7 @@ class DefaultCRI implements CRI {
         } catch (URISyntaxException x) {
             throw new IllegalArgumentException(x.getMessage(), x);
         }
-        validateScope();
+        validateIdentity();
     }
 
     /**
@@ -41,15 +41,19 @@ class DefaultCRI implements CRI {
      */
     public DefaultCRI(String rawCRI) {
         uri = URI.create(lowercaseIdentity(rawCRI));
-        validateScope();
+        validateIdentity();
     }
 
-    // '~' delimits the zone from the resourceName, so a scope carrying one could only be an
-    // attempt to confuse zone parsing — rejected outright
-    private void validateScope() {
+    // '~' delimits the zone from the resourceName, so any other occurrence could only confuse
+    // zone parsing — a scope carrying one, or a second '~' in the host part, is rejected outright
+    private void validateIdentity() {
         String scope = scope();
         if (scope != null && scope.indexOf(ZONE_DELIMITER) >= 0) {
             throw new IllegalArgumentException("The scope must not contain '~' but was '" + scope + "'");
+        }
+        String resourceName = resourceName();
+        if (resourceName != null && resourceName.indexOf(ZONE_DELIMITER) >= 0) {
+            throw new IllegalArgumentException("The resourceName must not contain '~' but was '" + resourceName + "'");
         }
     }
 

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 
 /**
  *
@@ -14,16 +15,19 @@ import java.net.URISyntaxException;
  */
 class DefaultCRI implements CRI {
 
+    private static final char ZONE_DELIMITER = '~';
+
     private final URI uri;
 
     public DefaultCRI(String scheme, String scope, String resourceName, String path, String version) {
         // Compose the authority as scope@resourceName and pass it to the authority-form URI
-        // constructor, which stores it verbatim.
+        // constructor, which stores it verbatim. The scheme and authority are the CRI's identity,
+        // so they fold to lowercase; the path and version are payload details and keep their case.
         String authority = resourceName != null
-                ? (scope != null ? scope + "@" : "") + resourceName
+                ? ((scope != null ? scope + "@" : "") + resourceName).toLowerCase(Locale.ROOT)
                 : null;
         try {
-            uri = new URI(scheme, authority, path, null, version);
+            uri = new URI(scheme.toLowerCase(Locale.ROOT), authority, path, null, version);
         } catch (URISyntaxException x) {
             throw new IllegalArgumentException(x.getMessage(), x);
         }
@@ -35,7 +39,26 @@ class DefaultCRI implements CRI {
      * @param rawCRI the raw string to create from an {@link CRI}
      */
     public DefaultCRI(String rawCRI) {
-        uri = URI.create(rawCRI);
+        uri = URI.create(foldIdentity(rawCRI));
+    }
+
+    // Folds the scheme and authority of a raw CRI to lowercase, leaving the path and everything
+    // after it untouched. The authority ends at the first '/', '?', or '#' after "://".
+    private static String foldIdentity(String rawCRI) {
+        String ret = rawCRI;
+        int schemeEnd = rawCRI.indexOf("://");
+        if (schemeEnd >= 0) {
+            int authorityEnd = rawCRI.length();
+            for (int i = schemeEnd + 3; i < rawCRI.length(); i++) {
+                char c = rawCRI.charAt(i);
+                if (c == '/' || c == '?' || c == '#') {
+                    authorityEnd = i;
+                    break;
+                }
+            }
+            ret = rawCRI.substring(0, authorityEnd).toLowerCase(Locale.ROOT) + rawCRI.substring(authorityEnd);
+        }
+        return ret;
     }
 
     @Override
@@ -45,7 +68,7 @@ class DefaultCRI implements CRI {
 
     @Override
     public String scope() {
-        // The raw authority is scope@resourceName; scope is the part before '@', null when absent.
+        // The raw authority is scope@[zone~]resourceName; scope is the part before '@', null when absent.
         String authority = uri.getRawAuthority();
         if (authority == null) {
             return null;
@@ -60,7 +83,32 @@ class DefaultCRI implements CRI {
     }
 
     @Override
+    public String zone() {
+        String hostPart = hostPart();
+        if (hostPart == null) {
+            return null;
+        }
+        int delimiter = hostPart.indexOf(ZONE_DELIMITER);
+        return delimiter >= 0 ? hostPart.substring(0, delimiter) : null;
+    }
+
+    @Override
+    public boolean hasZone() {
+        return zone() != null;
+    }
+
+    @Override
     public String resourceName() {
+        String hostPart = hostPart();
+        if (hostPart == null) {
+            return null;
+        }
+        int delimiter = hostPart.indexOf(ZONE_DELIMITER);
+        return delimiter >= 0 ? hostPart.substring(delimiter + 1) : hostPart;
+    }
+
+    // The authority after any scope@, holding [zone~]resourceName
+    private String hostPart() {
         String authority = uri.getRawAuthority();
         if (authority == null) {
             return null;
@@ -96,6 +144,10 @@ class DefaultCRI implements CRI {
         if(hasScope()){
             sb.append(scope());
             sb.append("@");
+        }
+        if(hasZone()){
+            sb.append(zone());
+            sb.append(ZONE_DELIMITER);
         }
         sb.append(resourceName());
 

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
@@ -31,6 +31,7 @@ class DefaultCRI implements CRI {
         } catch (URISyntaxException x) {
             throw new IllegalArgumentException(x.getMessage(), x);
         }
+        validateScope();
     }
 
     /**
@@ -40,6 +41,16 @@ class DefaultCRI implements CRI {
      */
     public DefaultCRI(String rawCRI) {
         uri = URI.create(foldIdentity(rawCRI));
+        validateScope();
+    }
+
+    // '~' delimits the zone from the resourceName, so a scope carrying one could only be an
+    // attempt to confuse zone parsing — rejected outright
+    private void validateScope() {
+        String scope = scope();
+        if (scope != null && scope.indexOf(ZONE_DELIMITER) >= 0) {
+            throw new IllegalArgumentException("The scope must not contain '~' but was '" + scope + "'");
+        }
     }
 
     // Folds the scheme and authority of a raw CRI to lowercase, leaving the path and everything

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
@@ -22,7 +22,7 @@ class DefaultCRI implements CRI {
     public DefaultCRI(String scheme, String scope, String resourceName, String path, String version) {
         // Compose the authority as scope@resourceName and pass it to the authority-form URI
         // constructor, which stores it verbatim. The scheme and authority are the CRI's identity,
-        // so they fold to lowercase; the path and version are payload details and keep their case.
+        // so they are lowercased; the path and version are payload details and keep their case.
         String authority = resourceName != null
                 ? ((scope != null ? scope + "@" : "") + resourceName).toLowerCase(Locale.ROOT)
                 : null;
@@ -40,7 +40,7 @@ class DefaultCRI implements CRI {
      * @param rawCRI the raw string to create from an {@link CRI}
      */
     public DefaultCRI(String rawCRI) {
-        uri = URI.create(foldIdentity(rawCRI));
+        uri = URI.create(lowercaseIdentity(rawCRI));
         validateScope();
     }
 
@@ -53,9 +53,9 @@ class DefaultCRI implements CRI {
         }
     }
 
-    // Folds the scheme and authority of a raw CRI to lowercase, leaving the path and everything
-    // after it untouched. The authority ends at the first '/', '?', or '#' after "://".
-    private static String foldIdentity(String rawCRI) {
+    // Lowercases the scheme and authority of a raw CRI, leaving the path and everything after it
+    // untouched. The authority ends at the first '/', '?', or '#' after "://".
+    private static String lowercaseIdentity(String rawCRI) {
         String ret = rawCRI;
         int schemeEnd = rawCRI.indexOf("://");
         if (schemeEnd >= 0) {

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
@@ -20,6 +20,13 @@ class DefaultCRI implements CRI {
     private final URI uri;
 
     public DefaultCRI(String scheme, String scope, String resourceName, String path, String version) {
+        // '@' delimits the scope in the composed authority, so neither part may carry one
+        if (scope != null && scope.indexOf('@') >= 0) {
+            throw new IllegalArgumentException("The scope must not contain '@' but was '" + scope + "'");
+        }
+        if (resourceName != null && resourceName.indexOf('@') >= 0) {
+            throw new IllegalArgumentException("The resourceName must not contain '@' but was '" + resourceName + "'");
+        }
         // Compose the authority as scope@resourceName and pass it to the authority-form URI
         // constructor, which stores it verbatim. The scheme and authority are the CRI's identity,
         // so they are lowercased; the path and version are payload details and keep their case.
@@ -44,8 +51,8 @@ class DefaultCRI implements CRI {
         validateIdentity();
     }
 
-    // '~' delimits the zone from the resourceName, so any other occurrence could only confuse
-    // zone parsing — a scope carrying one, or a second '~' in the host part, is rejected outright
+    // '~' delimits the zone and '@' delimits the scope, so any other occurrence of either could
+    // only confuse parsing — a delimiter inside a part is rejected outright
     private void validateIdentity() {
         String scope = scope();
         if (scope != null && scope.indexOf(ZONE_DELIMITER) >= 0) {
@@ -54,6 +61,10 @@ class DefaultCRI implements CRI {
         String resourceName = resourceName();
         if (resourceName != null && resourceName.indexOf(ZONE_DELIMITER) >= 0) {
             throw new IllegalArgumentException("The resourceName must not contain '~' but was '" + resourceName + "'");
+        }
+        String authority = uri.getRawAuthority();
+        if (authority != null && authority.indexOf('@') != authority.lastIndexOf('@')) {
+            throw new IllegalArgumentException("The authority must contain at most one '@' but was '" + authority + "'");
         }
     }
 

--- a/kinotic-core/src/main/java/org/kinotic/core/api/service/ServiceIdentifier.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/service/ServiceIdentifier.java
@@ -9,6 +9,8 @@ import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.util.Locale;
+
 /**
  * The {@link ServiceIdentifier} identifies a {@link ServiceDescriptor}
  * Created by Navíd Mitchell 🤪 on 8/18/21.
@@ -36,12 +38,16 @@ public class ServiceIdentifier {
         Validate.notEmpty(name, "The name must not be empty");
         Validate.notEmpty(version, "The version must not be empty");
         // The name is the final dot separated label of the address, so a dot inside it would
-        // change where the zone and namespace end when the address is parsed or pattern matched
+        // change where the namespace ends when the address is parsed
         Validate.isTrue(!name.contains("."), "The name must not contain '.' but was '%s'", name);
         // The namespace forms interior labels of the address; an underscore is illegal in a URI
         // host, so a segment carrying one would make the CRI an invalid URI
         Validate.isTrue(namespace == null || !namespace.contains("_"),
                         "The namespace must not contain '_' but was '%s'", namespace);
+        // '~' delimits the zone from the resourceName in a CRI, so it can never appear inside either part
+        Validate.isTrue(!name.contains("~"), "The name must not contain '~' but was '%s'", name);
+        Validate.isTrue(namespace == null || !namespace.contains("~"),
+                        "The namespace must not contain '~' but was '%s'", namespace);
         if (zone != null) {
             ZoneUtil.validateZone(zone);
         }
@@ -99,12 +105,13 @@ public class ServiceIdentifier {
 
     /**
      * Returns the fully qualified name this {@link ServiceIdentifier} is addressed by
-     * This is the zone.namespace.name, omitting any part that is not set
+     * This is the zone~namespace.name, omitting any part that is not set, always lowercase
      * @return string containing the qualified name
      */
     public String qualifiedName(){
         String name = (namespace != null && !namespace.isEmpty() ? namespace + "." : "") + this.name;
-        return zone != null ? zone + "." + name : name;
+        String qualified = zone != null ? zone + "~" + name : name;
+        return qualified.toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/kinotic-core/src/test/java/org/kinotic/core/api/service/ServiceIdentifierTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/api/service/ServiceIdentifierTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -14,29 +15,32 @@ public class ServiceIdentifierTest {
     @Test
     public void qualifiedNameIsZonePrefixed() {
         ServiceIdentifier identifier = new ServiceIdentifier("api", "org.kinotic.os.api.services.iam", "MemberService", null, "1.0.0");
-        assertEquals("api.org.kinotic.os.api.services.iam.MemberService", identifier.qualifiedName());
-        assertEquals("srv://api.org.kinotic.os.api.services.iam.MemberService#1.0.0", identifier.cri().raw());
+        assertEquals("api~org.kinotic.os.api.services.iam.memberservice", identifier.qualifiedName());
+        assertEquals("srv://api~org.kinotic.os.api.services.iam.memberservice#1.0.0", identifier.cri().raw());
+        assertEquals("api", identifier.cri().zone());
+        assertEquals("org.kinotic.os.api.services.iam.memberservice", identifier.cri().resourceName());
     }
 
     @Test
     public void platformZoneAddresses() {
         ServiceIdentifier identifier = new ServiceIdentifier("os-api", "com.example", "LogManager", null, "1.0.0");
-        assertEquals("os-api.com.example.LogManager", identifier.qualifiedName());
-        assertEquals("srv://os-api.com.example.LogManager#1.0.0", identifier.cri().raw());
+        assertEquals("os-api~com.example.logmanager", identifier.qualifiedName());
+        assertEquals("srv://os-api~com.example.logmanager#1.0.0", identifier.cri().raw());
     }
 
     @Test
     public void scopeAndMissingNamespaceRoundTrip() {
         ServiceIdentifier identifier = new ServiceIdentifier("system", null, "VmManager", "node1", "0.1.0");
-        assertEquals("system.VmManager", identifier.qualifiedName());
-        assertEquals("srv://node1@system.VmManager#0.1.0", identifier.cri().raw());
+        assertEquals("system~vmmanager", identifier.qualifiedName());
+        assertEquals("srv://node1@system~vmmanager#0.1.0", identifier.cri().raw());
     }
 
     @Test
     public void noZoneMeansTheUnZonedAddress() {
         ServiceIdentifier identifier = new ServiceIdentifier(null, "com.example", "LegacyService", null, "1.0.0");
-        assertEquals("com.example.LegacyService", identifier.qualifiedName());
-        assertEquals("srv://com.example.LegacyService#1.0.0", identifier.cri().raw());
+        assertEquals("com.example.legacyservice", identifier.qualifiedName());
+        assertEquals("srv://com.example.legacyservice#1.0.0", identifier.cri().raw());
+        assertNull(identifier.cri().zone());
     }
 
     @Test
@@ -54,6 +58,9 @@ public class ServiceIdentifierTest {
         assertThrows(IllegalArgumentException.class, () -> new ServiceIdentifier("api", "com.example", "Svc.Extra", null, "1.0.0"));
         // an underscore in a namespace segment would make the CRI an invalid URI
         assertThrows(IllegalArgumentException.class, () -> new ServiceIdentifier("api", "com.my_example", "Svc", null, "1.0.0"));
+        // '~' delimits the zone in a CRI, so neither the namespace nor the name may carry one
+        assertThrows(IllegalArgumentException.class, () -> new ServiceIdentifier("api", "com.exa~mple", "Svc", null, "1.0.0"));
+        assertThrows(IllegalArgumentException.class, () -> new ServiceIdentifier("api", "com.example", "Sv~c", null, "1.0.0"));
     }
 
 }

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
@@ -13,13 +13,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * CRIs are backed by {@link java.net.URI}, whose server-based authority parsing rejects
  * underscores. Zone labels never carry one (the grammar forbids it), but a namespace segment
- * still can, so these tests pin that CRIs resolve their scope and resourceName from an
+ * still can, so these tests pin that CRIs resolve their scope, zone, and resourceName from an
  * underscore-bearing address regardless.
  * Created by navid on 1/23/20
  */
 public class CRITests {
 
-    private static final String SERVICE_NAME = "org.kinotic.tests.TestService";
+    private static final String SERVICE_NAME = "org.kinotic.tests.testservice";
     private static final String SERVICE_SCOPE = "e35f51d0-6c6e-4b58-9b9d-f5b53dd978b0";
     private static final String SERVICE_VERSION = "0.1.0";
     private static final String SERVICE_LITERAL1 = EventConstants.SERVICE_DESTINATION_SCHEME
@@ -37,7 +37,9 @@ public class CRITests {
                                                         + SERVICE_VERSION;
 
     // A namespace segment carries an underscore, which java.net.URI will not accept as a hostname
-    private static final String ZONED_NAME = "os-api.org.kinotic.my_service.ITestService";
+    private static final String ZONE = "os-api";
+    private static final String RESOURCE_NAME = "org.kinotic.my_service.itestservice";
+    private static final String ZONED_NAME = ZONE + "~" + RESOURCE_NAME;
 
     @Test
     public void testRawCRI1(){
@@ -53,7 +55,8 @@ public class CRITests {
     public void parsesZonedResourceNameWithUnderscore(){
         CRI cri = CRI.create("srv://" + ZONED_NAME + "/testMethodWithString#1.0.0");
 
-        assertEquals(ZONED_NAME, cri.resourceName());
+        assertEquals(ZONE, cri.zone());
+        assertEquals(RESOURCE_NAME, cri.resourceName());
         assertEquals("srv://" + ZONED_NAME, cri.baseResource());
         assertEquals("/testMethodWithString", cri.path());
         assertEquals("1.0.0", cri.version());
@@ -65,7 +68,8 @@ public class CRITests {
         CRI cri = CRI.create("srv://node1@" + ZONED_NAME + "/save#1.0.0");
 
         assertEquals("node1", cri.scope());
-        assertEquals(ZONED_NAME, cri.resourceName());
+        assertEquals(ZONE, cri.zone());
+        assertEquals(RESOURCE_NAME, cri.resourceName());
         assertEquals("srv://node1@" + ZONED_NAME, cri.baseResource());
     }
 
@@ -73,10 +77,12 @@ public class CRITests {
     public void buildsZonedResourceNameFromComponents(){
         CRI cri = CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, null, ZONED_NAME, "/save", "1.0.0");
 
-        assertEquals(ZONED_NAME, cri.resourceName());
+        assertEquals(ZONE, cri.zone());
+        assertEquals(RESOURCE_NAME, cri.resourceName());
         assertEquals("srv://" + ZONED_NAME, cri.baseResource());
-        // The raw form round-trips back to a CRI that resolves the same resourceName
-        assertEquals(ZONED_NAME, CRI.create(cri.raw()).resourceName());
+        // The raw form round-trips back to a CRI that resolves the same zone and resourceName
+        assertEquals(ZONE, CRI.create(cri.raw()).zone());
+        assertEquals(RESOURCE_NAME, CRI.create(cri.raw()).resourceName());
     }
 
     @Test
@@ -84,8 +90,43 @@ public class CRITests {
         CRI cri = CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, "node1", ZONED_NAME, "/save", "1.0.0");
 
         assertEquals("node1", cri.scope());
-        assertEquals(ZONED_NAME, cri.resourceName());
+        assertEquals(ZONE, cri.zone());
+        assertEquals(RESOURCE_NAME, cri.resourceName());
         assertEquals("srv://node1@" + ZONED_NAME, cri.baseResource());
+    }
+
+    @Test
+    public void unZonedCRIHasNoZone(){
+        CRI cri = CRI.create(SERVICE_LITERAL1);
+
+        assertNull(cri.zone());
+        assertEquals(SERVICE_NAME, cri.resourceName());
+    }
+
+    @Test
+    public void rawFormFoldsIdentityAndPreservesThePath(){
+        CRI cri = CRI.create("SRV://Node1@OS-API~Org.Kinotic.Tests.TestService/testMethodWithString#1.0.0");
+
+        assertEquals("srv", cri.scheme());
+        assertEquals("node1", cri.scope());
+        assertEquals("os-api", cri.zone());
+        assertEquals("org.kinotic.tests.testservice", cri.resourceName());
+        // the path is a Java method name, so its case is significant and never folded
+        assertEquals("/testMethodWithString", cri.path());
+        assertEquals("srv://node1@os-api~org.kinotic.tests.testservice/testMethodWithString#1.0.0", cri.raw());
+    }
+
+    @Test
+    public void componentFormFoldsIdentityAndPreservesThePath(){
+        CRI cri = CRI.create("SRV", "Node1", "OS-API~Org.Kinotic.Tests.TestService", "/testMethodWithString", "1.0.0");
+
+        assertEquals("srv", cri.scheme());
+        assertEquals("node1", cri.scope());
+        assertEquals("os-api", cri.zone());
+        assertEquals("org.kinotic.tests.testservice", cri.resourceName());
+        assertEquals("/testMethodWithString", cri.path());
+        // both construction paths normalize to the same raw form
+        assertEquals(CRI.create(cri.raw()), cri);
     }
 
     private void validateCRI(CRI cri, boolean checkScope){

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * CRIs are backed by {@link java.net.URI}, whose server-based authority parsing rejects
@@ -93,6 +94,15 @@ public class CRITests {
         assertEquals(ZONE, cri.zone());
         assertEquals(RESOURCE_NAME, cri.resourceName());
         assertEquals("srv://node1@" + ZONED_NAME, cri.baseResource());
+    }
+
+    @Test
+    public void scopesCarryingTheZoneDelimiterAreRejected(){
+        // '~' delimits the zone, so a scope containing one could only be crafted to confuse parsing
+        assertThrows(IllegalArgumentException.class,
+                     () -> CRI.create("srv://evil~x@" + ZONED_NAME + "/save#1.0.0"));
+        assertThrows(IllegalArgumentException.class,
+                     () -> CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, "evil~x", ZONED_NAME, "/save", "1.0.0"));
     }
 
     @Test

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
@@ -114,20 +114,20 @@ public class CRITests {
     }
 
     @Test
-    public void rawFormFoldsIdentityAndPreservesThePath(){
+    public void rawFormLowercasesIdentityAndPreservesThePath(){
         CRI cri = CRI.create("SRV://Node1@OS-API~Org.Kinotic.Tests.TestService/testMethodWithString#1.0.0");
 
         assertEquals("srv", cri.scheme());
         assertEquals("node1", cri.scope());
         assertEquals("os-api", cri.zone());
         assertEquals("org.kinotic.tests.testservice", cri.resourceName());
-        // the path is a Java method name, so its case is significant and never folded
+        // the path is a Java method name, so its case is significant and never lowercased
         assertEquals("/testMethodWithString", cri.path());
         assertEquals("srv://node1@os-api~org.kinotic.tests.testservice/testMethodWithString#1.0.0", cri.raw());
     }
 
     @Test
-    public void componentFormFoldsIdentityAndPreservesThePath(){
+    public void componentFormLowercasesIdentityAndPreservesThePath(){
         CRI cri = CRI.create("SRV", "Node1", "OS-API~Org.Kinotic.Tests.TestService", "/testMethodWithString", "1.0.0");
 
         assertEquals("srv", cri.scheme());

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
@@ -106,6 +106,18 @@ public class CRITests {
     }
 
     @Test
+    public void strayScopeDelimitersAreRejected(){
+        // '@' delimits the scope: component parts may never carry one, and a raw form
+        // may have at most one
+        assertThrows(IllegalArgumentException.class,
+                     () -> CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, "a@b", ZONED_NAME, "/save", "1.0.0"));
+        assertThrows(IllegalArgumentException.class,
+                     () -> CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, null, "x@" + ZONED_NAME, "/save", "1.0.0"));
+        assertThrows(IllegalArgumentException.class,
+                     () -> CRI.create("srv://a@b@" + ZONED_NAME + "/save#1.0.0"));
+    }
+
+    @Test
     public void secondZoneDelimiterInTheHostPartIsRejected(){
         // only the first '~' is the delimiter; a resourceName carrying another is always a mistake
         assertThrows(IllegalArgumentException.class,

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
@@ -106,6 +106,15 @@ public class CRITests {
     }
 
     @Test
+    public void secondZoneDelimiterInTheHostPartIsRejected(){
+        // only the first '~' is the delimiter; a resourceName carrying another is always a mistake
+        assertThrows(IllegalArgumentException.class,
+                     () -> CRI.create("srv://" + ZONED_NAME + "~extra/save#1.0.0"));
+        assertThrows(IllegalArgumentException.class,
+                     () -> CRI.create(EventConstants.SERVICE_DESTINATION_SCHEME, null, ZONED_NAME + "~extra", "/save", "1.0.0"));
+    }
+
+    @Test
     public void unZonedCRIHasNoZone(){
         CRI cri = CRI.create(SERVICE_LITERAL1);
 

--- a/kinotic-js/workspace/packages/core/src/api/ServiceIdentifier.ts
+++ b/kinotic-js/workspace/packages/core/src/api/ServiceIdentifier.ts
@@ -13,7 +13,7 @@ export class ServiceIdentifier {
 
     constructor(namespace: string | null, name: string, zone?: string) {
         // The name is the final dot separated label of the address, so a dot inside it would
-        // change where the zone and namespace end when the address is parsed or pattern matched
+        // change where the namespace ends when the address is parsed
         if (name.includes('.')) {
             throw new Error(`The name must not contain '.' but was '${name}'`)
         }
@@ -22,6 +22,13 @@ export class ServiceIdentifier {
         if (namespace != null && namespace.includes('_')) {
             throw new Error(`The namespace must not contain '_' but was '${namespace}'`)
         }
+        // '~' delimits the zone from the resourceName in a CRI, so it can never appear inside either part
+        if (name.includes('~')) {
+            throw new Error(`The name must not contain '~' but was '${name}'`)
+        }
+        if (namespace != null && namespace.includes('~')) {
+            throw new Error(`The namespace must not contain '~' but was '${namespace}'`)
+        }
         this.namespace = namespace
         this.name = name
         this.zone = zone
@@ -29,12 +36,13 @@ export class ServiceIdentifier {
 
     /**
      * Returns the fully qualified name this {@link ServiceIdentifier} is addressed by
-     * This is the zone.namespace.name, omitting any part that is not set
+     * This is the zone~namespace.name, omitting any part that is not set, always lowercase
      * @return string containing the qualified name
      */
     public qualifiedName(): string {
         const name = this.namespace ? this.namespace + "." + this.name : this.name
-        return this.zone ? this.zone + "." + name : name
+        const qualified = this.zone ? this.zone + "~" + name : name
+        return qualified.toLowerCase()
     }
 
     /**

--- a/kinotic-js/workspace/packages/core/src/api/event/CRI.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/CRI.ts
@@ -61,7 +61,7 @@ export interface CRI {
     hasZone(): boolean
 
     /**
-     * The name of the resource represented by this `CRI`, excluding any zone.
+     * The name of the resource represented by this `CRI`.
      *
      * In the case of a `srv` `CRI`, this will be the service name.
      * In the case of a `stream` `CRI`, this will be the name of the event type that the stream expects.
@@ -91,7 +91,7 @@ export interface CRI {
      *
      * For the following CRI, `path` would be the portion specified by `path`:
      *
-     * `scheme://[scope@]resourceName/path`
+     * `scheme://[scope@][zone~]resourceName/path`
      *
      * @returns the path string if provided or `null` if not set
      */

--- a/kinotic-js/workspace/packages/core/src/api/event/CRI.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/CRI.ts
@@ -7,9 +7,12 @@ import {DefaultCRI} from './DefaultCRI'
  *
  * Will be in a format as follows where anything surrounded with `[]` is optional:
  *
- *      scheme://[scope@]resourceName[/path][#version]
+ *      scheme://[scope@][zone~]resourceName[/path][#version]
  *
  * NOTE: If scope needs to be used to identify a sub-scope, it will follow the form `scope = scope:sub-scope`.
+ *
+ * The scheme, scope, zone, and resourceName are the CRI's identity and are always lowercase; the
+ * path and version keep the case they were written with.
  *
  * This format can have varied meanings based upon the scheme used.
  *
@@ -39,14 +42,33 @@ export interface CRI {
     hasScope(): boolean
 
     /**
-     * The name of the resource represented by this `CRI`.
+     * The zone this `CRI` is addressed in, or `null` if un-zoned.
+     *
+     * The zone is the isolation boundary routing is validated against, such as
+     * `app.acme-org.orders-app` or `os-api`.
+     *
+     * For the following CRI, `zone` would be the portion specified by `zone`:
+     *
+     * `scheme://[scope@][zone~]resourceName/path`
+     *
+     * @returns a string containing the zone if provided or `null` if not set
+     */
+    zone(): string | null
+
+    /**
+     * @returns `true` if the `zone` is set
+     */
+    hasZone(): boolean
+
+    /**
+     * The name of the resource represented by this `CRI`, excluding any zone.
      *
      * In the case of a `srv` `CRI`, this will be the service name.
      * In the case of a `stream` `CRI`, this will be the name of the event type that the stream expects.
      *
      * For the following CRI, `resourceName` would be the portion specified by `resourceName`:
      *
-     * `scheme://[scope@]resourceName/path`
+     * `scheme://[scope@][zone~]resourceName/path`
      *
      * @returns the string containing the name of this resource
      */
@@ -83,7 +105,7 @@ export interface CRI {
     /**
      * Base Resource is a portion of the fully qualified `CRI` containing the following:
      *
-     * `scheme://[scope@]resourceName`
+     * `scheme://[scope@][zone~]resourceName`
      *
      * @returns string containing the baseResource
      */

--- a/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
@@ -52,6 +52,11 @@ export class DefaultCRI implements CRI {
         if (!this._scheme || !this._resourceName) {
             throw new Error(`Invalid CRI: scheme and resourceName are required. Got: ${this._raw}`)
         }
+        // '~' delimits the zone from the resourceName, so a scope carrying one could only be an
+        // attempt to confuse zone parsing — rejected outright
+        if (this._scope !== null && this._scope.includes(ZONE_DELIMITER)) {
+            throw new Error(`The scope must not contain '~' but was '${this._scope}'`)
+        }
     }
 
     public scheme(): string {

--- a/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
@@ -37,6 +37,13 @@ export class DefaultCRI implements CRI {
             this._version = parsed.version
         } else if (args.length === 5) {
             const [scheme, scope, resourceName, path, version] = args
+            // '@' delimits the scope in the composed authority, so neither part may carry one
+            if (scope && (scope as string).includes('@')) {
+                throw new Error(`The scope must not contain '@' but was '${scope}'`)
+            }
+            if ((resourceName as string).includes('@')) {
+                throw new Error(`The resourceName must not contain '@' but was '${resourceName}'`)
+            }
             this._scheme = scheme.toLowerCase()
             this._scope = scope ? scope.toLowerCase() : null
             const [zone, name] = DefaultCRI.splitZone((resourceName as string).toLowerCase())
@@ -52,13 +59,16 @@ export class DefaultCRI implements CRI {
         if (!this._scheme || !this._resourceName) {
             throw new Error(`Invalid CRI: scheme and resourceName are required. Got: ${this._raw}`)
         }
-        // '~' delimits the zone from the resourceName, so any other occurrence could only confuse
-        // zone parsing — a scope carrying one, or a second '~' in the host part, is rejected outright
+        // '~' delimits the zone and '@' delimits the scope, so any other occurrence of either
+        // could only confuse parsing — a delimiter inside a part is rejected outright
         if (this._scope !== null && this._scope.includes(ZONE_DELIMITER)) {
             throw new Error(`The scope must not contain '~' but was '${this._scope}'`)
         }
         if (this._resourceName.includes(ZONE_DELIMITER)) {
             throw new Error(`The resourceName must not contain '~' but was '${this._resourceName}'`)
+        }
+        if (this._resourceName.includes('@') || (this._zone !== null && this._zone.includes('@'))) {
+            throw new Error(`The authority must contain at most one '@' but was '${this._raw}'`)
         }
     }
 

--- a/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
@@ -52,10 +52,13 @@ export class DefaultCRI implements CRI {
         if (!this._scheme || !this._resourceName) {
             throw new Error(`Invalid CRI: scheme and resourceName are required. Got: ${this._raw}`)
         }
-        // '~' delimits the zone from the resourceName, so a scope carrying one could only be an
-        // attempt to confuse zone parsing — rejected outright
+        // '~' delimits the zone from the resourceName, so any other occurrence could only confuse
+        // zone parsing — a scope carrying one, or a second '~' in the host part, is rejected outright
         if (this._scope !== null && this._scope.includes(ZONE_DELIMITER)) {
             throw new Error(`The scope must not contain '~' but was '${this._scope}'`)
+        }
+        if (this._resourceName.includes(ZONE_DELIMITER)) {
+            throw new Error(`The resourceName must not contain '~' but was '${this._resourceName}'`)
         }
     }
 

--- a/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
@@ -1,5 +1,7 @@
 import type {CRI} from "./CRI"
 
+const ZONE_DELIMITER = '~'
+
 /**
  * Default implementation of the `CRI` interface.
  *
@@ -9,6 +11,7 @@ import type {CRI} from "./CRI"
 export class DefaultCRI implements CRI {
     private readonly _scheme: string
     private readonly _scope: string | null
+    private readonly _zone: string | null
     private readonly _resourceName: string
     private readonly _path: string | null
     private readonly _version: string | null
@@ -17,29 +20,34 @@ export class DefaultCRI implements CRI {
     constructor(rawCRI: string)
     constructor(scheme: string, scope: string | null, resourceName: string, path: string | null, version: string | null)
     constructor(...args: any[]) {
+        // The scheme, scope, zone, and resourceName are the CRI's identity, so they fold to
+        // lowercase; the path and version are payload details and keep their case.
         if (args.length === 1) {
             const rawURC = args[0]
             if (typeof rawURC !== "string") {
                 throw new Error("Raw URI must be a string")
             }
             const parsed = DefaultCRI.parseRaw(rawURC)
-            this._scheme = parsed.scheme
-            this._scope = parsed.scope
-            this._resourceName = parsed.resourceName
+            this._scheme = parsed.scheme.toLowerCase()
+            this._scope = parsed.scope ? parsed.scope.toLowerCase() : null
+            const [zone, resourceName] = DefaultCRI.splitZone(parsed.resourceName.toLowerCase())
+            this._zone = zone
+            this._resourceName = resourceName
             this._path = parsed.path
             this._version = parsed.version
-            this._raw = rawURC
         } else if (args.length === 5) {
             const [scheme, scope, resourceName, path, version] = args
-            this._scheme = scheme
-            this._scope = scope
-            this._resourceName = resourceName
+            this._scheme = scheme.toLowerCase()
+            this._scope = scope ? scope.toLowerCase() : null
+            const [zone, foldedName] = DefaultCRI.splitZone((resourceName as string).toLowerCase())
+            this._zone = zone
+            this._resourceName = foldedName
             this._path = path
             this._version = version
-            this._raw = DefaultCRI.buildRaw(scheme, scope, resourceName, path, version)
         } else {
             throw new Error("Invalid constructor arguments for DefaultCRI")
         }
+        this._raw = DefaultCRI.buildRaw(this._scheme, this._scope, this._zone, this._resourceName, this._path, this._version)
 
         if (!this._scheme || !this._resourceName) {
             throw new Error(`Invalid CRI: scheme and resourceName are required. Got: ${this._raw}`)
@@ -56,6 +64,14 @@ export class DefaultCRI implements CRI {
 
     public hasScope(): boolean {
         return this._scope !== null
+    }
+
+    public zone(): string | null {
+        return this._zone
+    }
+
+    public hasZone(): boolean {
+        return this._zone !== null
     }
 
     public resourceName(): string {
@@ -83,6 +99,9 @@ export class DefaultCRI implements CRI {
         if (this.hasScope()) {
             result += `${this._scope}@`
         }
+        if (this.hasZone()) {
+            result += `${this._zone}${ZONE_DELIMITER}`
+        }
         result += this._resourceName
         return result
     }
@@ -105,6 +124,14 @@ export class DefaultCRI implements CRI {
 
     public toString(): string {
         return this._raw
+    }
+
+    // Splits [zone~]resourceName into its zone (or null) and resourceName
+    private static splitZone(hostPart: string): [string | null, string] {
+        const delimiter = hostPart.indexOf(ZONE_DELIMITER)
+        return delimiter >= 0
+            ? [hostPart.substring(0, delimiter), hostPart.substring(delimiter + 1)]
+            : [null, hostPart]
     }
 
     // Helper to parse a raw CRI string
@@ -135,6 +162,7 @@ export class DefaultCRI implements CRI {
     private static buildRaw(
         scheme: string,
         scope: string | null,
+        zone: string | null,
         resourceName: string,
         path: string | null,
         version: string | null
@@ -142,6 +170,9 @@ export class DefaultCRI implements CRI {
         let result = `${scheme}://`
         if (scope) {
             result += `${scope}@`
+        }
+        if (zone) {
+            result += `${zone}${ZONE_DELIMITER}`
         }
         result += resourceName
         if (path) {

--- a/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
@@ -20,8 +20,8 @@ export class DefaultCRI implements CRI {
     constructor(rawCRI: string)
     constructor(scheme: string, scope: string | null, resourceName: string, path: string | null, version: string | null)
     constructor(...args: any[]) {
-        // The scheme, scope, zone, and resourceName are the CRI's identity, so they fold to
-        // lowercase; the path and version are payload details and keep their case.
+        // The scheme, scope, zone, and resourceName are the CRI's identity, so they are
+        // lowercased; the path and version are payload details and keep their case.
         if (args.length === 1) {
             const rawURC = args[0]
             if (typeof rawURC !== "string") {
@@ -39,9 +39,9 @@ export class DefaultCRI implements CRI {
             const [scheme, scope, resourceName, path, version] = args
             this._scheme = scheme.toLowerCase()
             this._scope = scope ? scope.toLowerCase() : null
-            const [zone, foldedName] = DefaultCRI.splitZone((resourceName as string).toLowerCase())
+            const [zone, name] = DefaultCRI.splitZone((resourceName as string).toLowerCase())
             this._zone = zone
-            this._resourceName = foldedName
+            this._resourceName = name
             this._path = path
             this._version = version
         } else {

--- a/kinotic-js/workspace/packages/core/test/Context.test.ts
+++ b/kinotic-js/workspace/packages/core/test/Context.test.ts
@@ -58,7 +58,7 @@ describe('Kinotic JS', () => {
             const eventHeaders = headers ? new Map(headers) : new Map()
             eventHeaders.set(EventConstants.REPLY_TO_HEADER, replyTo)
             eventHeaders.set(EventConstants.CONTENT_TYPE_HEADER, "application/json")
-            const event = new Event(cri.replace('com.example.', `${ZONE}.com.example.`), eventHeaders)
+            const event = new Event(cri.replace('com.example.', `${ZONE}~com.example.`), eventHeaders)
             if (args != null) {
                 event.setDataString(JSON.stringify(args))
             }

--- a/kinotic-js/workspace/packages/core/test/Context.test.ts
+++ b/kinotic-js/workspace/packages/core/test/Context.test.ts
@@ -5,8 +5,9 @@ import { createConnectionInfo, logFailure, validateConnectedInfo } from "./TestH
 import { firstValueFrom, Observable } from "rxjs"
 import { v4 as uuidv4 } from "uuid"
 
-// The client hosts this service, so it connects as an application participant and registers it
-// in its own app zone (app.<org>.<app>); the org id is DEFAULT_AUTH_HEADERS.organizationId.
+// The client hosts this service, so it connects as an organization participant (the app
+// runtime's identity) and registers it in an app zone under its org; the org id is
+// DEFAULT_AUTH_HEADERS.organizationId.
 const APP_ID = 'test-app'
 const ZONE = `app.kinotic-test.${APP_ID}`
 
@@ -20,7 +21,7 @@ describe('Kinotic JS', () => {
         beforeAll(async () => {
             // Registers this client's service under ZONE; must be set before it is instantiated
             Kinotic.zonePrefix = ZONE
-            const connectionInfo = createConnectionInfo({ authHeaders: { applicationId: APP_ID } })
+            const connectionInfo = createConnectionInfo()
             const connectedInfo: ConnectedInfo = await logFailure(
                 Kinotic.connect(connectionInfo),
                 "Failed to connect to Kinotic Gateway"

--- a/kinotic-js/workspace/packages/core/test/Publish.test.ts
+++ b/kinotic-js/workspace/packages/core/test/Publish.test.ts
@@ -6,8 +6,9 @@ import { createConnectionInfo, logFailure, validateConnectedInfo } from "./TestH
 import { firstValueFrom, Observable } from "rxjs"
 import { v4 as uuidv4 } from "uuid"
 
-// The client hosts these services, so it connects as an application participant and registers
-// them in its own app zone (app.<org>.<app>); the org id is DEFAULT_AUTH_HEADERS.organizationId.
+// The client hosts these services, so it connects as an organization participant (the app
+// runtime's identity) and registers them in an app zone under its org; the org id is
+// DEFAULT_AUTH_HEADERS.organizationId.
 const APP_ID = 'test-app'
 const ZONE = `app.kinotic-test.${APP_ID}`
 
@@ -21,7 +22,7 @@ describe('Kinotic JS', () => {
         beforeAll(async () => {
             // Registers this client's services under ZONE; must be set before they are instantiated
             Kinotic.zonePrefix = ZONE
-            const connectionInfo = createConnectionInfo({ authHeaders: { applicationId: APP_ID } })
+            const connectionInfo = createConnectionInfo()
             const connectedInfo: ConnectedInfo = await logFailure(
                 Kinotic.connect(connectionInfo),
                 "Failed to connect to Kinotic Gateway"

--- a/kinotic-js/workspace/packages/core/test/Publish.test.ts
+++ b/kinotic-js/workspace/packages/core/test/Publish.test.ts
@@ -41,7 +41,7 @@ describe('Kinotic JS', () => {
 
         // The services register in ZONE, so target their zoned address
         const createTestEvent = (cri: string, replyTo: string, args?: any[] | null): IEvent => {
-            const event = new Event(cri.replace('com.example.', `${ZONE}.com.example.`), new Map([
+            const event = new Event(cri.replace('com.example.', `${ZONE}~com.example.`), new Map([
                                                      [EventConstants.REPLY_TO_HEADER, replyTo],
                                                      [EventConstants.CONTENT_TYPE_HEADER, "application/json"],
                                                  ]))

--- a/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
+++ b/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
@@ -26,6 +26,11 @@ describe('Kinotic JS', () => {
             expect(() => createCRI('srv', 'evil~x', 'api~com.example.svc', 'save', '1.0.0')).toThrow()
         })
 
+        it('rejects a second zone delimiter in the host part', () => {
+            expect(() => createCRI('srv://api~com.example.svc~extra/save#1.0.0')).toThrow()
+            expect(() => createCRI('srv', null, 'api~com.example.svc~extra', 'save', '1.0.0')).toThrow()
+        })
+
         it('rejects a name containing a dot', () => {
             expect(() => new ServiceIdentifier('com.example', 'Svc.Extra', 'api')).toThrow()
         })

--- a/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
+++ b/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
@@ -9,8 +9,15 @@ describe('Kinotic JS', () => {
         it('builds a zone prefixed cri', () => {
             const identifier = new ServiceIdentifier('org.kinotic.os.api.services.iam', 'MemberService', 'os-api')
             identifier.version = '1.0.0'
-            expect(identifier.qualifiedName()).toBe('os-api.org.kinotic.os.api.services.iam.MemberService')
-            expect(identifier.cri().raw()).toBe('srv://os-api.org.kinotic.os.api.services.iam.MemberService#1.0.0')
+            expect(identifier.qualifiedName()).toBe('os-api~org.kinotic.os.api.services.iam.memberservice')
+            expect(identifier.cri().raw()).toBe('srv://os-api~org.kinotic.os.api.services.iam.memberservice#1.0.0')
+            expect(identifier.cri().zone()).toBe('os-api')
+            expect(identifier.cri().resourceName()).toBe('org.kinotic.os.api.services.iam.memberservice')
+        })
+
+        it('rejects a name or namespace containing the zone delimiter', () => {
+            expect(() => new ServiceIdentifier('com.example', 'Sv~c', 'api')).toThrow()
+            expect(() => new ServiceIdentifier('com.exa~mple', 'Svc', 'api')).toThrow()
         })
 
         it('rejects a name containing a dot', () => {

--- a/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
+++ b/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { ServiceIdentifier } from "../src/api/ServiceIdentifier"
+import { createCRI } from "../src/api/event/CRI"
 
 // Pure construction guards, no gateway needed, so this runs regardless of USE_GATEWAY_DOCKER.
 describe('Kinotic JS', () => {
@@ -18,6 +19,11 @@ describe('Kinotic JS', () => {
         it('rejects a name or namespace containing the zone delimiter', () => {
             expect(() => new ServiceIdentifier('com.example', 'Sv~c', 'api')).toThrow()
             expect(() => new ServiceIdentifier('com.exa~mple', 'Svc', 'api')).toThrow()
+        })
+
+        it('rejects a scope containing the zone delimiter', () => {
+            expect(() => createCRI('srv://evil~x@api~com.example.svc/save#1.0.0')).toThrow()
+            expect(() => createCRI('srv', 'evil~x', 'api~com.example.svc', 'save', '1.0.0')).toThrow()
         })
 
         it('rejects a name containing a dot', () => {

--- a/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
+++ b/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
@@ -31,6 +31,12 @@ describe('Kinotic JS', () => {
             expect(() => createCRI('srv', null, 'api~com.example.svc~extra', 'save', '1.0.0')).toThrow()
         })
 
+        it('rejects stray scope delimiters', () => {
+            expect(() => createCRI('srv', 'a@b', 'api~com.example.svc', 'save', '1.0.0')).toThrow()
+            expect(() => createCRI('srv', null, 'x@api~com.example.svc', 'save', '1.0.0')).toThrow()
+            expect(() => createCRI('srv://a@b@api~com.example.svc/save#1.0.0')).toThrow()
+        })
+
         it('rejects a name containing a dot', () => {
             expect(() => new ServiceIdentifier('com.example', 'Svc.Extra', 'api')).toThrow()
         })

--- a/website/content/1.apps/4.services/2.publishing-services.md
+++ b/website/content/1.apps/4.services/2.publishing-services.md
@@ -39,10 +39,10 @@ Kinotic.zonePrefix = appZone(config.organization, config.application)
 ```
 
 ```typescript
-@Publish()                       // → srv://app.acme-org.orders-app.OrderService
+@Publish()                       // → srv://app.acme-org.orders-app~orderservice
 class OrderService { ... }
 
-@Zone('billing')                 // → srv://app.acme-org.orders-app.billing.InvoiceService
+@Zone('billing')                 // → srv://app.acme-org.orders-app.billing~invoiceservice
 @Publish()
 class InvoiceService { ... }
 ```

--- a/website/content/3.reference/1.decorators.md
+++ b/website/content/3.reference/1.decorators.md
@@ -402,7 +402,7 @@ import { Publish, Zone } from '@kinotic-ai/core'
 @Zone('billing')
 @Publish()
 class InvoiceService {
-    // With zonePrefix app.acme-org.orders-app → srv://app.acme-org.orders-app.billing.InvoiceService
+    // With zonePrefix app.acme-org.orders-app → srv://app.acme-org.orders-app.billing~invoiceservice
 }
 ```
 

--- a/website/content/3.reference/4.cri-format.md
+++ b/website/content/3.reference/4.cri-format.md
@@ -35,7 +35,7 @@ Identifies the type of resource being addressed.
 | Scheme | Description |
 |--------|-------------|
 | `srv` | Published services and their methods |
-| `stream` | Event streams |
+| `stream` | Event streams (not yet routable through the gateway) |
 
 ### Scope
 

--- a/website/content/3.reference/4.cri-format.md
+++ b/website/content/3.reference/4.cri-format.md
@@ -64,7 +64,7 @@ Which zones a connection may address is determined by the authenticated particip
 | Participant | May send to | May subscribe to |
 |-------------|-------------|-------------|
 | APPLICATION (org, app) | `app-api`, `app.<org>.<app>` | reply destinations only |
-| ORGANIZATION (org) | `os-api`, `app-api` | `app.<org>.*` — its applications' zones |
+| ORGANIZATION (org) | `os-api`, `app-api`, `app.<org>.*` | `app.<org>.*` — its applications' zones |
 | SYSTEM | everything | `system` |
 
 ### Resource Name

--- a/website/content/3.reference/4.cri-format.md
+++ b/website/content/3.reference/4.cri-format.md
@@ -54,7 +54,7 @@ The optional zone places the resource in the isolation boundary the gateway vali
 
 | Zone | Description |
 |------|-------------|
-| `app.<organizationId>.<applicationId>` | One application's services. Only that application (and system participants) can call them; only that application can host them. Applications may nest their own sub-zones, e.g. `app.acme-org.orders-app.billing`. |
+| `app.<organizationId>.<applicationId>` | One application's services. Only that application (and system participants) can call them; they are hosted by the owning organization's runtime, which authenticates as an organization participant. Applications may nest their own sub-zones, e.g. `app.acme-org.orders-app.billing`. |
 | `app-api` | The platform's data plane for applications, such as entity persistence and named query execution. Hosted in-process by the platform only. |
 | `os-api` | The platform services organizations manage the system through, such as member, application, and entity definition management. Hosted in-process by the platform only. |
 | `system` | Platform-internal services. Only system participants can call or host them. |
@@ -63,9 +63,9 @@ Which zones a connection may address is determined by the authenticated particip
 
 | Participant | May send to | May subscribe to |
 |-------------|-------------|-------------|
-| APPLICATION (org, app) | `app-api`, `app.<org>.<app>` | `app.<org>.<app>` |
-| ORGANIZATION (org) | `os-api`, `app-api` | — |
-| SYSTEM | everything | `os-api`, `app-api`, `system` |
+| APPLICATION (org, app) | `app-api`, `app.<org>.<app>` | reply destinations only |
+| ORGANIZATION (org) | `os-api`, `app-api` | `app.<org>.*` — its applications' zones |
+| SYSTEM | everything | `system` |
 
 ### Resource Name
 

--- a/website/content/3.reference/4.cri-format.md
+++ b/website/content/3.reference/4.cri-format.md
@@ -19,7 +19,7 @@ Everything in brackets (`[]`) is optional.
 
 ## Case
 
-The scheme, scope, zone, and resourceName are the CRI's identity and are always lowercase — every construction path folds them, so two spellings of the same address are the same address. The path and version keep the case they were written with: a path carries a method name, whose case is significant.
+The scheme, scope, zone, and resourceName are the CRI's identity and are always lowercase — every construction path lowercases them, so two spellings of the same address are the same address. The path and version keep the case they were written with: a path carries a method name, whose case is significant.
 
 ```
 SRV://Node1@os-api~Org.Kinotic.Os.Api.Services.ProjectService/findByRepoFullName

--- a/website/content/3.reference/4.cri-format.md
+++ b/website/content/3.reference/4.cri-format.md
@@ -12,10 +12,19 @@ A CRI (Kinotic Resource Identifier) is used by Kinotic to route requests to the 
 ## Format
 
 ```
-scheme://[scope@]resourceName[/path][#version]
+scheme://[scope@][zone~]resourceName[/path][#version]
 ```
 
 Everything in brackets (`[]`) is optional.
+
+## Case
+
+The scheme, scope, zone, and resourceName are the CRI's identity and are always lowercase — every construction path folds them, so two spellings of the same address are the same address. The path and version keep the case they were written with: a path carries a method name, whose case is significant.
+
+```
+SRV://Node1@os-api~Org.Kinotic.Os.Api.Services.ProjectService/findByRepoFullName
+  → srv://node1@os-api~org.kinotic.os.api.services.projectservice/findByRepoFullName
+```
 
 ## Components
 
@@ -35,13 +44,13 @@ An optional qualifier that narrows the CRI to a specific context, such as a tena
 If a scope needs sub-scopes, use the format `scope:sub-scope`.
 
 ```
-srv://tenant-123@app.acme-org.orders-app.OrderService
-stream://device-42@app.acme-org.orders-app.temperature/sensor-1
+srv://tenant-123@app.acme-org.orders-app~orderservice
+stream://device-42@app.acme-org.orders-app~temperature/sensor-1
 ```
 
 ### Zone
 
-The leading portion of the resource name places the resource in a zone, the isolation boundary the gateway validates on every send and subscribe. A zone is one or more dot-separated labels of lowercase letters, digits, and interior dashes.
+The optional zone places the resource in the isolation boundary the gateway validates on every send and subscribe. It precedes the resourceName, separated by `~`. A zone is one or more dot-separated labels of lowercase letters, digits, and interior dashes.
 
 | Zone | Description |
 |------|-------------|
@@ -50,30 +59,30 @@ The leading portion of the resource name places the resource in a zone, the isol
 | `os-api` | The platform services organizations manage the system through, such as member, application, and entity definition management. Hosted in-process by the platform only. |
 | `system` | Platform-internal services. Only system participants can call or host them. |
 
-Which zones a connection may address is determined by the authenticated participant:
+Which zones a connection may address is determined by the authenticated participant. A participant may also address any sub-zone of a zone it is allowed, so `app.acme-org.orders-app.billing` is reachable by whoever may reach `app.acme-org.orders-app`. An address without a `~` carries no zone at all and is only reachable by system participants.
 
 | Participant | May send to | May host in |
 |-------------|-------------|-------------|
-| APPLICATION (org, app) | `app-api.*`, `app.<org>.<app>.*` | `app.<org>.<app>.*` |
-| ORGANIZATION (org) | `os-api.*` | — |
-| SYSTEM | everything | `os-api.*`, `app-api.*`, `system.*` |
+| APPLICATION (org, app) | `app-api`, `app.<org>.<app>` | `app.<org>.<app>` |
+| ORGANIZATION (org) | `os-api`, `app-api` | — |
+| SYSTEM | everything | `os-api`, `app-api`, `system` |
 
 ### Resource Name
 
-The name of the resource being addressed. For services, this is the zone followed by the fully qualified service name. For streams, this is the zone followed by the event type name.
+The name of the resource being addressed, excluding the zone. For services, this is the fully qualified service name. For streams, this is the event type name.
 
 ```
-srv://os-api.com.example.UserService
-stream://app.acme-org.orders-app.temperature
+srv://os-api~com.example.userservice
+stream://app.acme-org.orders-app~temperature
 ```
 
 ### Path
 
-An optional path that identifies a specific part of the resource, such as a method name on a service.
+An optional path that identifies a specific part of the resource, such as a method name on a service. The path's case is preserved.
 
 ```
-srv://os-api.com.example.UserService/findById
-stream://app.acme-org.orders-app.temperature/sensor-1
+srv://os-api~com.example.userservice/findById
+stream://app.acme-org.orders-app~temperature/sensor-1
 ```
 
 ### Version
@@ -81,8 +90,8 @@ stream://app.acme-org.orders-app.temperature/sensor-1
 An optional semantic version for the resource. Enables versioned service routing so multiple versions of a service can coexist.
 
 ```
-srv://os-api.com.example.UserService/findById#1.0.0
-srv://os-api.com.example.UserService#2.0.0
+srv://os-api~com.example.userservice/findById#1.0.0
+srv://os-api~com.example.userservice#2.0.0
 ```
 
 ## Factory Function
@@ -93,16 +102,16 @@ The `createCRI` function provides several overloads for constructing CRI instanc
 import { createCRI } from '@kinotic-ai/core'
 
 // From a raw string
-const cri1 = createCRI('srv://os-api.com.example.UserService/findById#1.0.0')
+const cri1 = createCRI('srv://os-api~com.example.userservice/findById#1.0.0')
 
-// From scheme and resource name
-const cri2 = createCRI('srv', 'os-api.com.example.UserService')
+// From scheme and resource name (which may carry a zone)
+const cri2 = createCRI('srv', 'os-api~com.example.userservice')
 
 // From scheme, scope, and resource name
-const cri3 = createCRI('stream', 'tenant-123', 'app.acme-org.orders-app.orders')
+const cri3 = createCRI('stream', 'tenant-123', 'app.acme-org.orders-app~orders')
 
 // From all components
-const cri4 = createCRI('srv', null, 'os-api.com.example.UserService', 'findById', '1.0.0')
+const cri4 = createCRI('srv', null, 'os-api~com.example.userservice', 'findById', '1.0.0')
 ```
 
 ### CRI Interface
@@ -110,28 +119,30 @@ const cri4 = createCRI('srv', null, 'os-api.com.example.UserService', 'findById'
 The `CRI` interface provides methods to access each component:
 
 ```typescript
-const cri = createCRI('srv://tenant-123@app.acme-org.orders-app.OrderService/placeOrder#2.0.0')
+const cri = createCRI('srv://tenant-123@app.acme-org.orders-app~orderservice/placeOrder#2.0.0')
 
 cri.scheme()        // 'srv'
 cri.scope()         // 'tenant-123'
 cri.hasScope()      // true
-cri.resourceName()  // 'app.acme-org.orders-app.OrderService'
+cri.zone()          // 'app.acme-org.orders-app'
+cri.hasZone()       // true
+cri.resourceName()  // 'orderservice'
 cri.path()          // 'placeOrder'
 cri.hasPath()       // true
 cri.version()       // '2.0.0'
 cri.hasVersion()    // true
-cri.baseResource()  // 'srv://tenant-123@app.acme-org.orders-app.OrderService'
-cri.raw()           // 'srv://tenant-123@app.acme-org.orders-app.OrderService/placeOrder#2.0.0'
+cri.baseResource()  // 'srv://tenant-123@app.acme-org.orders-app~orderservice'
+cri.raw()           // 'srv://tenant-123@app.acme-org.orders-app~orderservice/placeOrder#2.0.0'
 ```
 
 ## Examples
 
 | CRI | Description |
 |-----|-------------|
-| `srv://os-api.org.kinotic.os.api.services.iam.MemberService` | A platform service in the `os-api` zone |
-| `srv://app-api.org.kinotic.persistence.api.services.JsonEntitiesRepository/save` | A specific method on a platform service |
-| `srv://app.acme-org.orders-app.OrderService/create#1.0.0` | A versioned method on an application's own service |
-| `srv://app.acme-org.orders-app.billing.InvoiceService` | A service in an application-declared sub-zone |
-| `srv://system.org.kinotic.orchestrator.api.workload.WorkloadOrchestrationService` | A platform-internal service |
-| `stream://app.acme-org.orders-app.temperature` | An application's event stream |
-| `srv://node1@system.kinotic-ai.vm-manager.VmManager` | A scoped system service targeting one node |
+| `srv://os-api~org.kinotic.os.api.services.iam.memberservice` | A platform service in the `os-api` zone |
+| `srv://app-api~org.kinotic.persistence.api.services.jsonentitiesrepository/save` | A specific method on a platform service |
+| `srv://app.acme-org.orders-app~orderservice/create#1.0.0` | A versioned method on an application's own service |
+| `srv://app.acme-org.orders-app.billing~invoiceservice` | A service in an application-declared sub-zone |
+| `srv://system~org.kinotic.orchestrator.api.workload.workloadorchestrationservice` | A platform-internal service |
+| `stream://app.acme-org.orders-app~temperature` | An application's event stream |
+| `srv://node1@system~kinotic-ai.vm-manager.vmmanager` | A scoped system service targeting one node |

--- a/website/content/3.reference/4.cri-format.md
+++ b/website/content/3.reference/4.cri-format.md
@@ -61,7 +61,7 @@ The optional zone places the resource in the isolation boundary the gateway vali
 
 Which zones a connection may address is determined by the authenticated participant. A participant may also address any sub-zone of a zone it is allowed, so `app.acme-org.orders-app.billing` is reachable by whoever may reach `app.acme-org.orders-app`. An address without a `~` carries no zone at all and is only reachable by system participants.
 
-| Participant | May send to | May host in |
+| Participant | May send to | May subscribe to |
 |-------------|-------------|-------------|
 | APPLICATION (org, app) | `app-api`, `app.<org>.<app>` | `app.<org>.<app>` |
 | ORGANIZATION (org) | `os-api`, `app-api` | — |


### PR DESCRIPTION
## Summary

The CRI format becomes `scheme://[scope@][zone~]resourceName[/path][#version]`: `~` (an RFC 3986 unreserved character) delimits the zone from the resourceName, ending the ambiguity of zone labels blending into dotted namespaces, and the whole identity folds to lowercase so two spellings of one address are one address. The STOMP authorizer drops PathPattern matching for structured checks against the CRI's own components. Java and kinotic-js change in lockstep.

## CRI

- **First-class zone**: `zone()` / `hasZone()` on the `CRI` interface; `resourceName()` excludes the zone; `baseResource()` includes it. The legacy dotted form (`srv://app.acme-org.orders-app.OrderService`) parses as an **un-zoned** address.
- **Identity folding**: scheme, scope, zone, and resourceName fold to lowercase in both construction paths (raw string and components). The path carries a Java method name, so its case — and the version's — is preserved.
- **`~` is structural**: `ServiceIdentifier` rejects `~` inside a name or namespace, and both `DefaultCRI` construction paths reject a scope carrying `~` — a scope with the zone delimiter could only be crafted to confuse parsing.
- `ServiceIdentifier.qualifiedName()` becomes `zone~namespace.name`, folded — this is the wire address services register under and the directory entry id.

## StompAuthorizer

Pattern-free structured rewrite; the `PathPatternParser`, pattern cache, and de-scoping helper are gone:

- The zone comes from `cri.zone()` — the scope can never influence the decision, killing the crafted-scope attack by construction.
- `zoneAllowed`: exact match or sub-zone across a dot boundary (`zone.equals(allowed) || zone.startsWith(allowed + ".")`), so `app.<org>.<app>.billing` is reachable by whoever reaches `app.<org>.<app>`, while `orders-app-2` never matches `orders-app`.
- Reply subscriptions compare `cri.scope()` against the connection's `replyToId:` prefix.
- Temporary send grants are exact folded raw strings, single-use.
- System participants keep send-anywhere (including un-zoned legacy addresses); an address without `~` is unreachable by anyone else.

## kinotic-js

`CRI`, `DefaultCRI`, and `ServiceIdentifier` mirror the delimiter, folding, zone accessors, and validations. The gateway e2e tests (`Publish.test.ts`, `Context.test.ts`) build `~` addresses now.

## Docs

`reference/cri-format` documents the new format line, the zone component, the case rules with a fold example, and all-new example addresses; the zoned-address examples in `reference/decorators` and `apps/services/publishing-services` are reconciled.

## Tests

- `CRITests`: `~` parsing from both construction paths, folding with path case preserved, underscore-in-namespace pin retained, scope-delimiter rejection
- `ServiceIdentifierTest`: folded `~` qualified names and CRIs, `~` rejection in name/namespace
- `StompAuthorizerFactoryTest`: the full participant x verb x zone matrix in `~` form, sub-zone send/host, dot-boundary safety, **legacy dotted form denied**, crafted scopes, reply scoping, single-use normalized grants
- TS: pure construction tests pass; all four Java module suites green

## Breaking change

The address form is a wire break: old-form and new-form nodes cannot route to each other, and directory entry ids change shape — wipe the dev `kinotic_service_directory` index on first boot of this branch. The TS gateway e2e tests were updated but need a Docker gateway (`USE_GATEWAY_DOCKER=true`) to execute, which the authoring environment lacked — worth one local run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw)_