### PR TITLE
Load the vertx Jackson 3 codec reflectively to fix the develop build

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/internal/config/VertxJackson3JsonFactory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/config/VertxJackson3JsonFactory.java
@@ -1,6 +1,5 @@
 package org.kinotic.core.internal.config;
 
-import io.vertx.core.json.jackson.v3.DatabindCodec;
 import io.vertx.core.spi.JsonFactory;
 import io.vertx.core.spi.json.JsonCodec;
 
@@ -11,10 +10,23 @@ import io.vertx.core.spi.json.JsonCodec;
  */
 public class VertxJackson3JsonFactory implements JsonFactory {
 
-    private static final JsonCodec CODEC = new DatabindCodec();
+    private static final JsonCodec CODEC = createJackson3Codec();
 
     @Override
     public JsonCodec codec() {
         return CODEC;
+    }
+
+    // the codec class exists only in vertx-core's META-INF/versions/21 section, which source-processing
+    // tools (delombok, javadoc) cannot resolve; the runtime class loader handles multi-release jars
+    // normally, so it is loaded reflectively and a failure here fails the JsonFactory SPI load at boot
+    private static JsonCodec createJackson3Codec() {
+        try {
+            return (JsonCodec) Class.forName("io.vertx.core.json.jackson.v3.DatabindCodec")
+                                    .getDeclaredConstructor()
+                                    .newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("The vertx Jackson 3 codec could not be loaded", e);
+        }
     }
 }


### PR DESCRIPTION
Fixes the develop CI failure introduced by #328:

```
kinotic-core/src/main/java/org/kinotic/core/internal/config/VertxJackson3JsonFactory.java:3: error: package io.vertx.core.json.jackson.v3 does not exist
import io.vertx.core.json.jackson.v3.DatabindCodec;
```

`compileJava` actually passes — the error comes from the delombok/javadoc source pipeline (interleaved under the `:kinotic-domain:compileJava` header in the CI log). Those tools re-process sources with a javac front-end that cannot resolve classes existing only in a jar's `META-INF/versions/` section, and `v3.DatabindCodec` lives exclusively in vertx-core 5.1.4's `versions/21` directory. Local builds never ran javadoc, which is why this never failed before merge; `./gradlew :kinotic-core:javadoc` reproduces it.

The fix removes the compile-time reference and loads the codec by name — the runtime class loader handles multi-release jars normally:

```java
private static JsonCodec createJackson3Codec() {
    try {
        return (JsonCodec) Class.forName("io.vertx.core.json.jackson.v3.DatabindCodec")
                                .getDeclaredConstructor()
                                .newInstance();
    } catch (ReflectiveOperationException e) {
        throw new IllegalStateException("The vertx Jackson 3 codec could not be loaded", e);
    }
}
```

A missing class fails the `JsonFactory` SPI load at boot rather than silently falling back to Jackson 2.

## Verification

- `:kinotic-core:javadoc` clean (previously emitted the error)
- `:kinotic-core:test` green — the suites exercise the reflective load at runtime, since the SPI fires on first vertx JSON use

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw)_