### PR TITLE
Address the clienttest services with '~' in the core gateway tests

### DIFF
--- a/kinotic-js/workspace/packages/core/test/EventBus.test.ts
+++ b/kinotic-js/workspace/packages/core/test/EventBus.test.ts
@@ -24,7 +24,7 @@ describe('Kinotic JS', () => {
         it('should fail invalid service request', async () => {
             // Target a zone this organization participant may send to, so the request reaches
             // reply-to validation (the behavior under test) rather than being denied by zone rules
-            const toSend: IEvent = new Event('srv://os-api.org.kinotic.server.clienttest.ITestService/testMethodWithString')
+            const toSend: IEvent = new Event('srv://os-api~org.kinotic.server.clienttest.ITestService/testMethodWithString')
             toSend.setHeader(EventConstants.REPLY_TO_HEADER, '')
             toSend.setHeader(EventConstants.CONTENT_TYPE_HEADER, EventConstants.CONTENT_JSON)
             const correlationId = uuidv4()

--- a/kinotic-js/workspace/packages/core/test/INonExistentService.ts
+++ b/kinotic-js/workspace/packages/core/test/INonExistentService.ts
@@ -11,7 +11,7 @@ class NonExistentService implements INonExistentService {
     private readonly serviceProxy: IServiceProxy
 
     constructor() {
-        this.serviceProxy = Kinotic.serviceProxy('os-api.com.namespace.NonExistentService')
+        this.serviceProxy = Kinotic.serviceProxy('os-api~com.namespace.NonExistentService')
     }
 
     probablyNotHome(): Promise<void> {

--- a/kinotic-js/workspace/packages/core/test/ITestService.ts
+++ b/kinotic-js/workspace/packages/core/test/ITestService.ts
@@ -45,7 +45,7 @@ export class TestService implements ITestService {
 
     constructor(continuum?: KinoticSingleton) {
         let toUse = continuum || Kinotic
-        this.serviceProxy = toUse.serviceProxy('os-api.org.kinotic.server.clienttest.ITestService')
+        this.serviceProxy = toUse.serviceProxy('os-api~org.kinotic.server.clienttest.ITestService')
     }
 
     testMethodWithString(value: string): Promise<string> {

--- a/kinotic-js/workspace/packages/core/test/KinoticRpc.test.ts
+++ b/kinotic-js/workspace/packages/core/test/KinoticRpc.test.ts
@@ -34,7 +34,7 @@ describe('Kinotic JS', () => {
         })
 
         it('should return missing service error', async () => {
-            await expect(NON_EXISTENT_SERVICE.probablyNotHome()).rejects.toThrowError('(NO_HANDLERS,-1) No handlers for address srv://os-api.com.namespace.NonExistentService')
+            await expect(NON_EXISTENT_SERVICE.probablyNotHome()).rejects.toThrowError('(NO_HANDLERS,-1) No handlers for address srv://os-api~com.namespace.NonExistentService')
         })
 
         // --- Binary Passthrough Tests ---


### PR DESCRIPTION
The develop run's workspace-test failure (23 core tests) comes down to four dotted zone joins the `~` migration missed — the same defect class as the service proxies fixed in #322, this time in the core package's own gateway tests:

```
Received: "Not Authorized to send to srv://os-api.org.kinotic.server.clienttest.ITestService/testMethodWithString"
```

```typescript
// ITestService.ts:48 — parses as un-zoned → gateway denies → disconnect cascade
toUse.serviceProxy('os-api.org.kinotic.server.clienttest.ITestService')
// now — the form ITestService registers under via @Zone(DomainUtil.OS_API_ZONE)
toUse.serviceProxy('os-api~org.kinotic.server.clienttest.ITestService')
```

Four sites: `ITestService.ts`, `INonExistentService.ts`, `EventBus.test.ts` (raw Event address), and the `KinoticRpc.test.ts` NO_HANDLERS error-message assertion. These date from #286/#291 when dots were the zone format; a repo-wide sweep found no other dotted zone literals.

Note: these tests have been failing since #321 merged — the workspace-test step's `continue-on-error` masks its step conclusion, so the failure only surfaced through the final gate alongside the (now fixed) e2e break.

Verified here: type-check green across all six packages. The gateway suites themselves need Docker — this run's CI validates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw)_