### PR TITLE
Preserve case in the CRI identity and fix dotted zone joins in service proxies

### DIFF
--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizer.java
@@ -52,15 +52,15 @@ public class StompAuthorizer {
 
     /**
      * Grants one send to the given destination, consumed by the next matching {@link #sendAllowed(CRI)}.
-     * @param rawCri the destination to allow, matched exactly after normalization
+     * @param rawCri the destination to allow, matched exactly
      */
     public void addTemporarySendAllowed(String rawCri) {
         if (temporarySendGrants.size() == MAX_TEMPORARY_GRANTS) {
             temporarySendGrants.removeFirst();
             log.warn("Reached max temporary grants some messages may be dropped");
         }
-        // normalizing through CRI lowercases the identity, so the grant compares equal to the
-        // normalized raw() of the send it authorizes
+        // round-tripping through CRI validates the grant and stores the same raw() form the
+        // incoming send's CRI produces, so the two compare as exact strings
         temporarySendGrants.add(CRI.create(rawCri).raw());
     }
 

--- a/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
+++ b/kinotic-api-gateway/src/test/java/org/kinotic/gateway/internal/endpoints/stomp/StompAuthorizerFactoryTest.java
@@ -218,15 +218,16 @@ public class StompAuthorizerFactoryTest {
     }
 
     @Test
-    public void temporaryGrantsAllowOneNormalizedSend() {
+    public void temporaryGrantsAllowOneExactMatchSend() {
         StompAuthorizer authorizer = organizationAuthorizer("acme-org");
-        String replyDestination = "reply://" + REPLY_TO_ID + ":sub-1@Kinoitc.js.EventBus/replyHandler";
+        String replyDestination = "reply://" + REPLY_TO_ID + ":sub-1@kinoitc.js.EventBus/replyHandler";
 
         assertFalse(authorizer.sendAllowed(CRI.create(replyDestination)));
 
-        // the grant and the send normalize to the same lowercase identity regardless of input case
+        // grants match by exact string, so a case variant of the granted destination stays denied
         authorizer.addTemporarySendAllowed(replyDestination);
-        assertTrue(authorizer.sendAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@kinoitc.js.EventBus/replyHandler")));
+        assertFalse(authorizer.sendAllowed(CRI.create("reply://" + REPLY_TO_ID + ":sub-1@Kinoitc.js.EventBus/replyHandler")));
+        assertTrue(authorizer.sendAllowed(CRI.create(replyDestination)));
 
         // a grant authorizes exactly one send
         assertFalse(authorizer.sendAllowed(CRI.create(replyDestination)));

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/CRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/CRI.java
@@ -13,8 +13,7 @@ package org.kinotic.core.api.event;
  *
  * NOTE: If scope needs to be used to identify a sub-scope it will follow the form scope = scope:sub-scope
  *
- * The scheme, scope, zone, and resourceName are the CRI's identity and are always lowercase; the
- * path and version keep the case they were written with.
+ * Every part keeps the case it was written with; addresses match by exact string comparison.
  *
  * This format can have varied meanings based upon the scheme used.
  *

--- a/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/event/DefaultCRI.java
@@ -7,7 +7,6 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Locale;
 
 /**
  *
@@ -28,13 +27,12 @@ class DefaultCRI implements CRI {
             throw new IllegalArgumentException("The resourceName must not contain '@' but was '" + resourceName + "'");
         }
         // Compose the authority as scope@resourceName and pass it to the authority-form URI
-        // constructor, which stores it verbatim. The scheme and authority are the CRI's identity,
-        // so they are lowercased; the path and version are payload details and keep their case.
+        // constructor, which stores it verbatim
         String authority = resourceName != null
-                ? ((scope != null ? scope + "@" : "") + resourceName).toLowerCase(Locale.ROOT)
+                ? (scope != null ? scope + "@" : "") + resourceName
                 : null;
         try {
-            uri = new URI(scheme.toLowerCase(Locale.ROOT), authority, path, null, version);
+            uri = new URI(scheme, authority, path, null, version);
         } catch (URISyntaxException x) {
             throw new IllegalArgumentException(x.getMessage(), x);
         }
@@ -47,7 +45,7 @@ class DefaultCRI implements CRI {
      * @param rawCRI the raw string to create from an {@link CRI}
      */
     public DefaultCRI(String rawCRI) {
-        uri = URI.create(lowercaseIdentity(rawCRI));
+        uri = URI.create(rawCRI);
         validateIdentity();
     }
 
@@ -66,25 +64,6 @@ class DefaultCRI implements CRI {
         if (authority != null && authority.indexOf('@') != authority.lastIndexOf('@')) {
             throw new IllegalArgumentException("The authority must contain at most one '@' but was '" + authority + "'");
         }
-    }
-
-    // Lowercases the scheme and authority of a raw CRI, leaving the path and everything after it
-    // untouched. The authority ends at the first '/', '?', or '#' after "://".
-    private static String lowercaseIdentity(String rawCRI) {
-        String ret = rawCRI;
-        int schemeEnd = rawCRI.indexOf("://");
-        if (schemeEnd >= 0) {
-            int authorityEnd = rawCRI.length();
-            for (int i = schemeEnd + 3; i < rawCRI.length(); i++) {
-                char c = rawCRI.charAt(i);
-                if (c == '/' || c == '?' || c == '#') {
-                    authorityEnd = i;
-                    break;
-                }
-            }
-            ret = rawCRI.substring(0, authorityEnd).toLowerCase(Locale.ROOT) + rawCRI.substring(authorityEnd);
-        }
-        return ret;
     }
 
     @Override

--- a/kinotic-core/src/main/java/org/kinotic/core/api/service/ServiceIdentifier.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/service/ServiceIdentifier.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import java.util.Locale;
 
 /**
  * The {@link ServiceIdentifier} identifies a {@link ServiceDescriptor}
@@ -105,13 +104,12 @@ public class ServiceIdentifier {
 
     /**
      * Returns the fully qualified name this {@link ServiceIdentifier} is addressed by
-     * This is the zone~namespace.name, omitting any part that is not set, always lowercase
+     * This is the zone~namespace.name, omitting any part that is not set
      * @return string containing the qualified name
      */
     public String qualifiedName(){
         String name = (namespace != null && !namespace.isEmpty() ? namespace + "." : "") + this.name;
-        String qualified = zone != null ? zone + "~" + name : name;
-        return qualified.toLowerCase(Locale.ROOT);
+        return zone != null ? zone + "~" + name : name;
     }
 
     /**

--- a/kinotic-core/src/test/java/org/kinotic/core/api/service/ServiceIdentifierTest.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/api/service/ServiceIdentifierTest.java
@@ -15,31 +15,31 @@ public class ServiceIdentifierTest {
     @Test
     public void qualifiedNameIsZonePrefixed() {
         ServiceIdentifier identifier = new ServiceIdentifier("api", "org.kinotic.os.api.services.iam", "MemberService", null, "1.0.0");
-        assertEquals("api~org.kinotic.os.api.services.iam.memberservice", identifier.qualifiedName());
-        assertEquals("srv://api~org.kinotic.os.api.services.iam.memberservice#1.0.0", identifier.cri().raw());
+        assertEquals("api~org.kinotic.os.api.services.iam.MemberService", identifier.qualifiedName());
+        assertEquals("srv://api~org.kinotic.os.api.services.iam.MemberService#1.0.0", identifier.cri().raw());
         assertEquals("api", identifier.cri().zone());
-        assertEquals("org.kinotic.os.api.services.iam.memberservice", identifier.cri().resourceName());
+        assertEquals("org.kinotic.os.api.services.iam.MemberService", identifier.cri().resourceName());
     }
 
     @Test
     public void platformZoneAddresses() {
         ServiceIdentifier identifier = new ServiceIdentifier("os-api", "com.example", "LogManager", null, "1.0.0");
-        assertEquals("os-api~com.example.logmanager", identifier.qualifiedName());
-        assertEquals("srv://os-api~com.example.logmanager#1.0.0", identifier.cri().raw());
+        assertEquals("os-api~com.example.LogManager", identifier.qualifiedName());
+        assertEquals("srv://os-api~com.example.LogManager#1.0.0", identifier.cri().raw());
     }
 
     @Test
     public void scopeAndMissingNamespaceRoundTrip() {
         ServiceIdentifier identifier = new ServiceIdentifier("system", null, "VmManager", "node1", "0.1.0");
-        assertEquals("system~vmmanager", identifier.qualifiedName());
-        assertEquals("srv://node1@system~vmmanager#0.1.0", identifier.cri().raw());
+        assertEquals("system~VmManager", identifier.qualifiedName());
+        assertEquals("srv://node1@system~VmManager#0.1.0", identifier.cri().raw());
     }
 
     @Test
     public void noZoneMeansTheUnZonedAddress() {
         ServiceIdentifier identifier = new ServiceIdentifier(null, "com.example", "LegacyService", null, "1.0.0");
-        assertEquals("com.example.legacyservice", identifier.qualifiedName());
-        assertEquals("srv://com.example.legacyservice#1.0.0", identifier.cri().raw());
+        assertEquals("com.example.LegacyService", identifier.qualifiedName());
+        assertEquals("srv://com.example.LegacyService#1.0.0", identifier.cri().raw());
         assertNull(identifier.cri().zone());
     }
 

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/CRITests.java
@@ -135,28 +135,27 @@ public class CRITests {
     }
 
     @Test
-    public void rawFormLowercasesIdentityAndPreservesThePath(){
-        CRI cri = CRI.create("SRV://Node1@OS-API~Org.Kinotic.Tests.TestService/testMethodWithString#1.0.0");
+    public void rawFormPreservesCaseInEveryPart(){
+        CRI cri = CRI.create("srv://Node1@os-api~org.kinotic.tests.TestService/testMethodWithString#1.0.0");
 
         assertEquals("srv", cri.scheme());
-        assertEquals("node1", cri.scope());
+        assertEquals("Node1", cri.scope());
         assertEquals("os-api", cri.zone());
-        assertEquals("org.kinotic.tests.testservice", cri.resourceName());
-        // the path is a Java method name, so its case is significant and never lowercased
+        assertEquals("org.kinotic.tests.TestService", cri.resourceName());
         assertEquals("/testMethodWithString", cri.path());
-        assertEquals("srv://node1@os-api~org.kinotic.tests.testservice/testMethodWithString#1.0.0", cri.raw());
+        assertEquals("srv://Node1@os-api~org.kinotic.tests.TestService/testMethodWithString#1.0.0", cri.raw());
     }
 
     @Test
-    public void componentFormLowercasesIdentityAndPreservesThePath(){
-        CRI cri = CRI.create("SRV", "Node1", "OS-API~Org.Kinotic.Tests.TestService", "/testMethodWithString", "1.0.0");
+    public void componentFormPreservesCaseInEveryPart(){
+        CRI cri = CRI.create("srv", "Node1", "os-api~org.kinotic.tests.TestService", "/testMethodWithString", "1.0.0");
 
         assertEquals("srv", cri.scheme());
-        assertEquals("node1", cri.scope());
+        assertEquals("Node1", cri.scope());
         assertEquals("os-api", cri.zone());
-        assertEquals("org.kinotic.tests.testservice", cri.resourceName());
+        assertEquals("org.kinotic.tests.TestService", cri.resourceName());
         assertEquals("/testMethodWithString", cri.path());
-        // both construction paths normalize to the same raw form
+        // both construction paths produce the same raw form
         assertEquals(CRI.create(cri.raw()), cri);
     }
 

--- a/kinotic-js/workspace/packages/core/src/api/ServiceIdentifier.ts
+++ b/kinotic-js/workspace/packages/core/src/api/ServiceIdentifier.ts
@@ -36,13 +36,12 @@ export class ServiceIdentifier {
 
     /**
      * Returns the fully qualified name this {@link ServiceIdentifier} is addressed by
-     * This is the zone~namespace.name, omitting any part that is not set, always lowercase
+     * This is the zone~namespace.name, omitting any part that is not set
      * @return string containing the qualified name
      */
     public qualifiedName(): string {
         const name = this.namespace ? this.namespace + "." + this.name : this.name
-        const qualified = this.zone ? this.zone + "~" + name : name
-        return qualified.toLowerCase()
+        return this.zone ? this.zone + "~" + name : name
     }
 
     /**

--- a/kinotic-js/workspace/packages/core/src/api/event/CRI.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/CRI.ts
@@ -11,8 +11,7 @@ import {DefaultCRI} from './DefaultCRI'
  *
  * NOTE: If scope needs to be used to identify a sub-scope, it will follow the form `scope = scope:sub-scope`.
  *
- * The scheme, scope, zone, and resourceName are the CRI's identity and are always lowercase; the
- * path and version keep the case they were written with.
+ * Every part keeps the case it was written with; addresses match by exact string comparison.
  *
  * This format can have varied meanings based upon the scheme used.
  *

--- a/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
+++ b/kinotic-js/workspace/packages/core/src/api/event/DefaultCRI.ts
@@ -20,17 +20,15 @@ export class DefaultCRI implements CRI {
     constructor(rawCRI: string)
     constructor(scheme: string, scope: string | null, resourceName: string, path: string | null, version: string | null)
     constructor(...args: any[]) {
-        // The scheme, scope, zone, and resourceName are the CRI's identity, so they are
-        // lowercased; the path and version are payload details and keep their case.
         if (args.length === 1) {
             const rawURC = args[0]
             if (typeof rawURC !== "string") {
                 throw new Error("Raw URI must be a string")
             }
             const parsed = DefaultCRI.parseRaw(rawURC)
-            this._scheme = parsed.scheme.toLowerCase()
-            this._scope = parsed.scope ? parsed.scope.toLowerCase() : null
-            const [zone, resourceName] = DefaultCRI.splitZone(parsed.resourceName.toLowerCase())
+            this._scheme = parsed.scheme
+            this._scope = parsed.scope
+            const [zone, resourceName] = DefaultCRI.splitZone(parsed.resourceName)
             this._zone = zone
             this._resourceName = resourceName
             this._path = parsed.path
@@ -44,9 +42,9 @@ export class DefaultCRI implements CRI {
             if ((resourceName as string).includes('@')) {
                 throw new Error(`The resourceName must not contain '@' but was '${resourceName}'`)
             }
-            this._scheme = scheme.toLowerCase()
-            this._scope = scope ? scope.toLowerCase() : null
-            const [zone, name] = DefaultCRI.splitZone((resourceName as string).toLowerCase())
+            this._scheme = scheme
+            this._scope = scope ?? null
+            const [zone, name] = DefaultCRI.splitZone(resourceName as string)
             this._zone = zone
             this._resourceName = name
             this._path = path

--- a/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
+++ b/kinotic-js/workspace/packages/core/test/ServiceIdentifier.test.ts
@@ -10,10 +10,10 @@ describe('Kinotic JS', () => {
         it('builds a zone prefixed cri', () => {
             const identifier = new ServiceIdentifier('org.kinotic.os.api.services.iam', 'MemberService', 'os-api')
             identifier.version = '1.0.0'
-            expect(identifier.qualifiedName()).toBe('os-api~org.kinotic.os.api.services.iam.memberservice')
-            expect(identifier.cri().raw()).toBe('srv://os-api~org.kinotic.os.api.services.iam.memberservice#1.0.0')
+            expect(identifier.qualifiedName()).toBe('os-api~org.kinotic.os.api.services.iam.MemberService')
+            expect(identifier.cri().raw()).toBe('srv://os-api~org.kinotic.os.api.services.iam.MemberService#1.0.0')
             expect(identifier.cri().zone()).toBe('os-api')
-            expect(identifier.cri().resourceName()).toBe('org.kinotic.os.api.services.iam.memberservice')
+            expect(identifier.cri().resourceName()).toBe('org.kinotic.os.api.services.iam.MemberService')
         })
 
         it('rejects a name or namespace containing the zone delimiter', () => {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IApplicationService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IApplicationService.ts
@@ -28,7 +28,7 @@ export interface IApplicationService extends ICrudServiceProxy<Application> {
 export class ApplicationService extends CrudServiceProxy<Application> implements IApplicationService {
 
     constructor(kinotic: IKinotic) {
-        super(kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.os.api.services.ApplicationService`))
+        super(kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.os.api.services.ApplicationService`))
     }
 
     public createApplicationIfNotExist(id: string, description: string): Promise<Application> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IDataInsightsService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IDataInsightsService.ts
@@ -26,7 +26,7 @@ export class DataInsightsService implements IDataInsightsService {
     private readonly serviceProxy: IServiceProxy
 
     constructor(kinotic: IKinotic) {
-        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.persistence.api.services.insights.DataInsightsService`)
+        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.persistence.api.services.insights.DataInsightsService`)
     }
 
     public processRequest(request: InsightRequest): Observable<InsightProgress> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IDeviceApprovalService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IDeviceApprovalService.ts
@@ -21,7 +21,7 @@ export class DeviceApprovalService implements IDeviceApprovalService {
     private readonly serviceProxy: IServiceProxy
 
     constructor(kinotic: IKinotic) {
-        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.os.api.services.iam.DeviceApprovalService`)
+        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.os.api.services.iam.DeviceApprovalService`)
     }
 
     public approve(userCode: string): Promise<void> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IEntityDefinitionService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IEntityDefinitionService.ts
@@ -68,7 +68,7 @@ export interface IEntityDefinitionService extends ICrudServiceProxy<EntityDefini
 export class EntityDefinitionService extends CrudServiceProxy<EntityDefinition> implements IEntityDefinitionService {
 
     constructor(kinotic: IKinotic) {
-        super(kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.persistence.api.services.EntityDefinitionService`))
+        super(kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.persistence.api.services.EntityDefinitionService`))
     }
 
     public countForApplication(applicationId: string): Promise<number> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IGitHubAppInstallationService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IGitHubAppInstallationService.ts
@@ -37,7 +37,7 @@ export class GitHubAppInstallationService extends CrudServiceProxy<GitHubAppInst
     implements IGitHubAppInstallationService {
 
     constructor(kinotic: IKinotic) {
-        super(kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.github.api.services.GitHubAppInstallationService`))
+        super(kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.github.api.services.GitHubAppInstallationService`))
     }
 
     public startInstall(returnTo: string | null): Promise<string> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IInviteEmailTemplateService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IInviteEmailTemplateService.ts
@@ -22,7 +22,7 @@ export interface IInviteEmailTemplateService extends ICrudServiceProxy<InviteEma
 export class InviteEmailTemplateService extends CrudServiceProxy<InviteEmailTemplate> implements IInviteEmailTemplateService {
 
     constructor(kinotic: IKinotic) {
-        super(kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.os.api.services.InviteEmailTemplateService`))
+        super(kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.os.api.services.InviteEmailTemplateService`))
     }
 
     public findByApplication(applicationId: string): Promise<InviteEmailTemplate | null> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/ILogService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/ILogService.ts
@@ -29,7 +29,7 @@ export class LogService implements ILogService {
     private readonly serviceProxy: IServiceProxy
 
     constructor(kinotic: IKinotic) {
-        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.os.api.services.LogService`)
+        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.os.api.services.LogService`)
     }
 
     public tail(workloadId: string): Observable<Uint8Array> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IMemberService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IMemberService.ts
@@ -63,7 +63,7 @@ export class MemberService implements IMemberService {
     private readonly serviceProxy: IServiceProxy
 
     constructor(kinotic: IKinotic) {
-        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.os.api.services.iam.MemberService`)
+        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.os.api.services.iam.MemberService`)
     }
 
     public async findMembers(applicationId: string | null, pageable: Pageable): Promise<IterablePage<IamUser>> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IMigrationService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IMigrationService.ts
@@ -42,7 +42,7 @@ export class MigrationService implements IMigrationService {
     private readonly serviceProxy: IServiceProxy;
 
     constructor(kinotic: IKinotic) {
-        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.persistence.api.services.MigrationService`);
+        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.persistence.api.services.MigrationService`);
     }
 
     public executeMigrations(migrationRequest: MigrationRequest): Promise<MigrationResult> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/INamedQueriesDefinitionService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/INamedQueriesDefinitionService.ts
@@ -16,7 +16,7 @@ export interface INamedQueriesDefinitionService extends ICrudServiceProxy<NamedQ
 export class NamedQueriesDefinitionService extends CrudServiceProxy<NamedQueriesDefinition> implements INamedQueriesDefinitionService {
 
     constructor(kinotic: IKinotic) {
-        super(kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.persistence.api.services.NamedQueriesDefinitionService`))
+        super(kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.persistence.api.services.NamedQueriesDefinitionService`))
     }
 
     public syncIndex(): Promise<void> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IOrganizationService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IOrganizationService.ts
@@ -20,7 +20,7 @@ export interface IOrganizationService extends ICrudServiceProxy<Organization> {
 export class OrganizationService extends CrudServiceProxy<Organization> implements IOrganizationService {
 
     constructor(kinotic: IKinotic) {
-        super(kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.os.api.services.OrganizationService`))
+        super(kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.os.api.services.OrganizationService`))
     }
 
     public getOidcConfigurations(organizationId: string): Promise<any[]> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IProjectService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IProjectService.ts
@@ -45,7 +45,7 @@ export interface IProjectService extends ICrudServiceProxy<Project> {
 export class ProjectService extends CrudServiceProxy<Project> implements IProjectService {
 
     constructor(kinotic: IKinotic) {
-        super(kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.os.api.services.ProjectService`))
+        super(kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.os.api.services.ProjectService`))
     }
 
     public countForApplication(applicationId: string): Promise<number> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IVmNodeService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IVmNodeService.ts
@@ -26,7 +26,7 @@ export interface IVmNodeService extends ICrudServiceProxy<VmNode> {
 export class VmNodeServiceProxy extends CrudServiceProxy<VmNode> implements IVmNodeService {
 
     constructor(kinotic: IKinotic) {
-        super(kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.os.api.services.VmNodeService`))
+        super(kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.os.api.services.VmNodeService`))
     }
 
     public findAvailableNode(requiredCpus: number, requiredMemoryMb: number, requiredDiskMb: number): Promise<VmNode | null> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IWorkloadService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IWorkloadService.ts
@@ -31,7 +31,7 @@ export interface IWorkloadService extends ICrudServiceProxy<Workload> {
 export class WorkloadServiceProxy extends CrudServiceProxy<Workload> implements IWorkloadService {
 
     constructor(kinotic: IKinotic) {
-        super(kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.os.api.services.WorkloadService`))
+        super(kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.os.api.services.WorkloadService`))
     }
 
     public async findAllForNode(nodeId: string, pageable: Pageable): Promise<IterablePage<Workload>> {

--- a/kinotic-js/workspace/packages/os-api/src/api/services/LogManager.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/LogManager.ts
@@ -12,7 +12,7 @@ export class LogManager implements ILogManager {
     private readonly serviceProxy: IServiceProxy
 
     constructor(kinotic: IKinotic) {
-        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.os.api.services.LogManager`)
+        this.serviceProxy = kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.os.api.services.LogManager`)
     }
 
     loggers(nodeId: string): Promise<LoggersDescriptor> {

--- a/kinotic-js/workspace/packages/persistence/src/api/IAdminEntitiesRepository.ts
+++ b/kinotic-js/workspace/packages/persistence/src/api/IAdminEntitiesRepository.ts
@@ -125,7 +125,7 @@ export class AdminEntitiesRepository implements IAdminEntitiesRepository {
     protected serviceProxy: IServiceProxy
 
     constructor(kinotic: IKinotic) {
-        this.serviceProxy = kinotic.serviceProxy(`${APP_API_ZONE}.org.kinotic.persistence.api.services.AdminJsonEntitiesRepository`)
+        this.serviceProxy = kinotic.serviceProxy(`${APP_API_ZONE}~org.kinotic.persistence.api.services.AdminJsonEntitiesRepository`)
     }
 
     public count(entityDefinitionId: string, tenantSelection: TenantSelection): Promise<number> {

--- a/kinotic-js/workspace/packages/persistence/src/api/IAdminEntityRepository.ts
+++ b/kinotic-js/workspace/packages/persistence/src/api/IAdminEntityRepository.ts
@@ -170,7 +170,7 @@ export class AdminEntityRepository<T> implements IAdminEntityRepository<T> {
         return this.adminEntitiesRepository.findAll(this.entityId, tenantSelection, pageable)
     }
 
-    public findById(id: TenantSpecificId): Promise<T> {
+    public findById(id: TenantSpecificId): Promise<T | null> {
         return this.adminEntitiesRepository.findById(this.entityId, id)
     }
 

--- a/kinotic-js/workspace/packages/persistence/src/api/IEntitiesRepository.ts
+++ b/kinotic-js/workspace/packages/persistence/src/api/IEntitiesRepository.ts
@@ -180,7 +180,7 @@ export class EntitiesRepository implements IEntitiesRepository {
     protected serviceProxy: IServiceProxy
 
     constructor(kinotic: IKinotic) {
-        this.serviceProxy = kinotic.serviceProxy(`${APP_API_ZONE}.org.kinotic.persistence.api.services.JsonEntitiesRepository`)
+        this.serviceProxy = kinotic.serviceProxy(`${APP_API_ZONE}~org.kinotic.persistence.api.services.JsonEntitiesRepository`)
     }
 
     public bulkSave<T>(entityDefinitionId: string, entities: T[]): Promise<void> {

--- a/kinotic-js/workspace/packages/persistence/src/api/idl/EntityServiceDecoratorsConfig.ts
+++ b/kinotic-js/workspace/packages/persistence/src/api/idl/EntityServiceDecoratorsConfig.ts
@@ -1,5 +1,5 @@
 import type { EntityServiceDecorator } from './EntityServiceDecorator'
-import type { IEntityService } from '@/api/IEntityService'
+import type { IEntityRepository } from '@/api/IEntityRepository'
 
 // Helper type to determine if a type is a function
 type IfFunction<T, U> = T extends (...args: any[]) => any ? U : never;
@@ -12,11 +12,11 @@ type MethodsOf<T> = {
 // List of methods to exclude
 type ExcludedMethods = 'namedQuery' | 'namedQueryPage';
 
-// Filtered methods from IEntityService
+// Filtered methods from IEntityRepository
 type FilteredMethods<T> = Exclude<MethodsOf<T>, ExcludedMethods>;
 
-// Defining the DecoratedFunction type based on IEntityService methods, excluding some, and adding a few more
-export type DecoratedFunction = FilteredMethods<IEntityService<any>> | 'allCreate' | 'allRead' | 'allUpdate' | 'allDelete';
+// Defining the DecoratedFunction type based on IEntityRepository methods, excluding some, and adding a few more
+export type DecoratedFunction = FilteredMethods<IEntityRepository<any>> | 'allCreate' | 'allRead' | 'allUpdate' | 'allDelete';
 
 /**
  * Configuration for the {@link EntityServiceDecoratorsDecorator}

--- a/kinotic-js/workspace/packages/vm-manager/src/index.ts
+++ b/kinotic-js/workspace/packages/vm-manager/src/index.ts
@@ -78,7 +78,7 @@ async function start() {
     console.log(`Connected to Kinotic server at ${config.serverHost}:${config.serverPort}`)
 
     const nodeOrchestrator = new VmNodeOrchestrationServiceProxy(
-        Kinotic.serviceProxy('system.org.kinotic.orchestrator.api.workload.VmNodeOrchestrationService')
+        Kinotic.serviceProxy('system~org.kinotic.orchestrator.api.workload.VmNodeOrchestrationService')
     )
 
     // Reattach to workloads a previous vm-manager process left running before the

--- a/website/content/1.apps/4.services/2.publishing-services.md
+++ b/website/content/1.apps/4.services/2.publishing-services.md
@@ -39,10 +39,10 @@ Kinotic.zonePrefix = appZone(config.organization, config.application)
 ```
 
 ```typescript
-@Publish()                       // → srv://app.acme-org.orders-app~orderservice
+@Publish()                       // → srv://app.acme-org.orders-app~OrderService
 class OrderService { ... }
 
-@Zone('billing')                 // → srv://app.acme-org.orders-app.billing~invoiceservice
+@Zone('billing')                 // → srv://app.acme-org.orders-app.billing~InvoiceService
 @Publish()
 class InvoiceService { ... }
 ```

--- a/website/content/3.reference/1.decorators.md
+++ b/website/content/3.reference/1.decorators.md
@@ -402,7 +402,7 @@ import { Publish, Zone } from '@kinotic-ai/core'
 @Zone('billing')
 @Publish()
 class InvoiceService {
-    // With zonePrefix app.acme-org.orders-app → srv://app.acme-org.orders-app.billing~invoiceservice
+    // With zonePrefix app.acme-org.orders-app → srv://app.acme-org.orders-app.billing~InvoiceService
 }
 ```
 

--- a/website/content/3.reference/4.cri-format.md
+++ b/website/content/3.reference/4.cri-format.md
@@ -19,11 +19,10 @@ Everything in brackets (`[]`) is optional.
 
 ## Case
 
-The scheme, scope, zone, and resourceName are the CRI's identity and are always lowercase — every construction path lowercases them, so two spellings of the same address are the same address. The path and version keep the case they were written with: a path carries a method name, whose case is significant.
+Every part keeps the case it was written with, and addresses match by exact string comparison — `OrderService` and `OrderService` are two different addresses. Service names carry the case of the class that published them, so a typical address looks like:
 
 ```
-SRV://Node1@os-api~Org.Kinotic.Os.Api.Services.ProjectService/findByRepoFullName
-  → srv://node1@os-api~org.kinotic.os.api.services.projectservice/findByRepoFullName
+srv://os-api~org.kinotic.os.api.services.ProjectService/findByRepoFullName
 ```
 
 ## Components
@@ -44,7 +43,7 @@ An optional qualifier that narrows the CRI to a specific context, such as a tena
 If a scope needs sub-scopes, use the format `scope:sub-scope`.
 
 ```
-srv://tenant-123@app.acme-org.orders-app~orderservice
+srv://tenant-123@app.acme-org.orders-app~OrderService
 stream://device-42@app.acme-org.orders-app~temperature/sensor-1
 ```
 
@@ -72,7 +71,7 @@ Which zones a connection may address is determined by the authenticated particip
 The name of the resource being addressed, excluding the zone. For services, this is the fully qualified service name. For streams, this is the event type name.
 
 ```
-srv://os-api~com.example.userservice
+srv://os-api~com.example.UserService
 stream://app.acme-org.orders-app~temperature
 ```
 
@@ -81,7 +80,7 @@ stream://app.acme-org.orders-app~temperature
 An optional path that identifies a specific part of the resource, such as a method name on a service. The path's case is preserved.
 
 ```
-srv://os-api~com.example.userservice/findById
+srv://os-api~com.example.UserService/findById
 stream://app.acme-org.orders-app~temperature/sensor-1
 ```
 
@@ -90,8 +89,8 @@ stream://app.acme-org.orders-app~temperature/sensor-1
 An optional semantic version for the resource. Enables versioned service routing so multiple versions of a service can coexist.
 
 ```
-srv://os-api~com.example.userservice/findById#1.0.0
-srv://os-api~com.example.userservice#2.0.0
+srv://os-api~com.example.UserService/findById#1.0.0
+srv://os-api~com.example.UserService#2.0.0
 ```
 
 ## Factory Function
@@ -102,16 +101,16 @@ The `createCRI` function provides several overloads for constructing CRI instanc
 import { createCRI } from '@kinotic-ai/core'
 
 // From a raw string
-const cri1 = createCRI('srv://os-api~com.example.userservice/findById#1.0.0')
+const cri1 = createCRI('srv://os-api~com.example.UserService/findById#1.0.0')
 
 // From scheme and resource name (which may carry a zone)
-const cri2 = createCRI('srv', 'os-api~com.example.userservice')
+const cri2 = createCRI('srv', 'os-api~com.example.UserService')
 
 // From scheme, scope, and resource name
 const cri3 = createCRI('stream', 'tenant-123', 'app.acme-org.orders-app~orders')
 
 // From all components
-const cri4 = createCRI('srv', null, 'os-api~com.example.userservice', 'findById', '1.0.0')
+const cri4 = createCRI('srv', null, 'os-api~com.example.UserService', 'findById', '1.0.0')
 ```
 
 ### CRI Interface
@@ -119,30 +118,30 @@ const cri4 = createCRI('srv', null, 'os-api~com.example.userservice', 'findById'
 The `CRI` interface provides methods to access each component:
 
 ```typescript
-const cri = createCRI('srv://tenant-123@app.acme-org.orders-app~orderservice/placeOrder#2.0.0')
+const cri = createCRI('srv://tenant-123@app.acme-org.orders-app~OrderService/placeOrder#2.0.0')
 
 cri.scheme()        // 'srv'
 cri.scope()         // 'tenant-123'
 cri.hasScope()      // true
 cri.zone()          // 'app.acme-org.orders-app'
 cri.hasZone()       // true
-cri.resourceName()  // 'orderservice'
+cri.resourceName()  // 'OrderService'
 cri.path()          // 'placeOrder'
 cri.hasPath()       // true
 cri.version()       // '2.0.0'
 cri.hasVersion()    // true
-cri.baseResource()  // 'srv://tenant-123@app.acme-org.orders-app~orderservice'
-cri.raw()           // 'srv://tenant-123@app.acme-org.orders-app~orderservice/placeOrder#2.0.0'
+cri.baseResource()  // 'srv://tenant-123@app.acme-org.orders-app~OrderService'
+cri.raw()           // 'srv://tenant-123@app.acme-org.orders-app~OrderService/placeOrder#2.0.0'
 ```
 
 ## Examples
 
 | CRI | Description |
 |-----|-------------|
-| `srv://os-api~org.kinotic.os.api.services.iam.memberservice` | A platform service in the `os-api` zone |
-| `srv://app-api~org.kinotic.persistence.api.services.jsonentitiesrepository/save` | A specific method on a platform service |
-| `srv://app.acme-org.orders-app~orderservice/create#1.0.0` | A versioned method on an application's own service |
-| `srv://app.acme-org.orders-app.billing~invoiceservice` | A service in an application-declared sub-zone |
-| `srv://system~org.kinotic.orchestrator.api.workload.workloadorchestrationservice` | A platform-internal service |
+| `srv://os-api~org.kinotic.os.api.services.iam.MemberService` | A platform service in the `os-api` zone |
+| `srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository/save` | A specific method on a platform service |
+| `srv://app.acme-org.orders-app~OrderService/create#1.0.0` | A versioned method on an application's own service |
+| `srv://app.acme-org.orders-app.billing~InvoiceService` | A service in an application-declared sub-zone |
+| `srv://system~org.kinotic.orchestrator.api.workload.WorkloadOrchestrationService` | A platform-internal service |
 | `stream://app.acme-org.orders-app~temperature` | An application's event stream |
-| `srv://node1@system~kinotic-ai.vm-manager.vmmanager` | A scoped system service targeting one node |
+| `srv://node1@system~kinotic-ai.vm-manager.VmManager` | A scoped system service targeting one node |


### PR DESCRIPTION
## Preserve case in the CRI identity

Lowercasing the identity mangled CamelCase service names in debug logging and, worse, coerced case-significant ids carried in the scope:

```java
// scope is defined as a tenant/user/device id — external identifiers whose case we don't own
CRI.create("srv://Device-AbC123@app.acme-org.orders-app~OrderService/notify");
// before this PR → scope() == "device-abc123"
```

Every CRI part now keeps the case it was written with (Java + TS), and addresses match by exact string comparison. A case mismatch in the authorizer's zone checks or temporary grants is **denied, fail closed** — surfaced as an error instead of silently absorbed:

```java
// StompAuthorizerFactoryTest — grants match by exact string
authorizer.addTemporarySendAllowed(replyDestination);
assertFalse(authorizer.sendAllowed(CRI.create(caseVariantOfReplyDestination)));
assertTrue(authorizer.sendAllowed(CRI.create(replyDestination)));
```

Zones remain lowercase **by grammar** — `ZoneUtil` validates rather than coerces, so server-minted zones are unchanged. The `~`/`@` grammar hardening and the structured authorizer are untouched.

## Fix dotted zone joins in os-api, persistence, and vm-manager proxies

Every service proxy still joined its zone with a dot — the legacy form the CRI grammar parses as **un-zoned**, which the gateway denies for non-system participants and which matches no registered service:

```typescript
// before — parses as un-zoned, denied at the gateway
kinotic.serviceProxy(`${OS_API_ZONE}.org.kinotic.os.api.services.iam.MemberService`)
// after — the form ServiceIdentifier registers services under
kinotic.serviceProxy(`${OS_API_ZONE}~org.kinotic.os.api.services.iam.MemberService`)
```

18 call sites across `os-api` (16), `persistence` (2), and one literal in `vm-manager`. This is the break the e2e suite would have hit even with published 4.0.0 packages — the proxies it calls through never got the `~` migration.

Also cherry-picks the two pre-existing persistence type-check fixes from #322 (`IEntityService` → `IEntityRepository` import, `findById` return type) so this branch type-checks standalone; identical patch, merges cleanly.

## Verification

- Java: `:kinotic-core:test :kinotic-api-gateway:test :kinotic-idl:test :kinotic-domain:test :kinotic-os-api:test` green
- TS: `bun run type-check` green across all six packages; pure suites (idl, persistence, os-api, spawn, core `ServiceIdentifier`) green
- Gateway-Docker suites need CI (no Docker in the authoring environment)
- Docs updated: `cri-format.md` Case section now documents exact-match semantics, examples show real CamelCase service names

Must merge (with #322) **before** the 4.0.0 npm publish — this changes the canonical wire form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw)_