### PR TITLE
Wait for every expected tool before asserting the directory listing

### DIFF
--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/McpToolDirectoryTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/McpToolDirectoryTests.java
@@ -50,7 +50,7 @@ public class McpToolDirectoryTests extends KinoticTestBase {
         }
 
         Assertions.assertTrue(names.containsAll(expected),
-                              "expected tools missing from the directory listing, got: " + names);
+                              "timed out waiting for " + expected + " in the directory listing, got: " + names);
     }
 
 }

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/McpToolDirectoryTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/McpToolDirectoryTests.java
@@ -31,26 +31,26 @@ public class McpToolDirectoryTests extends KinoticTestBase {
 
     @Test
     public void mcpExposedServicesArePublishedAndListed() throws Exception {
-        // the directory publishes on ApplicationReadyEvent and liveness flips entries online; poll until settled
+        // the directory publishes on ApplicationReadyEvent and liveness flips entries online one at a
+        // time, so the poll must wait for every expected tool before asserting anything
+        List<String> expected = List.of(FIND_PROJECTS_BY_REPO, GET_OIDC_CONFIGURATIONS);
         CursorPageable pageable = Pageable.create(null, 1000, Sort.by("id"));
         List<String> names = List.of();
         long deadline = System.currentTimeMillis() + 30_000;
-        while (System.currentTimeMillis() < deadline && !names.contains(FIND_PROJECTS_BY_REPO)) {
+        while (System.currentTimeMillis() < deadline && !names.containsAll(expected)) {
             names = serviceDirectory.findMcpToolsCallableBy(null, null, pageable)
                                     .await()
                                     .getTools()
                                     .stream()
                                     .map(McpToolDefinition::getName)
                                     .toList();
-            if (!names.contains(FIND_PROJECTS_BY_REPO)) {
+            if (!names.containsAll(expected)) {
                 Thread.sleep(1000);
             }
         }
 
-        Assertions.assertTrue(names.contains(FIND_PROJECTS_BY_REPO),
-                              "ProjectService tool missing from the directory listing, got: " + names);
-        Assertions.assertTrue(names.contains(GET_OIDC_CONFIGURATIONS),
-                              "ApplicationService tool missing from the directory listing, got: " + names);
+        Assertions.assertTrue(names.containsAll(expected),
+                              "expected tools missing from the directory listing, got: " + names);
     }
 
 }


### PR DESCRIPTION
Fixes the `McpToolDirectoryTests` race in the integration job. The failure itself is good news — the listing shows the pipeline fully working:

```
ApplicationService tool missing from the directory listing, got:
[os-api.org.kinotic.os.api.services.ProjectService.findByRepoFullName,
 os-api.org.kinotic.os.api.services.ProjectService.createProjectIfNotExist,
 os-api.org.kinotic.os.api.services.ProjectService.retryRepoInitialization]
```

The defect was in the test's poll: it exited as soon as the *ProjectService* tool appeared, then immediately asserted the *ApplicationService* tool — but entries flip online one at a time, so the second service can lag the first by a beat. (The JS e2e proves ApplicationService publishes fine: its `createApplicationIfNotExist` visibility assertion passes.)

```java
// the loop now waits for the full expected set within the same 30s deadline
List<String> expected = List.of(FIND_PROJECTS_BY_REPO, GET_OIDC_CONFIGURATIONS);
while (System.currentTimeMillis() < deadline && !names.containsAll(expected)) { ... }
```

A genuine publish failure still fails identically — the deadline expires and the assertion prints the full listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw)_