### PR TITLE
Resolve inherited generic signatures during schema generation

### DIFF
--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
@@ -90,14 +90,15 @@ public class DefaultSchemaFactory implements SchemaFactory {
         serviceDefinition.setName(clazz.getSimpleName());
 
         ReflectionUtils.doWithMethods(clazz, method -> {
-            // TODO: make this work properly when an interface defines generics that the implementor will define in implementation, This would require an interface class and a target class above to work correctly
 
             FunctionDefinition functionDefinition = new FunctionDefinition();
-            functionDefinition.setReturnType(conversionContext.convert(ResolvableType.forMethodReturnType(method)));
+            // resolving against clazz binds type variables a generic parent declares, so an inherited
+            // CompletableFuture<T> save(T entity) converts with T bound instead of failing as ?
+            functionDefinition.setReturnType(conversionContext.convert(ResolvableType.forMethodReturnType(method, clazz)));
 
             for (int i = 0; i < method.getParameterCount(); i++) {
 
-                MethodParameter methodParameter = new MethodParameter(method, i);
+                MethodParameter methodParameter = new MethodParameter(method, i).withContainingClass(clazz);
 
                 C3Type c3Type = conversionContext.convert(ResolvableType.forMethodParameter(methodParameter));
 

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/PojoTypeConverter.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/PojoTypeConverter.java
@@ -10,6 +10,7 @@ import org.kinotic.idl.api.schema.ObjectC3Type;
 import groovy.lang.GroovyObject;
 import groovy.lang.MetaClass;
 import org.springframework.beans.BeanUtils;
+import org.springframework.core.MethodParameter;
 import org.springframework.core.ResolvableType;
 import org.springframework.util.Assert;
 
@@ -53,7 +54,11 @@ public class PojoTypeConverter implements GenericTypeConverter {
 
             if(!ignorePropertyDescriptor(descriptor)) {
 
-                ResolvableType returnTypeResolvableType = ResolvableType.forMethodReturnType(descriptor.getReadMethod());
+                // resolving against the owner type binds type variables the property declares,
+                // so List<T> getContent() on a Page<Project> converts with T bound to Project
+                ResolvableType returnTypeResolvableType =
+                        ResolvableType.forMethodParameter(new MethodParameter(descriptor.getReadMethod(), -1),
+                                                          resolvableType);
 
                 C3Type fieldC3Type = conversionContext.convert(returnTypeResolvableType);
 

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/ResolvableTypeConverterComposite.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/ResolvableTypeConverterComposite.java
@@ -67,7 +67,7 @@ public class ResolvableTypeConverterComposite implements GenericTypeConverter {
     @Override
     public boolean supports(ResolvableType resolvableType) {
         Validate.notNull(resolvableType, "ResolvableType cannot be null");
-        return selectConverter(resolvableType) != null;
+        return selectConverter(resolveIfNeeded(resolvableType)) != null;
     }
 
     @Override
@@ -75,9 +75,23 @@ public class ResolvableTypeConverterComposite implements GenericTypeConverter {
                           ConversionContext conversionContext) {
         Validate.notNull(resolvableType, "ResolvableType cannot be null");
 
-        ResolvableTypeConverter converter = selectConverter(resolvableType);
+        ResolvableType resolved = resolveIfNeeded(resolvableType);
+        ResolvableTypeConverter converter = selectConverter(resolved);
         Assert.notNull(converter, "Unsupported Class no ResolvableTypeConverter can be found for " + resolvableType);
-        return converter.convert(resolvableType, conversionContext);
+        return converter.convert(resolved, conversionContext);
+    }
+
+    // A type variable or wildcard carries no raw class of its own even when it resolves against an
+    // implementation type, so dispatch on the resolved class: converters see String, not ID
+    private static ResolvableType resolveIfNeeded(ResolvableType resolvableType) {
+        ResolvableType ret = resolvableType;
+        if (resolvableType.getRawClass() == null) {
+            Class<?> resolved = resolvableType.resolve();
+            if (resolved != null) {
+                ret = ResolvableType.forClass(resolved);
+            }
+        }
+        return ret;
     }
 
     private ResolvableTypeConverter selectConverter(ResolvableType resolvableType){

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
@@ -9,10 +9,14 @@ import org.kinotic.idl.api.schema.EnumC3Type;
 import org.kinotic.idl.api.schema.FunctionDefinition;
 import org.kinotic.idl.api.schema.NamespaceDefinition;
 import org.kinotic.idl.api.schema.ObjectC3Type;
+import org.kinotic.idl.api.schema.ReferenceC3Type;
 import org.kinotic.idl.api.schema.ServiceDefinition;
 import org.kinotic.idl.api.schema.StreamC3Type;
+import org.kinotic.idl.api.schema.StringC3Type;
 import org.kinotic.idl.internal.support.BrokenTestService;
 import org.kinotic.idl.internal.support.OtherTestService;
+import org.kinotic.idl.internal.support.TestObject;
+import org.kinotic.idl.internal.support.TestObjectCrudService;
 import org.kinotic.idl.internal.support.TestService;
 import org.kinotic.idl.internal.support.TestStatus;
 import org.slf4j.Logger;
@@ -86,6 +90,25 @@ public class TestSchemaFactory {
 
         String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(namespaceDefinition);
         log.info("Namespace Definition\n"+json);
+    }
+
+    @Test
+    public void testInheritedGenericSignaturesResolve() {
+        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(TestObjectCrudService.class));
+
+        ServiceDefinition crudService = findService(namespaceDefinition, TestObjectCrudService.class);
+        Assertions.assertEquals(2, crudService.getFunctions().size());
+
+        // T and ID bind against TestObjectCrudService, so the inherited signatures convert concretely
+        // instead of failing as unresolved type variables
+        C3Type testObjectReference = new ReferenceC3Type(TestObject.class.getName());
+        FunctionDefinition save = findFunction(crudService, "save");
+        Assertions.assertEquals(new AsyncC3Type(testObjectReference), save.getReturnType());
+        Assertions.assertEquals(testObjectReference, save.getParameters().getFirst().getType());
+
+        FunctionDefinition findById = findFunction(crudService, "findById");
+        Assertions.assertEquals(new AsyncC3Type(testObjectReference), findById.getReturnType());
+        Assertions.assertEquals(new StringC3Type(), findById.getParameters().getFirst().getType());
     }
 
     @Test

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/GenericCrudService.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/GenericCrudService.java
@@ -1,0 +1,14 @@
+package org.kinotic.idl.internal.support;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Created by Navíd Mitchell 🤪 on 7/26/26.
+ */
+public interface GenericCrudService<T, ID> {
+
+    CompletableFuture<T> save(T entity);
+
+    CompletableFuture<T> findById(ID id);
+
+}

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestObjectCrudService.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestObjectCrudService.java
@@ -1,0 +1,7 @@
+package org.kinotic.idl.internal.support;
+
+/**
+ * Created by Navíd Mitchell 🤪 on 7/26/26.
+ */
+public interface TestObjectCrudService extends GenericCrudService<TestObject, String> {
+}

--- a/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
@@ -1,0 +1,80 @@
+package org.kinotic.os.api.services;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.kinotic.idl.api.directory.ResolvableTypeConverter;
+import org.kinotic.idl.api.schema.NamespaceDefinition;
+import org.kinotic.idl.internal.directory.DefaultResolvableTypeConverter;
+import org.kinotic.idl.internal.directory.DefaultSchemaFactory;
+import org.kinotic.idl.internal.directory.ReactiveTypeConverter;
+import org.kinotic.idl.internal.directory.TokenBufferTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.ArrayTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.BooleanTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.ByteTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.CharacterTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.DateTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.DoubleTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.EnumTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.FloatTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.IntegerTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.IterableTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.LongTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.MapTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.OptionalTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.ShortTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.StringTypeConverter;
+import org.kinotic.idl.internal.directory.jdk.URITypeConverter;
+import org.kinotic.idl.internal.directory.jdk.VoidTypeConverter;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.ReactiveAdapterRegistry;
+
+import java.util.List;
+
+/**
+ * Verifies every MCP-exposed os-api service converts to a ServiceDefinition with the same converter set
+ * the server wires at startup — an unconvertible type anywhere in a signature silently drops the whole
+ * service from the directory, and with it every tool it provides.
+ */
+public class McpServiceSchemaTest {
+
+    @Test
+    public void mcpExposedServicesConvert() {
+        List<ResolvableTypeConverter> converters = List.of(new ArrayTypeConverter(),
+                                                           new BooleanTypeConverter(),
+                                                           new ByteTypeConverter(),
+                                                           new CharacterTypeConverter(),
+                                                           new DateTypeConverter(),
+                                                           new DoubleTypeConverter(),
+                                                           new EnumTypeConverter(),
+                                                           new FloatTypeConverter(),
+                                                           new IntegerTypeConverter(),
+                                                           new IterableTypeConverter(),
+                                                           new LongTypeConverter(),
+                                                           new MapTypeConverter(),
+                                                           new OptionalTypeConverter(),
+                                                           new ShortTypeConverter(),
+                                                           new StringTypeConverter(),
+                                                           new URITypeConverter(),
+                                                           new VoidTypeConverter(),
+                                                           new TokenBufferTypeConverter(),
+                                                           new ReactiveTypeConverter(sharedRegistryProvider()));
+        DefaultSchemaFactory schemaFactory = new DefaultSchemaFactory(new DefaultResolvableTypeConverter(converters));
+
+        NamespaceDefinition namespaceDefinition =
+                schemaFactory.createForServices(List.of(ProjectService.class, ApplicationService.class));
+
+        // createForServices omits any service that fails conversion, so a shrunken count is the failure signal
+        Assertions.assertEquals(2, namespaceDefinition.getServices().size());
+    }
+
+    // resolves to the shared ReactiveAdapterRegistry, as ReactiveTypeConverter falls back to outside a Spring context
+    private static ObjectProvider<ReactiveAdapterRegistry> sharedRegistryProvider() {
+        return new ObjectProvider<>() {
+            @Override
+            public ReactiveAdapterRegistry getIfAvailable() {
+                return null;
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
The enum fix (#333) was necessary but not sufficient — the MCP e2e still times out because the same conversion chain fails one step later. Reproduced locally by converting the real os-api interfaces with the exact converter set the server wires (new `McpServiceSchemaTest`):

```
ERROR o.k.i.i.directory.DefaultSchemaFactory -- Failed to create ServiceDefinition for org.kinotic.os.api.services.ProjectService
java.lang.IllegalArgumentException: Unsupported Class no ResolvableTypeConverter can be found for ?
	at org.kinotic.idl.internal.directory.ReactiveTypeConverter.convert(ReactiveTypeConverter.java:49)
```

## Root cause

`ProjectService`/`ApplicationService` inherit the generic CRUD methods (`CompletableFuture<T> save(T entity)`, `findById(ID id)`, `findAll(Pageable): CompletableFuture<Page<T>>`), and `createForService` converted them without binding the type variables — the old `TODO` in `DefaultSchemaFactory` called out exactly this. Three layers each needed the binding:

**1. `DefaultSchemaFactory` never gave Spring the implementation class**, so `T`/`ID` reached the converters unresolved:

```java
// before: ResolvableType.forMethodReturnType(method) — T resolves to ?
functionDefinition.setReturnType(conversionContext.convert(ResolvableType.forMethodReturnType(method, clazz)));
...
MethodParameter methodParameter = new MethodParameter(method, i).withContainingClass(clazz);
```

**2. A resolved type variable still has no raw class of its own**, and `ResolvableTypeConverterComposite` dispatches on `getRawClass()` — so even bound, `ID`→`String` failed with `Unsupported Class ... java.lang.String`. The composite now dispatches on the resolved class:

```java
// ResolvableTypeConverterComposite
private static ResolvableType resolveIfNeeded(ResolvableType resolvableType) {
    ResolvableType ret = resolvableType;
    if (resolvableType.getRawClass() == null) {
        Class<?> resolved = resolvableType.resolve();
        if (resolved != null) {
            ret = ResolvableType.forClass(resolved);
        }
    }
    return ret;
}
```

**3. `PojoTypeConverter` dropped the owner's generics when introspecting properties**, so `List<T> getContent()` inside `Page<Project>` hit the same wall:

```java
// binds T against the owner: List<T> getContent() on Page<Project> converts as List<Project>
ResolvableType returnTypeResolvableType =
        ResolvableType.forMethodParameter(new MethodParameter(descriptor.getReadMethod(), -1),
                                          resolvableType);
```

## Why #333's e2e run still failed

Both defects were always present; whichever method converted first produced the logged error. The docker repro surfaced the enum first, so #333 fixed that one — this one was waiting right behind it. (The e2e also pulls a published server image via `pull_policy: always`, so any run before an image containing both fixes will keep failing regardless.)

## Tests

- `kinotic-os-api/McpServiceSchemaTest` — converts the real `ProjectService` + `ApplicationService` with the same converter set the server wires at startup; this is the test that caught this defect and fails on either regression. Note: it hand-wires the converter list (mirrors `DefaultResolvableTypeConverter`), so a newly added converter component must be added there too.
- `kinotic-idl/TestSchemaFactory.testInheritedGenericSignaturesResolve` — new `GenericCrudService<T, ID>` / `TestObjectCrudService` fixtures assert `save`/`findById` convert with `T`→`TestObject`, `ID`→`String`.

## Known limitation (not new, now reachable)

`Page<Project>` and `Page<Application>` both convert to an `ObjectC3Type` named `org.kinotic.core.api.crud.Page` with different `content` types — `DefaultServiceDirectory.referenceResolver` keys by qualified name, so one silently wins. Harmless today (no `@McpTool` signature reaches `Page`), but generic complex types collide by name in the stored `serviceDefinition`; worth a follow-up decision on naming generic instantiations.

## Verification

`:kinotic-idl:test`, `:kinotic-core:test`, `:kinotic-domain:test`, `:kinotic-api-gateway:test`, `:kinotic-os-api:test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw)_