### PR TITLE
Fix the MCP e2e readiness wait: expect.poll is not allowed in beforeAll

### DIFF
--- a/kinotic-js/e2e-tests/test/native/Mcp.test.ts
+++ b/kinotic-js/e2e-tests/test/native/Mcp.test.ts
@@ -46,8 +46,13 @@ describe('Kinotic JS', () => {
                                                     applicationId: APP_ID})
 
         // the directory publishes on server startup; wait for the listing to settle
-        await expect.poll(() => toolNames(systemClient), {timeout: 30000, interval: 1000})
-                    .toContain(FIND_PROJECTS_BY_REPO)
+        const deadline = Date.now() + 30000
+        while (!(await toolNames(systemClient)).includes(FIND_PROJECTS_BY_REPO)) {
+            if (Date.now() > deadline) {
+                throw new Error(`Timed out waiting for ${FIND_PROJECTS_BY_REPO} to appear in the tool listing`)
+            }
+            await new Promise(resolve => setTimeout(resolve, 1000))
+        }
     }, 120000)
 
     afterAll(async () => {


### PR DESCRIPTION
The MCP suite died in `beforeAll`:

```
FAIL  test/native/Mcp.test.ts > Kinotic JS
Error: expect.poll() must be called inside a test
```

vitest only allows `expect.poll` inside a test body, so the readiness wait is now a plain retry loop with the same 30s deadline:

```ts
// the directory publishes on server startup; wait for the listing to settle
const deadline = Date.now() + 30000
while (!(await toolNames(systemClient)).includes(FIND_PROJECTS_BY_REPO)) {
    if (Date.now() > deadline) {
        throw new Error(`Timed out waiting for ${FIND_PROJECTS_BY_REPO} to appear in the tool listing`)
    }
    await new Promise(resolve => setTimeout(resolve, 1000))
}
```

The failure fired after all three `connectMcpClient` calls, so the system/org/app participants had already completed the MCP `initialize` handshake against the real server — auth and the endpoint are working; this wait was the only blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw)_