### PR TITLE
Retain parameter names so MCP tool schemas carry real names

### DIFF
--- a/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
@@ -33,6 +33,14 @@ tasks.withType(AbstractArchiveTask).configureEach {
     reproducibleFileOrder = true
 }
 
+// Retain method parameter names in class files: the IDL converter reads them for service schemas
+// and MCP tool input schemas (IdlUtil.parameterName). KinoticJacksonConfig pins Jackson's
+// ConstructorDetector to EXPLICIT_ONLY so the now-visible constructor names cannot change how
+// value types deserialize.
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs << '-parameters'
+}
+
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/config/KinoticJacksonConfig.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/config/KinoticJacksonConfig.java
@@ -4,13 +4,16 @@ import org.kinotic.core.api.crud.Page;
 import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.core.internal.serializer.PageSerializer;
 import org.kinotic.core.internal.serializer.PageableDeserializer;
+import org.kinotic.vertx.jackson3.VertxJackson3Module;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
+import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.ReactiveAdapterRegistry;
 import tools.jackson.core.Version;
+import tools.jackson.databind.cfg.ConstructorDetector;
 import tools.jackson.databind.module.SimpleModule;
 
 /**
@@ -20,6 +23,24 @@ import tools.jackson.databind.module.SimpleModule;
 @Configuration
 @Import(JacksonAutoConfiguration.class)
 public class KinoticJacksonConfig {
+
+    /**
+     * Boot folds every {@code JacksonModule} bean into its managed mapper, so this bean makes the Spring
+     * mapper handle the Vert.x types with their Vert.x wire format.
+     */
+    @Bean
+    public VertxJackson3Module vertxJackson3Module() {
+        return new VertxJackson3Module();
+    }
+
+    @Bean
+    public JsonMapperBuilderCustomizer kinoticJsonMapperCustomizer() {
+        // -parameters makes constructor parameter names visible to Jackson, which would otherwise promote
+        // plain constructors to implicit creators and change how value types deserialize. EXPLICIT_ONLY
+        // limits creator detection to @JsonCreator constructors, so the compiler flag cannot shift wire
+        // behavior.
+        return builder -> builder.constructorDetector(ConstructorDetector.EXPLICIT_ONLY);
+    }
 
     @Bean
     public SimpleModule kinoticCoreModule(){

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/config/KinoticVertxConfig.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/config/KinoticVertxConfig.java
@@ -14,7 +14,6 @@ import org.kinotic.core.api.event.Event;
 import org.kinotic.core.internal.api.event.EventMessageCodec;
 import org.kinotic.core.internal.KinoticIgniteClusterManager;
 import org.kinotic.vertx.jackson3.VertxJackson3Codec;
-import org.kinotic.vertx.jackson3.VertxJackson3Module;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -43,15 +42,6 @@ public class KinoticVertxConfig {
         System.setProperty("vertx.clustered","true");
 
         return new KinoticIgniteClusterManager(ignite);
-    }
-
-    /**
-     * Boot folds every {@code JacksonModule} bean into its managed {@link JsonMapper}, so this bean makes the
-     * Spring mapper handle the Vert.x types with their Vert.x wire format.
-     */
-    @Bean
-    public VertxJackson3Module vertxJackson3Module() {
-        return new VertxJackson3Module();
     }
 
     @Bean

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
@@ -105,10 +105,13 @@ public class TestSchemaFactory {
         FunctionDefinition save = findFunction(crudService, "save");
         Assertions.assertEquals(new AsyncC3Type(testObjectReference), save.getReturnType());
         Assertions.assertEquals(testObjectReference, save.getParameters().getFirst().getType());
+        // -parameters retains the source names, so the contract carries "entity", not arg0
+        Assertions.assertEquals("entity", save.getParameters().getFirst().getName());
 
         FunctionDefinition findById = findFunction(crudService, "findById");
         Assertions.assertEquals(new AsyncC3Type(testObjectReference), findById.getReturnType());
         Assertions.assertEquals(new StringC3Type(), findById.getParameters().getFirst().getType());
+        Assertions.assertEquals("id", findById.getParameters().getFirst().getName());
     }
 
     @Test

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -25,6 +25,8 @@ public interface OrderService {
 
 `description` is required — it is what the LLM reads to decide when to call the tool. The optional `title` is a human-readable display name surfaced in tool listings; it never affects the tool name. The three hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`) are served as MCP tool annotations.
 
+The input schema's property names are the function's Java parameter names (`orderId` above), retained in the class file at compile time. A single parameter can carry a different contract name with `@Name("...")`.
+
 A function with a streaming return type (`Flux`, `Publisher`) cannot be a tool — registration fails with an error naming the function. Single-value async returns (`CompletableFuture`, `Mono`) are fine.
 
 ## Tool naming


### PR DESCRIPTION
Implements option A from the parameter-name discussion: `-parameters` everywhere, with the Jackson behavior shift it used to cause pinned off.

## The flag

```groovy
// buildSrc/.../org.kinotic.java-common-conventions.gradle
tasks.withType(JavaCompile).configureEach {
    options.compilerArgs << '-parameters'
}
```

`IdlUtil.parameterName` already falls back to `methodParameter.getParameter().getName()`, so with names retained the MCP tool input schemas serve `repoFullName` instead of `arg0` with no `@Name` annotations anywhere (`@Name` stays as the per-parameter override).

## Why it no longer breaks Jackson

The breakage mechanism is creator detection: once constructor parameter names are visible, Jackson 3 promotes plain constructors to implicit creators, changing how value types (`@AllArgsConstructor` Lombok classes, single-arg constructors) deserialize. The pin closes it at the one mapper the whole platform now binds with:

```java
// KinoticJacksonConfig — the Boot mapper the codec also serves via VertxJackson3Codec.setMapper
@Bean
public JsonMapperBuilderCustomizer kinoticJsonMapperCustomizer() {
    return builder -> builder.constructorDetector(ConstructorDetector.EXPLICIT_ONLY);
}
```

Only `@JsonCreator` constructors participate in creation, so the compiler flag cannot shift wire behavior. The `vertxJackson3Module` bean also moved into `KinoticJacksonConfig` beside it — the pre-existing Jackson configuration home — out of `KinoticVertxConfig`.

## Assertions on the real names

- `TestSchemaFactory.testInheritedGenericSignaturesResolve` now asserts `save`'s parameter is named `entity` and `findById`'s is `id`.
- `Mcp.test.ts` returns from the interim `arg0` accommodations (854a3ed52) to the real contract: `repoFullName` in the schema assertion and all three `tools/call` argument objects.
- `07.mcp-tools.md` documents where schema property names come from and the `@Name` override.

## Verification

Every buildable suite green with the flag live: idl, core, domain, gateway, os-api, persistence, util, sql, migration, vertx-jackson3-codec, plus `:kinotic-test:compileTestJava`. The name assertions prove retention; the full suites prove `EXPLICIT_ONLY` holds deserialization behavior steady.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw)_