### PR TITLE
Match enums by predicate so directory schema generation succeeds

### DIFF
--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/jdk/EnumTypeConverter.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/jdk/EnumTypeConverter.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang3.Validate;
 import org.kinotic.idl.api.schema.EnumC3Type;
 import org.kinotic.idl.api.schema.C3Type;
 import org.kinotic.idl.api.directory.ConversionContext;
-import org.kinotic.idl.api.directory.SpecificTypeConverter;
+import org.kinotic.idl.api.directory.GenericTypeConverter;
 import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
@@ -13,11 +13,14 @@ import org.springframework.util.Assert;
  * Created by Navíd Mitchell 🤪 on 4/13/23.
  */
 @Component
-public class EnumTypeConverter implements SpecificTypeConverter {
+public class EnumTypeConverter implements GenericTypeConverter {
 
     @Override
-    public Class<?>[] supports() {
-        return new Class<?>[] {Enum.class};
+    public boolean supports(ResolvableType resolvableType) {
+        // a predicate, not an exact-class match: a concrete enum's raw class is never java.lang.Enum,
+        // and this must claim enums before the PojoTypeConverter catch-all introspects them as beans
+        Class<?> rawClass = resolvableType.getRawClass();
+        return rawClass != null && rawClass.isEnum();
     }
 
     @Override

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
@@ -5,13 +5,16 @@ import org.junit.jupiter.api.Test;
 import org.kinotic.idl.api.directory.SchemaFactory;
 import org.kinotic.idl.api.schema.AsyncC3Type;
 import org.kinotic.idl.api.schema.C3Type;
+import org.kinotic.idl.api.schema.EnumC3Type;
 import org.kinotic.idl.api.schema.FunctionDefinition;
 import org.kinotic.idl.api.schema.NamespaceDefinition;
+import org.kinotic.idl.api.schema.ObjectC3Type;
 import org.kinotic.idl.api.schema.ServiceDefinition;
 import org.kinotic.idl.api.schema.StreamC3Type;
 import org.kinotic.idl.internal.support.BrokenTestService;
 import org.kinotic.idl.internal.support.OtherTestService;
 import org.kinotic.idl.internal.support.TestService;
+import org.kinotic.idl.internal.support.TestStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,8 +62,27 @@ public class TestSchemaFactory {
                                 findFunction(otherTestService, "findAddressAsync").getReturnType());
 
         // TestObject and TestAddress are referenced by BOTH services but converted in one session,
-        // so each appears exactly once in the namespace
+        // so each appears exactly once in the namespace; the enum property converts inline so it
+        // adds no complex type of its own
         Assertions.assertEquals(2, namespaceDefinition.getComplexC3Types().size());
+
+        // an enum property converts as an EnumC3Type with the constant names, not through the
+        // PojoTypeConverter catch-all (which would introspect Enum internals and fail on Class<E>)
+        ObjectC3Type testObject = (ObjectC3Type) namespaceDefinition.getComplexC3Types()
+                                                                    .stream()
+                                                                    .filter(type -> type.getName().equals("TestObject"))
+                                                                    .findFirst()
+                                                                    .orElseThrow();
+        C3Type statusType = testObject.getProperties()
+                                      .stream()
+                                      .filter(property -> property.getName().equals("status"))
+                                      .findFirst()
+                                      .orElseThrow()
+                                      .getType();
+        Assertions.assertEquals(new EnumC3Type().setNamespace(TestStatus.class.getPackageName())
+                                                .setName(TestStatus.class.getSimpleName())
+                                                .setValues(List.of("ACTIVE", "RETIRED")),
+                                statusType);
 
         String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(namespaceDefinition);
         log.info("Namespace Definition\n"+json);

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/DefaultTestService.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/DefaultTestService.java
@@ -23,7 +23,7 @@ public class DefaultTestService implements TestService{
 
     @Override
     public TestObject test() {
-        return new TestObject("Bob", 42, true);
+        return new TestObject("Bob", 42, true, TestStatus.ACTIVE);
     }
 
     @Override

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestObject.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestObject.java
@@ -19,5 +19,6 @@ public class TestObject {
     private String name;
     private int age;
     private boolean isCool;
+    private TestStatus status;
 
 }

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestStatus.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestStatus.java
@@ -1,0 +1,9 @@
+package org.kinotic.idl.internal.support;
+
+/**
+ * Created by Navíd Mitchell 🤪 on 7/26/26.
+ */
+public enum TestStatus {
+    ACTIVE,
+    RETIRED
+}


### PR DESCRIPTION
Fixes the MCP e2e timeout: `kinotic_service_directory` held 0 documents because schema generation failed at startup for every service whose signatures reach a user-defined enum — `@McpTool` on `ProjectService`/`ApplicationService` pointed the IDL converter at `Project`/`OidcConfiguration` (and their enum properties) for the first time.

```
ERROR o.k.i.i.directory.DefaultSchemaFactory : Failed to create ServiceDefinition for org.kinotic.os.api.services.ProjectService
java.lang.IllegalArgumentException: Unsupported Class no ResolvableTypeConverter can be found for java.lang.Class<?>
```

## Root cause

`EnumTypeConverter` was a `SpecificTypeConverter`, and those register by exact class name:

```java
// kinotic-idl/.../jdk/EnumTypeConverter.java — sole registry key: "java.lang.Enum"
public Class<?>[] supports() { return new Class<?>[] {Enum.class}; }
```

```java
// ResolvableTypeConverterComposite.selectConverter — exact match, no hierarchy walk
ret = specificConverters.get(rawClass.getName());   // "…model.ProjectType" != "java.lang.Enum"
```

No concrete enum's raw class is ever `java.lang.Enum`, so the converter was unreachable and enums fell through to the `PojoTypeConverter` catch-all. Bean introspection of an enum passes `Enum.getDeclaringClass()` through the `Object`-only method filter, emitting a `Class<E>` property that no converter supports — and `createForService` fails for the whole interface, so the service never publishes.

## Fix

"Is this an enum?" is a predicate, not an exact type, so the converter is now a `GenericTypeConverter`:

```java
@Override
public boolean supports(ResolvableType resolvableType) {
    // a predicate, not an exact-class match: a concrete enum's raw class is never java.lang.Enum,
    // and this must claim enums before the PojoTypeConverter catch-all introspects them as beans
    Class<?> rawClass = resolvableType.getRawClass();
    return rawClass != null && rawClass.isEnum();
}
```

As a `@Component` it is collected by `addConverters(autowiredConverters)`, which runs before the manually appended `PojoTypeConverter`, so enums are claimed ahead of the catch-all. `convert()` is unchanged — it already emits `EnumC3Type` with the constant names.

## Regression test

`TestObject` (referenced by the existing fixture services, including under async/stream wrappers — the exact production shape) now carries an enum property, and `TestSchemaFactory` asserts it converts inline:

```java
Assertions.assertEquals(new EnumC3Type().setNamespace(TestStatus.class.getPackageName())
                                        .setName(TestStatus.class.getSimpleName())
                                        .setValues(List.of("ACTIVE", "RETIRED")),
                        statusType);
```

Pre-fix this fails at the kinotic-idl unit level with the same `Unsupported Class` error — many layers closer to the cause than the e2e's tool-listing timeout.

## Verification

`:kinotic-idl:test`, `:kinotic-core:test`, `:kinotic-domain:test`, `:kinotic-api-gateway:test` all green; `:kinotic-os-api:compileJava` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw)_