### PR TITLE
Migrate SecurityService from CompletableFuture to Vert.x Future

### DIFF
--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
@@ -4,7 +4,6 @@ package org.kinotic.gateway.internal.endpoints.stomp;
 
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
-import io.vertx.core.Vertx;
 import io.vertx.ext.stomp.lite.AbstractStompServerHandler;
 import io.vertx.ext.stomp.lite.frame.Frame;
 import io.vertx.ext.stomp.lite.frame.InvalidConnectFrame;
@@ -27,14 +26,11 @@ public class DefaultStompServerHandler extends AbstractStompServerHandler {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultStompServerHandler.class);
 
-    private final Vertx vertx;
     private final EndpointConnectionHandler endpointConnectionHandler;
     private final JsonMapper jsonMapper;
 
 
-    public DefaultStompServerHandler(Vertx vertx,
-                                     Services services) {
-        this.vertx = vertx;
+    public DefaultStompServerHandler(Services services) {
         this.endpointConnectionHandler = new EndpointConnectionHandler(services);
         this.jsonMapper = services.jsonMapper;
     }
@@ -46,8 +42,7 @@ public class DefaultStompServerHandler extends AbstractStompServerHandler {
 
     @Override
     public Future<Map<String, String>> connect(Map<String, String> connectHeaders) {
-        return Future.fromCompletionStage(endpointConnectionHandler.connect(connectHeaders),
-                                          vertx.getOrCreateContext());
+        return endpointConnectionHandler.connect(connectHeaders);
     }
 
     @Override

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandler.java
@@ -41,8 +41,7 @@ public class DefaultStompServerHandler extends AbstractStompServerHandler {
 
     @Override
     public Future<MultiMap> handshake(RoutingContext routingContext) {
-        return Future.fromCompletionStage(endpointConnectionHandler.handshake(routingContext),
-                                                                       vertx.getOrCreateContext());
+        return endpointConnectionHandler.handshake(routingContext);
     }
 
     @Override

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandlerFactory.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/DefaultStompServerHandlerFactory.java
@@ -2,7 +2,6 @@
 
 package org.kinotic.gateway.internal.endpoints.stomp;
 
-import io.vertx.core.Vertx;
 import io.vertx.ext.stomp.lite.StompServerHandler;
 import io.vertx.ext.stomp.lite.StompServerHandlerFactory;
 import org.kinotic.gateway.internal.endpoints.Services;
@@ -15,18 +14,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class DefaultStompServerHandlerFactory implements StompServerHandlerFactory {
 
-    private final Vertx vertx;
     private final Services services;
 
-    public DefaultStompServerHandlerFactory(Vertx vertx, Services services) {
-        this.vertx = vertx;
+    public DefaultStompServerHandlerFactory(Services services) {
         this.services = services;
     }
 
     @Override
     public StompServerHandler create() {
-        return new DefaultStompServerHandler(vertx,
-                                             services);
+        return new DefaultStompServerHandler(services);
     }
 
 }

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
@@ -52,27 +52,25 @@ public class EndpointConnectionHandler {
         this.securityService = services.securityService;
     }
 
-    public CompletableFuture<MultiMap> handshake(RoutingContext routingContext) {
+    public Future<MultiMap> handshake(RoutingContext routingContext) {
         session = routingContext.session();
         this.connectedInfo = connectedInfoFromSession();
 
         if (connectedInfo != null && connectedInfo.getParticipant() != null) {
-            return CompletableFuture.completedFuture(MultiMap.caseInsensitiveMultiMap());
+            return Future.succeededFuture(MultiMap.caseInsensitiveMultiMap());
         }
 
         return securityService.authenticate(toCaseInsensitiveMap(routingContext.request().headers()))
-                              .handle((participant, throwable) -> {
-                                  if(throwable != null){
-                                      if(!(throwable instanceof AuthenticationException)) {
-                                          throw new AuthenticationException("Could not authenticate with the given credentials", throwable);
-                                      }else{
-                                          throw (AuthenticationException) throwable;
-                                      }
-                                  }else {
-                                      return participant;
+                              .recover(throwable -> {
+                                  Throwable cause;
+                                  if(throwable instanceof AuthenticationException){
+                                      cause = throwable;
+                                  }else{
+                                      cause = new AuthenticationException("Could not authenticate with the given credentials", throwable);
                                   }
+                                  return Future.failedFuture(cause);
                               })
-                              .thenApply(participant -> {
+                              .map(participant -> {
                                   connectedInfo = new ConnectedInfo();
                                   connectedInfo.setParticipant(participant);
                                   if (session != null) {

--- a/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
+++ b/kinotic-api-gateway/src/main/java/org/kinotic/gateway/internal/endpoints/stomp/EndpointConnectionHandler.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Created by Navid Mitchell on 11/3/20
@@ -80,15 +79,18 @@ public class EndpointConnectionHandler {
                               });
     }
 
-    public CompletableFuture<Map<String, String>> connect(Map<String, String> connectHeaders) {
-        if (connectedInfo != null && connectedInfo.getParticipant() != null) {
-            try {
-                sessionKeepAliveMode = SessionKeepAliveMode.fromHeader(connectHeaders.get(EventConstants.SESSION_KEEP_ALIVE_HEADER));
-                if (sessionKeepAliveMode != SessionKeepAliveMode.NONE && session == null) {
-                    return CompletableFuture.failedFuture(
-                            new AuthenticationException("A Vert.x session is required unless session keep alive mode is NONE"));
-                }
+    public Future<Map<String, String>> connect(Map<String, String> connectHeaders) {
+        if (connectedInfo == null || connectedInfo.getParticipant() == null) {
+            return Future.failedFuture(new AuthenticationException("Client must authenticate before sending a CONNECT frame"));
+        }
 
+        Future<Map<String, String>> ret;
+        try {
+            sessionKeepAliveMode = SessionKeepAliveMode.fromHeader(connectHeaders.get(EventConstants.SESSION_KEEP_ALIVE_HEADER));
+            if (sessionKeepAliveMode != SessionKeepAliveMode.NONE && session == null) {
+                ret = Future.failedFuture(
+                        new AuthenticationException("A Vert.x session is required unless session keep alive mode is NONE"));
+            } else {
                 // The replyToId is generated server side so the client cannot pick a guessable
                 // or colliding value. It is reused for the life of the session so the client's
                 // reply destination stays stable across reconnects.
@@ -104,16 +106,15 @@ public class EndpointConnectionHandler {
                 if (sessionKeepAliveMode == SessionKeepAliveMode.CONNECTION) {
                     startSessionTouchTimer();
                 }
-                return CompletableFuture.completedFuture(Map.of(EventConstants.CONNECTED_INFO_HEADER,
-                                                                services.jsonMapper.writeValueAsString(connectedInfo)));
-            } catch (JacksonException e) {
-                return CompletableFuture.failedFuture(e);
-            } catch (IllegalArgumentException e) {
-                return CompletableFuture.failedFuture(new AuthenticationException("Invalid CONNECT frame", e));
+                ret = Future.succeededFuture(Map.of(EventConstants.CONNECTED_INFO_HEADER,
+                                                    services.jsonMapper.writeValueAsString(connectedInfo)));
             }
+        } catch (JacksonException e) {
+            ret = Future.failedFuture(e);
+        } catch (IllegalArgumentException e) {
+            ret = Future.failedFuture(new AuthenticationException("Invalid CONNECT frame", e));
         }
-
-        return CompletableFuture.failedFuture(new AuthenticationException("Client must authenticate before sending a CONNECT frame"));
+        return ret;
     }
 
     public void removeSession() {

--- a/kinotic-core/src/main/java/org/kinotic/core/api/security/AuthenticationHandler.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/security/AuthenticationHandler.java
@@ -1,7 +1,6 @@
 package org.kinotic.core.api.security;
 
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
@@ -21,14 +20,11 @@ public class AuthenticationHandler implements Handler<RoutingContext> {
 
     private final SecurityService securityService;
     private final SecurityContext securityContext;
-    private final Vertx vertx;
 
     public AuthenticationHandler(SecurityService securityService,
-                                 SecurityContext securityContext,
-                                 Vertx vertx) {
+                                 SecurityContext securityContext) {
         this.securityService = securityService;
         this.securityContext = securityContext;
-        this.vertx = vertx;
     }
 
     @Override
@@ -45,24 +41,24 @@ public class AuthenticationHandler implements Handler<RoutingContext> {
             authInfo.put(entry.getKey().toLowerCase(), entry.getValue());
         }
 
-        Future.fromCompletionStage(securityService.authenticate(authInfo), vertx.getOrCreateContext())
-                      .onComplete(event -> {
-                          if(event.succeeded()){
-                              ctx.put(EventConstants.SENDER_HEADER, event.result());
-                              // Bind the Participant to the current Vert.x context so downstream
-                              // handlers (and anything they call) can read it via
-                              // SecurityContext.currentParticipant().
-                              Context vertxContext = Vertx.currentContext();
-                              if (vertxContext != null) {
-                                  securityContext.setParticipant(vertxContext, event.result());
-                              }
-                              ctx.request().resume();
-                              ctx.next();
-                          }else{
-                              ctx.request().resume();
-                              ctx.fail(401, event.cause());
-                          }
-                      });
+        securityService.authenticate(authInfo)
+                       .onComplete(event -> {
+                           if(event.succeeded()){
+                               ctx.put(EventConstants.SENDER_HEADER, event.result());
+                               // Bind the Participant to the current Vert.x context so downstream
+                               // handlers (and anything they call) can read it via
+                               // SecurityContext.currentParticipant().
+                               Context vertxContext = Vertx.currentContext();
+                               if (vertxContext != null) {
+                                   securityContext.setParticipant(vertxContext, event.result());
+                               }
+                               ctx.request().resume();
+                               ctx.next();
+                           }else{
+                               ctx.request().resume();
+                               ctx.fail(401, event.cause());
+                           }
+                       });
     }
 
     private boolean handlePreflight(RoutingContext ctx) {

--- a/kinotic-core/src/main/java/org/kinotic/core/api/security/SecurityService.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/security/SecurityService.java
@@ -2,8 +2,9 @@
 
 package org.kinotic.core.api.security;
 
+import io.vertx.core.Future;
+
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * {@link SecurityService} provides core security functionality.
@@ -16,9 +17,10 @@ public interface SecurityService {
     /**
      * Check if a given participant can authenticate
      * @param authenticationInfo a {@link Map} containing the authentication information
-     * @return a {@link CompletableFuture} completing with a {@link Participant} if authentication was successful or an error if authentication failed
+     * @return a {@link Future} completing with a {@link Participant} if authentication was successful or an error if authentication failed.
+     *         The returned {@link Future} is completed on the Vert.x context of the caller.
      *         WARNING: do not store sensitive information in {@link Participant} as it will be sent to receivers of requests sent by the {@link Participant}
      */
-    CompletableFuture<Participant> authenticate(Map<String, String> authenticationInfo);
+    Future<Participant> authenticate(Map<String, String> authenticationInfo);
 
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/iam/KinoticSecurityService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/iam/KinoticSecurityService.java
@@ -1,5 +1,7 @@
 package org.kinotic.domain.internal.api.services.iam;
 
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +19,6 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Sole {@link SecurityService} implementation for Kinotic OS. Handles both email/password
@@ -54,9 +55,10 @@ public class KinoticSecurityService implements SecurityService {
     private final IamUserService userService;
     private final IamCredentialRepository credentialRepository;
     private final KinoticJwtIssuer jwtIssuer;
+    private final Vertx vertx;
 
     @Override
-    public CompletableFuture<Participant> authenticate(Map<String, String> authenticationInfo) {
+    public Future<Participant> authenticate(Map<String, String> authenticationInfo) {
         // HTTP callers (AuthenticationHandler) lowercase all header names; STOMP preserves case.
         // Wrap in a case-insensitive view so both transports work with the same camelCase names.
         Map<String, String> authInfo = caseInsensitive(authenticationInfo);
@@ -65,17 +67,19 @@ public class KinoticSecurityService implements SecurityService {
         String applicationId = authInfo.get("applicationId");
 
         if (applicationId != null && organizationId == null) {
-            return CompletableFuture.failedFuture(new AuthenticationException(
+            return Future.failedFuture(new AuthenticationException(
                     "organizationId header is required when applicationId is supplied"));
         }
 
         String authHeader = authInfo.get("Authorization");
 
+        Future<Participant> ret;
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            return authenticateKinoticJwt(organizationId, applicationId, authHeader.substring(7));
+            ret = authenticateKinoticJwt(organizationId, applicationId, authHeader.substring(7));
         } else {
-            return authenticateEmailPassword(organizationId, applicationId, authInfo);
+            ret = authenticateEmailPassword(organizationId, applicationId, authInfo);
         }
+        return ret;
     }
 
     private static Map<String, String> caseInsensitive(Map<String, String> source) {
@@ -89,42 +93,47 @@ public class KinoticSecurityService implements SecurityService {
     /**
      * Authenticates a user via email and password within the target scope.
      */
-    private CompletableFuture<Participant> authenticateEmailPassword(String organizationId,
-                                                                     String applicationId,
-                                                                     Map<String, String> authInfo) {
+    private Future<Participant> authenticateEmailPassword(String organizationId,
+                                                          String applicationId,
+                                                          Map<String, String> authInfo) {
         String email = authInfo.get("clientId");
         String password = authInfo.get("clientSecret");
 
         if (email == null || password == null) {
-            return CompletableFuture.failedFuture(new AuthenticationException("clientId and clientSecret headers are required for credential authentication"));
+            return Future.failedFuture(new AuthenticationException("clientId and clientSecret headers are required for credential authentication"));
         }
 
-        return userService.findByEmail(email, organizationId, applicationId)
-                          .thenCompose(user -> {
-                              if (user == null) {
-                                  return CompletableFuture.failedFuture(new AuthenticationException("Invalid credentials"));
-                              }
-                              if (!user.isEnabled()) {
-                                  return CompletableFuture.failedFuture(new AuthenticationException("User account is disabled"));
-                              }
-                              if (user.getAuthType() != AuthType.LOCAL) {
-                                  return CompletableFuture.failedFuture(new AuthenticationException("User is not a local account"));
-                              }
-                              return credentialRepository.findById(user.getId())
-                                                      .thenCompose(credential -> verifyPasswordAndCreateParticipant(user, credential, password));
-                          });
+        return Future.fromCompletionStage(userService.findByEmail(email, organizationId, applicationId),
+                                          vertx.getOrCreateContext())
+                     .compose(user -> {
+                         Future<Participant> ret;
+                         if (user == null) {
+                             ret = Future.failedFuture(new AuthenticationException("Invalid credentials"));
+                         } else if (!user.isEnabled()) {
+                             ret = Future.failedFuture(new AuthenticationException("User account is disabled"));
+                         } else if (user.getAuthType() != AuthType.LOCAL) {
+                             ret = Future.failedFuture(new AuthenticationException("User is not a local account"));
+                         } else {
+                             ret = Future.fromCompletionStage(credentialRepository.findById(user.getId()),
+                                                              vertx.getOrCreateContext())
+                                         .compose(credential -> verifyPasswordAndCreateParticipant(user, credential, password));
+                         }
+                         return ret;
+                     });
     }
 
-    private CompletableFuture<Participant> verifyPasswordAndCreateParticipant(IamUser user,
-                                                                              IamCredential credential,
-                                                                              String password) {
+    private Future<Participant> verifyPasswordAndCreateParticipant(IamUser user,
+                                                                   IamCredential credential,
+                                                                   String password) {
+        Future<Participant> ret;
         if (credential == null) {
-            return CompletableFuture.failedFuture(new AuthenticationException("Invalid credentials"));
+            ret = Future.failedFuture(new AuthenticationException("Invalid credentials"));
+        } else if (!DomainUtil.verifyPassword(password, credential.getPasswordHash())) {
+            ret = Future.failedFuture(new AuthenticationException("Invalid credentials"));
+        } else {
+            ret = Future.succeededFuture(DomainUtil.createParticipant(user));
         }
-        if (!DomainUtil.verifyPassword(password, credential.getPasswordHash())) {
-            return CompletableFuture.failedFuture(new AuthenticationException("Invalid credentials"));
-        }
-        return CompletableFuture.completedFuture(DomainUtil.createParticipant(user));
+        return ret;
     }
 
     /**
@@ -134,42 +143,47 @@ public class KinoticSecurityService implements SecurityService {
      * {@code organizationId} / {@code applicationId} claims that match the auth headers
      * (defense in depth against a JWT for org A being replayed against org B).
      */
-    private CompletableFuture<Participant> authenticateKinoticJwt(String organizationId,
-                                                                  String applicationId,
-                                                                  String token) {
-        CompletableFuture<Participant> result = new CompletableFuture<>();
-        jwtIssuer.authenticate(token)
-                 .onSuccess(user -> {
-                     JsonObject p = user.principal();
-                     String sub = p.getString("sub");
-                     String jwtOrgId = p.getString("organizationId");
-                     String jwtAppId = p.getString("applicationId");
+    private Future<Participant> authenticateKinoticJwt(String organizationId,
+                                                       String applicationId,
+                                                       String token) {
+        return jwtIssuer.authenticate(token)
+                        .recover(err -> Future.failedFuture(
+                                new AuthenticationException("JWT validation failed: " + err.getMessage(), err)))
+                        .compose(user -> {
+                            JsonObject p = user.principal();
+                            String sub = p.getString("sub");
+                            String jwtOrgId = p.getString("organizationId");
+                            String jwtAppId = p.getString("applicationId");
 
-                     if (sub == null) {
-                         result.completeExceptionally(new AuthenticationException("JWT missing sub claim"));
-                         return;
-                     }
-                     if (!Objects.equals(organizationId, jwtOrgId) || !Objects.equals(applicationId, jwtAppId)) {
-                         result.completeExceptionally(new AuthenticationException(
-                                 "JWT scope " + describeScope(jwtOrgId, jwtAppId)
-                                         + " does not match auth headers " + describeScope(organizationId, applicationId)));
-                         return;
-                     }
-                     userService.findById(sub).whenComplete((iamUser, err) -> {
-                         if (err != null) {
-                             result.completeExceptionally(new AuthenticationException("User lookup failed", err));
-                         } else if (iamUser == null) {
-                             result.completeExceptionally(new AuthenticationException("No user for sub " + sub));
+                            Future<Participant> ret;
+                            if (sub == null) {
+                                ret = Future.failedFuture(new AuthenticationException("JWT missing sub claim"));
+                            } else if (!Objects.equals(organizationId, jwtOrgId)
+                                    || !Objects.equals(applicationId, jwtAppId)) {
+                                ret = Future.failedFuture(new AuthenticationException(
+                                        "JWT scope " + describeScope(jwtOrgId, jwtAppId)
+                                                + " does not match auth headers " + describeScope(organizationId, applicationId)));
+                            } else {
+                                ret = findEnabledUser(sub);
+                            }
+                            return ret;
+                        });
+    }
+
+    private Future<Participant> findEnabledUser(String sub) {
+        return Future.fromCompletionStage(userService.findById(sub), vertx.getOrCreateContext())
+                     .recover(err -> Future.failedFuture(new AuthenticationException("User lookup failed", err)))
+                     .compose(iamUser -> {
+                         Future<Participant> ret;
+                         if (iamUser == null) {
+                             ret = Future.failedFuture(new AuthenticationException("No user for sub " + sub));
                          } else if (!iamUser.isEnabled()) {
-                             result.completeExceptionally(new AuthenticationException("User account is disabled"));
+                             ret = Future.failedFuture(new AuthenticationException("User account is disabled"));
                          } else {
-                             result.complete(DomainUtil.createParticipant(iamUser));
+                             ret = Future.succeededFuture(DomainUtil.createParticipant(iamUser));
                          }
+                         return ret;
                      });
-                 })
-                 .onFailure(err -> result.completeExceptionally(
-                         new AuthenticationException("JWT validation failed: " + err.getMessage(), err)));
-        return result;
     }
 
     private static String describeScope(String organizationId, String applicationId) {

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/endpoints/graphql/GqlVerticle.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/endpoints/graphql/GqlVerticle.java
@@ -44,7 +44,7 @@ public class GqlVerticle extends VerticleBase {
         Router router = ApiGatewayUtil.createRouterWithCors(vertx, corsProperties);
 
         if(securityService !=null){
-            router.route().handler(new AuthenticationHandler(securityService, securityContext, vertx));
+            router.route().handler(new AuthenticationHandler(securityService, securityContext));
         }
 
         router.post(properties.getGraphqlPath() + ":" + ORGANIZATION_PATH_PARAMETER + "/:" + APPLICATION_PATH_PARAMETER)

--- a/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/endpoints/openapi/OpenApiVertxRouterFactory.java
+++ b/kinotic-persistence/src/main/java/org/kinotic/persistence/internal/endpoints/openapi/OpenApiVertxRouterFactory.java
@@ -133,7 +133,7 @@ public class OpenApiVertxRouterFactory {
               });
 
         if (securityService != null) {
-            router.route().handler(new AuthenticationHandler(securityService, securityContext, vertx));
+            router.route().handler(new AuthenticationHandler(securityService, securityContext));
         }
 
         addDeleteRoutes(router, bodyHandler, true);

--- a/kinotic-server/src/main/java/org/kinotic/server/clienttest/TestSecurityService.java
+++ b/kinotic-server/src/main/java/org/kinotic/server/clienttest/TestSecurityService.java
@@ -1,5 +1,6 @@
 package org.kinotic.server.clienttest;
 
+import io.vertx.core.Future;
 import org.kinotic.core.api.security.Participant;
 import org.kinotic.core.api.security.ParticipantConstants;
 import org.kinotic.core.api.security.SecurityService;
@@ -12,7 +13,6 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * {@link SecurityService} used only under the {@code clienttest} profile, where domain and
@@ -30,7 +30,7 @@ public class TestSecurityService implements SecurityService {
     private static final String CLI_PARTICIPANT_ID = "-42-Kinotic-CLI-42-";
 
     @Override
-    public CompletableFuture<Participant> authenticate(Map<String, String> authenticationInfo) {
+    public Future<Participant> authenticate(Map<String, String> authenticationInfo) {
         // STOMP preserves header case while HTTP callers lowercase; a case-insensitive view
         // lets both work with the same camelCase names.
         Map<String, String> authInfo = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -71,6 +71,6 @@ public class TestSecurityService implements SecurityService {
                                                        .roles(roles)
                                                        .build();
         }
-        return CompletableFuture.completedFuture(participant);
+        return Future.succeededFuture(participant);
     }
 }


### PR DESCRIPTION
Converts the `SecurityService` authentication API and all implementations from Java's `CompletableFuture` to Vert.x's `Future`, eliminating the need for manual context bridging in callers and enabling proper async composition within the Vert.x event loop.

## Summary

The `SecurityService.authenticate()` method signature changed from returning `CompletableFuture<Participant>` to `Future<Participant>`. This aligns authentication with Vert.x's async model and removes the impedance mismatch that required callers to wrap results with `Future.fromCompletionStage()`.

## Key Changes

**Core API (`kinotic-core`)**
- `SecurityService.authenticate()` now returns `Future<Participant>` instead of `CompletableFuture<Participant>`
- `AuthenticationHandler` no longer needs to wrap the result or inject `Vertx` for context bridging — it calls `securityService.authenticate()` directly and chains `.onComplete()`

**Implementation (`kinotic-domain`)**
- `KinoticSecurityService` refactored to use Vert.x `Future` throughout:
  - `authenticateEmailPassword()` and `authenticateKinoticJwt()` now return `Future<Participant>`
  - Converted `CompletableFuture.thenCompose()` chains to `Future.compose()` chains
  - Wrapped legacy `CompletableFuture` results from `userService` and `credentialRepository` with `Future.fromCompletionStage(vertx.getOrCreateContext())`
  - Extracted `findEnabledUser()` helper to reduce nesting in JWT authentication path
  - Added `Vertx` field to `KinoticSecurityService` for context access

**STOMP Endpoint (`kinotic-api-gateway`)**
- `EndpointConnectionHandler.handshake()` and `.connect()` now return `Future` instead of `CompletableFuture`
- Replaced `.handle()` with `.recover()` and `.map()` for cleaner error and success handling
- `DefaultStompServerHandler` no longer wraps results with `Future.fromCompletionStage()` — methods return `Future` directly
- Removed `Vertx` injection from `DefaultStompServerHandler` and `DefaultStompServerHandlerFactory`

**Test Implementation (`kinotic-server`)**
- `TestSecurityService` updated to return `Future<Participant>`

## Implementation Details

The refactoring maintains the same authentication logic while leveraging Vert.x's native async model. Where legacy services still return `CompletableFuture` (e.g., `IamUserService.findByEmail()`), results are bridged with `Future.fromCompletionStage(completableFuture, vertx.getOrCreateContext())` to ensure proper context propagation.

Error handling was simplified: instead of `CompletableFuture.failedFuture()` and manual exception handling, the code now uses `Future.failedFuture()` and `.recover()` for consistent error composition.

The single-return idiom (assigning to a `ret` variable and returning once) was applied throughout to maintain the codebase's control-flow convention.

https://claude.ai/code/session_01GU9sooEyLk42Ldb2hE5tYy