### PR TITLE
Correct the KinoticTestBase stack description

### DIFF
--- a/kinotic-test/src/test/java/org/kinotic/test/support/kinotic/KinoticTestBase.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/support/kinotic/KinoticTestBase.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 /**
- * Test base for tests that need the full Kinotic stack (Elasticsearch + kinotic-server)
+ * Test base for tests that need the Kinotic stack (Elasticsearch + kinotic-migration)
  * via Docker Compose (compose.kinotic-test.yml).
  * Uses Testcontainers Docker Compose support.
  */


### PR DESCRIPTION
One-line Javadoc correction. `KinoticTestBase` described its stack as "Elasticsearch + kinotic-server", but the compose file it names brings up Elasticsearch and kinotic-migration — kinotic-server only appears in the e2e stack.

```yaml
# deployment/docker-compose/compose.kinotic-test.yml
include:
  - compose.elasticsearch.yml
  - compose.kinotic-migration.yml
```

## Note on this PR's history

This branch previously carried the ghcr image-staging work plus temporary CI scaffolding, because it was cut from #338's head so diagnostic runs would use the staging workflow rather than publishing to Docker Hub from a feature branch. #338 has since merged as `e6fb313`, so the branch has been reset onto current `develop` and reduced to this single change. The earlier description of this PR described #338's contents and no longer applies.

The scaffolding it carried — a temporary branch trigger and a test-duration probe — was always marked for removal and is gone. The probe did its job: it measured the `kinotic_test` step as 207s wall clock against `summed in-test time: 70.0s over 14 classes / 92 cases`, showing roughly two thirds of that step is Gradle recompiling upstream modules plus Elasticsearch startup rather than test execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsQSZtghTK5fnfjzqbv3pd