### PR TITLE
Resolve service schemas against the implementation and support type-level McpTool

### DIFF
--- a/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
@@ -145,6 +145,16 @@ dependencyManagement {
     }
 }
 
+// McpToolDocProcessor (shipped in kinotic-idl) extracts method Javadoc into jar resources that
+// DefaultSchemaFactory serves as MCP tool descriptions; kinotic-idl cannot be its own processor,
+// it wires the processor over its test fixtures in its own build.gradle
+if (project.name != 'kinotic-idl') {
+    dependencies {
+        annotationProcessor project(':kinotic-idl')
+        testAnnotationProcessor project(':kinotic-idl')
+    }
+}
+
 dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 

--- a/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
@@ -34,9 +34,9 @@ tasks.withType(AbstractArchiveTask).configureEach {
 }
 
 // Retain method parameter names in class files: the IDL converter reads them for service schemas
-// and MCP tool input schemas (IdlUtil.parameterName). KinoticJacksonConfig pins Jackson's
-// ConstructorDetector to EXPLICIT_ONLY so the now-visible constructor names cannot change how
-// value types deserialize.
+// and MCP tool input schemas (IdlUtil.parameterName). KinoticJacksonConfig disables Jackson's
+// DETECT_PARAMETER_NAMES so the now-visible constructor names cannot change how value types
+// deserialize.
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-parameters'
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/api/directory/ServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/directory/ServiceDirectory.java
@@ -86,12 +86,10 @@ public interface ServiceDirectory {
     /**
      * Notifies the directory that the calling node no longer provides the service. Other nodes may still provide
      * it, so how liveness is updated is the implementation's decision. Entries are never deleted; a
-     * known-but-offline service is a feature.
+     * known-but-offline service is a feature. An identifier this node never registered is ignored.
      * @param serviceIdentifier the identifier the service registered under
-     * @param serviceInterface the {@code @Publish} interface being unregistered
-     * @param serviceImplementation the class implementing the interface, an AOP proxy class is unwrapped
      */
-    void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation);
+    void unregister(ServiceIdentifier serviceIdentifier);
 
     /**
      * Verifies the cluster-wide registration state of the given service address and writes the verified liveness.

--- a/kinotic-core/src/main/java/org/kinotic/core/api/directory/ServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/directory/ServiceDirectory.java
@@ -68,8 +68,10 @@ public interface ServiceDirectory {
      * reported by the directory.
      * @param serviceIdentifier the identifier the service registered under
      * @param serviceInterface the {@code @Publish} interface being registered
+     * @param serviceImplementation the class implementing the interface; parameter names and annotations
+     *                              resolve against its methods, matching the runtime invocation
      */
-    void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface);
+    void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation);
 
     /**
      * Reports that a caller could not reach the service at the given CRI.
@@ -86,8 +88,9 @@ public interface ServiceDirectory {
      * known-but-offline service is a feature.
      * @param serviceIdentifier the identifier the service registered under
      * @param serviceInterface the {@code @Publish} interface being unregistered
+     * @param serviceImplementation the class implementing the interface
      */
-    void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface);
+    void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation);
 
     /**
      * Verifies the cluster-wide registration state of the given service address and writes the verified liveness.

--- a/kinotic-core/src/main/java/org/kinotic/core/api/directory/ServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/directory/ServiceDirectory.java
@@ -68,10 +68,11 @@ public interface ServiceDirectory {
      * reported by the directory.
      * @param serviceIdentifier the identifier the service registered under
      * @param serviceInterface the {@code @Publish} interface being registered
-     * @param instance the instance that responds to service invocations; parameter names and annotations
-     *                 resolve against its methods, matching the runtime invocation
+     * @param serviceImplementation the class implementing the interface, an AOP proxy class is unwrapped;
+     *                              parameter names and annotations resolve against its methods, matching
+     *                              the runtime invocation
      */
-    void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Object instance);
+    void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation);
 
     /**
      * Reports that a caller could not reach the service at the given CRI.
@@ -88,9 +89,9 @@ public interface ServiceDirectory {
      * known-but-offline service is a feature.
      * @param serviceIdentifier the identifier the service registered under
      * @param serviceInterface the {@code @Publish} interface being unregistered
-     * @param instance the instance that responded to service invocations
+     * @param serviceImplementation the class implementing the interface, an AOP proxy class is unwrapped
      */
-    void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Object instance);
+    void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation);
 
     /**
      * Verifies the cluster-wide registration state of the given service address and writes the verified liveness.

--- a/kinotic-core/src/main/java/org/kinotic/core/api/directory/ServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/directory/ServiceDirectory.java
@@ -68,10 +68,10 @@ public interface ServiceDirectory {
      * reported by the directory.
      * @param serviceIdentifier the identifier the service registered under
      * @param serviceInterface the {@code @Publish} interface being registered
-     * @param serviceImplementation the class implementing the interface; parameter names and annotations
-     *                              resolve against its methods, matching the runtime invocation
+     * @param instance the instance that responds to service invocations; parameter names and annotations
+     *                 resolve against its methods, matching the runtime invocation
      */
-    void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation);
+    void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Object instance);
 
     /**
      * Reports that a caller could not reach the service at the given CRI.
@@ -88,9 +88,9 @@ public interface ServiceDirectory {
      * known-but-offline service is a feature.
      * @param serviceIdentifier the identifier the service registered under
      * @param serviceInterface the {@code @Publish} interface being unregistered
-     * @param serviceImplementation the class implementing the interface
+     * @param instance the instance that responded to service invocations
      */
-    void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation);
+    void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Object instance);
 
     /**
      * Verifies the cluster-wide registration state of the given service address and writes the verified liveness.

--- a/kinotic-core/src/main/java/org/kinotic/core/api/service/ReflectiveServiceDescriptor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/service/ReflectiveServiceDescriptor.java
@@ -2,20 +2,16 @@
 
 package org.kinotic.core.api.service;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.ReflectionUtils;
+import org.kinotic.idl.api.utils.IdlUtil;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 /**
  * Created by Navíd Mitchell 🤪 on 9/2/21.
  */
 class ReflectiveServiceDescriptor implements ServiceDescriptor{
-
-    private static final Logger log = LoggerFactory.getLogger(ReflectiveServiceDescriptor.class);
 
     private final ServiceIdentifier serviceIdentifier;
     private final Collection<FunctionDescriptor> functionDescriptors;
@@ -29,24 +25,12 @@ class ReflectiveServiceDescriptor implements ServiceDescriptor{
     public ReflectiveServiceDescriptor(ServiceIdentifier serviceIdentifier, Class<?> serviceClass) {
         this.serviceIdentifier = serviceIdentifier;
 
-        // build list of service functions
-        Map<String, FunctionDescriptor> functionMap = new HashMap<>();
-        ReflectionUtils.doWithMethods(serviceClass, method -> {
-            String methodName = method.getName();
-            if(functionMap.containsKey(methodName)){
-                // in some cases such as with default methods we may actually get the same method multiple times check for that.
-                if(!functionMap.get(methodName).invocationMethod().equals(method)){
-                    log.warn("{} has overloaded method {} overloading is not supported. \n {} will be ignored",
-                             serviceClass.getName(),
-                             methodName,
-                             method.toGenericString());
-                }
-            }else{
-                functionMap.put(methodName,  FunctionDescriptor.create(methodName, method));
-            }
-        }, ReflectionUtils.USER_DECLARED_METHODS);
-
-        this.functionDescriptors = functionMap.values();
+        // IdlUtil.serviceFunctions is the same walk DefaultSchemaFactory converts, so the functions
+        // this descriptor registers are exactly the functions any published schema carries
+        List<FunctionDescriptor> functions = new ArrayList<>();
+        IdlUtil.serviceFunctions(serviceClass)
+               .forEach((name, method) -> functions.add(FunctionDescriptor.create(name, method)));
+        this.functionDescriptors = functions;
     }
 
     @Override

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
@@ -19,7 +19,6 @@ import org.springframework.beans.FatalBeanException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.DestructionAwareBeanPostProcessor;
 import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.util.ClassUtils;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -65,8 +64,7 @@ public class ServiceRegistrationBeanPostProcessor implements DestructionAwareBea
             ServiceDirectory serviceDirectory = serviceDirectoryProvider.getIfAvailable();
             if (serviceDirectory != null) {
                 try {
-                    // the user class, so an AOP proxy never becomes the naming source
-                    serviceDirectory.register(serviceIdentifier, clazz, ClassUtils.getUserClass(bean));
+                    serviceDirectory.register(serviceIdentifier, clazz, bean);
                 } catch (Exception e) {
                     log.error("Failed to register service {} in the ServiceDirectory", serviceIdentifier, e);
                 }
@@ -95,7 +93,7 @@ public class ServiceRegistrationBeanPostProcessor implements DestructionAwareBea
             ServiceDirectory serviceDirectory = serviceDirectoryProvider.getIfAvailable();
             if (serviceDirectory != null) {
                 try {
-                    serviceDirectory.unregister(serviceIdentifier, clazz, ClassUtils.getUserClass(bean));
+                    serviceDirectory.unregister(serviceIdentifier, clazz, bean);
                 } catch (Exception e) {
                     log.error("Failed to mark service {} offline in the ServiceDirectory", serviceIdentifier, e);
                 }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
@@ -93,7 +93,7 @@ public class ServiceRegistrationBeanPostProcessor implements DestructionAwareBea
             ServiceDirectory serviceDirectory = serviceDirectoryProvider.getIfAvailable();
             if (serviceDirectory != null) {
                 try {
-                    serviceDirectory.unregister(serviceIdentifier, clazz, bean.getClass());
+                    serviceDirectory.unregister(serviceIdentifier);
                 } catch (Exception e) {
                     log.error("Failed to mark service {} offline in the ServiceDirectory", serviceIdentifier, e);
                 }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
@@ -19,6 +19,7 @@ import org.springframework.beans.FatalBeanException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.DestructionAwareBeanPostProcessor;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.ClassUtils;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -64,7 +65,8 @@ public class ServiceRegistrationBeanPostProcessor implements DestructionAwareBea
             ServiceDirectory serviceDirectory = serviceDirectoryProvider.getIfAvailable();
             if (serviceDirectory != null) {
                 try {
-                    serviceDirectory.register(serviceIdentifier, clazz);
+                    // the user class, so an AOP proxy never becomes the naming source
+                    serviceDirectory.register(serviceIdentifier, clazz, ClassUtils.getUserClass(bean));
                 } catch (Exception e) {
                     log.error("Failed to register service {} in the ServiceDirectory", serviceIdentifier, e);
                 }
@@ -93,7 +95,7 @@ public class ServiceRegistrationBeanPostProcessor implements DestructionAwareBea
             ServiceDirectory serviceDirectory = serviceDirectoryProvider.getIfAvailable();
             if (serviceDirectory != null) {
                 try {
-                    serviceDirectory.unregister(serviceIdentifier, clazz);
+                    serviceDirectory.unregister(serviceIdentifier, clazz, ClassUtils.getUserClass(bean));
                 } catch (Exception e) {
                     log.error("Failed to mark service {} offline in the ServiceDirectory", serviceIdentifier, e);
                 }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
@@ -64,7 +64,7 @@ public class ServiceRegistrationBeanPostProcessor implements DestructionAwareBea
             ServiceDirectory serviceDirectory = serviceDirectoryProvider.getIfAvailable();
             if (serviceDirectory != null) {
                 try {
-                    serviceDirectory.register(serviceIdentifier, clazz, bean);
+                    serviceDirectory.register(serviceIdentifier, clazz, bean.getClass());
                 } catch (Exception e) {
                     log.error("Failed to register service {} in the ServiceDirectory", serviceIdentifier, e);
                 }
@@ -93,7 +93,7 @@ public class ServiceRegistrationBeanPostProcessor implements DestructionAwareBea
             ServiceDirectory serviceDirectory = serviceDirectoryProvider.getIfAvailable();
             if (serviceDirectory != null) {
                 try {
-                    serviceDirectory.unregister(serviceIdentifier, clazz, bean);
+                    serviceDirectory.unregister(serviceIdentifier, clazz, bean.getClass());
                 } catch (Exception e) {
                     log.error("Failed to mark service {} offline in the ServiceDirectory", serviceIdentifier, e);
                 }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -338,14 +338,17 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     }
 
     private boolean hasMcpToolFunction(DirectoryRegistration registration) {
-        boolean ret = false;
-        for (Method method : registration.contract().getMethods()) {
-            // findAnnotation on the most specific method honors @McpTool declared on the contract method
-            // or only on the implementation's override, matching DefaultSchemaFactory's discovery
-            Method specificMethod = ClassUtils.getMostSpecificMethod(method, registration.implementation());
-            if (AnnotationUtils.findAnnotation(specificMethod, McpTool.class) != null) {
-                ret = true;
-                break;
+        // a type-level @McpTool marks every function a tool, so the contract alone decides
+        boolean ret = AnnotationUtils.findAnnotation(registration.contract(), McpTool.class) != null;
+        if (!ret) {
+            for (Method method : registration.contract().getMethods()) {
+                // findAnnotation on the most specific method honors @McpTool declared on the contract method
+                // or only on the implementation's override, matching DefaultSchemaFactory's discovery
+                Method specificMethod = ClassUtils.getMostSpecificMethod(method, registration.implementation());
+                if (AnnotationUtils.findAnnotation(specificMethod, McpTool.class) != null) {
+                    ret = true;
+                    break;
+                }
             }
         }
         return ret;

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -185,7 +185,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     private Future<Void> publishAllToDirectory(Map<ServiceIdentifier, DirectoryRegistration> registrations) {
         Map<Class<?>, Class<?>> services = new HashMap<>();
         for (DirectoryRegistration registration : registrations.values()) {
-            services.put(registration.contract(), registration.implementation());
+            services.put(registration.serviceInterface(), registration.serviceImplementation());
         }
         NamespaceDefinition namespace = schemaFactory.createForServices(services);
         Map<String, ObjectC3Type> referenceResolver = referenceResolver(namespace.getComplexC3Types());
@@ -199,7 +199,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
             try {
                 // the definition's qualified name is package + '.' + simpleName per the SchemaFactory
                 // contract — never Class.getName(), which uses '$' for nested types
-                Class<?> serviceInterface = registration.getValue().contract();
+                Class<?> serviceInterface = registration.getValue().serviceInterface();
                 ServiceDefinition definition = definitionsByQualifiedName.get(
                         serviceInterface.getPackageName() + "." + serviceInterface.getSimpleName());
                 if (definition == null) {
@@ -339,7 +339,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     // Directory inclusion is opt-in via @Publish(advertise = true); an @McpTool function is already
     // explicit intent to expose the service, so it implies inclusion
     private boolean shouldPublishToDirectory(DirectoryRegistration registration) {
-        return isAdvertised(registration.contract()) || hasMcpToolFunction(registration);
+        return isAdvertised(registration.serviceInterface()) || hasMcpToolFunction(registration);
     }
 
     private boolean isAdvertised(Class<?> serviceInterface) {
@@ -349,12 +349,12 @@ public class DefaultServiceDirectory implements ServiceDirectory {
 
     private boolean hasMcpToolFunction(DirectoryRegistration registration) {
         // a type-level @McpTool marks every function a tool, so the contract alone decides
-        boolean ret = AnnotationUtils.findAnnotation(registration.contract(), McpTool.class) != null;
+        boolean ret = AnnotationUtils.findAnnotation(registration.serviceInterface(), McpTool.class) != null;
         if (!ret) {
-            for (Method method : IdlUtil.serviceFunctions(registration.contract()).values()) {
+            for (Method method : IdlUtil.serviceFunctions(registration.serviceInterface()).values()) {
                 // findAnnotation on the most specific method honors @McpTool declared on the contract method
                 // or only on the implementation's override, matching DefaultSchemaFactory's discovery
-                Method specificMethod = ClassUtils.getMostSpecificMethod(method, registration.implementation());
+                Method specificMethod = ClassUtils.getMostSpecificMethod(method, registration.serviceImplementation());
                 if (AnnotationUtils.findAnnotation(specificMethod, McpTool.class) != null) {
                     ret = true;
                     break;

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -80,6 +80,9 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     // Registrations arriving during startup are held here and published in ONE conversion session on
     // ApplicationReadyEvent, so model types shared between services are converted once per node
     private final Map<ServiceIdentifier, DirectoryRegistration> pendingRegistrations = new HashMap<>();
+    // Identifiers this node has published or queued, so unregister(ServiceIdentifier) knows whether
+    // liveness needs a refresh without the caller re-supplying the registration classes
+    private final Set<ServiceIdentifier> registered = new HashSet<>(); // guarded by registrationLock
     private final Object registrationLock = new Object();
     private boolean startupComplete; // guarded by registrationLock
 
@@ -115,6 +118,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
         }
         boolean queued;
         synchronized (registrationLock) {
+            registered.add(serviceIdentifier);
             queued = !startupComplete;
             if (queued) {
                 pendingRegistrations.put(serviceIdentifier, registration);
@@ -131,14 +135,18 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     }
 
     @Override
-    public void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation) {
-        if (!shouldPublishToDirectory(new DirectoryRegistration(serviceInterface, ClassUtils.getUserClass(serviceImplementation)))) {
-            return;
+    public void unregister(ServiceIdentifier serviceIdentifier) {
+        boolean published;
+        synchronized (registrationLock) {
+            // a registration still pending never reached the directory, removing it from the batch is enough
+            published = registered.remove(serviceIdentifier) && pendingRegistrations.remove(serviceIdentifier) == null;
         }
-        // this node leaving says nothing about other instances of the service — verify, never
-        // write offline blindly
-        refreshOnline(serviceIdentifier)
-                .onFailure(throwable -> log.error("Failed to refresh liveness for unregistered service {}", serviceIdentifier, throwable));
+        if (published) {
+            // this node leaving says nothing about other instances of the service — verify, never
+            // write offline blindly
+            refreshOnline(serviceIdentifier)
+                    .onFailure(throwable -> log.error("Failed to refresh liveness for unregistered service {}", serviceIdentifier, throwable));
+        }
     }
 
     private void drainStartupRegistrations() {

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -22,7 +22,7 @@ import org.kinotic.core.api.service.ServiceIdentifier;
 import org.kinotic.idl.api.annotations.McpTool;
 import org.kinotic.idl.api.converter.IdlConverterFactory;
 import org.kinotic.idl.api.converter.jsonschema.McpJsonSchemaGenerator;
-import org.kinotic.idl.api.directory.DirectoryRegistration;
+import org.kinotic.idl.api.directory.ServiceDeclaration;
 import org.kinotic.idl.api.directory.SchemaFactory;
 import org.kinotic.idl.api.utils.IdlUtil;
 import org.kinotic.idl.api.schema.AsyncC3Type;
@@ -80,7 +80,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
 
     // Registrations arriving during startup are held here and published in ONE conversion session on
     // ApplicationReadyEvent, so model types shared between services are converted once per node
-    private final Map<ServiceIdentifier, DirectoryRegistration> pendingRegistrations = new HashMap<>();
+    private final Map<ServiceIdentifier, ServiceDeclaration> pendingRegistrations = new HashMap<>();
     // Identifiers this node has published or queued, so unregister(ServiceIdentifier) knows whether
     // liveness needs a refresh without the caller re-supplying the registration classes
     private final Set<ServiceIdentifier> registered = new HashSet<>(); // guarded by registrationLock
@@ -113,7 +113,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     @Override
     public void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation) {
         // the user class, so an AOP proxy never becomes the naming source
-        DirectoryRegistration registration = new DirectoryRegistration(serviceInterface, ClassUtils.getUserClass(serviceImplementation));
+        ServiceDeclaration registration = new ServiceDeclaration(serviceInterface, ClassUtils.getUserClass(serviceImplementation));
         if (!shouldPublishToDirectory(registration)) {
             return;
         }
@@ -151,7 +151,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     }
 
     private void drainStartupRegistrations() {
-        Map<ServiceIdentifier, DirectoryRegistration> batch;
+        Map<ServiceIdentifier, ServiceDeclaration> batch;
         synchronized (registrationLock) {
             startupComplete = true;
             batch = new HashMap<>(pendingRegistrations);
@@ -183,7 +183,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
      * Converts and upserts entries for all given registrations in one conversion session, so model types shared
      * between services are converted once.
      */
-    private Future<Void> publishAllToDirectory(Map<ServiceIdentifier, DirectoryRegistration> registrations) {
+    private Future<Void> publishAllToDirectory(Map<ServiceIdentifier, ServiceDeclaration> registrations) {
         NamespaceDefinition namespace = schemaFactory.createForServices(registrations.values());
         Map<String, ObjectC3Type> referenceResolver = referenceResolver(namespace.getComplexC3Types());
         Map<String, ServiceDefinition> definitionsByQualifiedName = new HashMap<>();
@@ -192,7 +192,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
         }
 
         List<Future<Void>> writes = new ArrayList<>();
-        for (Map.Entry<ServiceIdentifier, DirectoryRegistration> registration : registrations.entrySet()) {
+        for (Map.Entry<ServiceIdentifier, ServiceDeclaration> registration : registrations.entrySet()) {
             try {
                 // the definition's qualified name is package + '.' + simpleName per the SchemaFactory
                 // contract — never Class.getName(), which uses '$' for nested types
@@ -335,7 +335,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
 
     // Directory inclusion is opt-in via @Publish(advertise = true); an @McpTool function is already
     // explicit intent to expose the service, so it implies inclusion
-    private boolean shouldPublishToDirectory(DirectoryRegistration registration) {
+    private boolean shouldPublishToDirectory(ServiceDeclaration registration) {
         return isAdvertised(registration.serviceInterface()) || hasMcpToolFunction(registration);
     }
 
@@ -344,7 +344,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
         return publish != null && publish.advertise();
     }
 
-    private boolean hasMcpToolFunction(DirectoryRegistration registration) {
+    private boolean hasMcpToolFunction(ServiceDeclaration registration) {
         // a type-level @McpTool marks every function a tool, so the contract alone decides
         boolean ret = AnnotationUtils.findAnnotation(registration.serviceInterface(), McpTool.class) != null;
         if (!ret) {

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -22,6 +22,7 @@ import org.kinotic.core.api.service.ServiceIdentifier;
 import org.kinotic.idl.api.annotations.McpTool;
 import org.kinotic.idl.api.converter.IdlConverterFactory;
 import org.kinotic.idl.api.converter.jsonschema.McpJsonSchemaGenerator;
+import org.kinotic.idl.api.directory.DirectoryRegistration;
 import org.kinotic.idl.api.directory.SchemaFactory;
 import org.kinotic.idl.api.utils.IdlUtil;
 import org.kinotic.idl.api.schema.AsyncC3Type;
@@ -183,11 +184,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
      * between services are converted once.
      */
     private Future<Void> publishAllToDirectory(Map<ServiceIdentifier, DirectoryRegistration> registrations) {
-        Map<Class<?>, Class<?>> services = new HashMap<>();
-        for (DirectoryRegistration registration : registrations.values()) {
-            services.put(registration.serviceInterface(), registration.serviceImplementation());
-        }
-        NamespaceDefinition namespace = schemaFactory.createForServices(services);
+        NamespaceDefinition namespace = schemaFactory.createForServices(registrations.values());
         Map<String, ObjectC3Type> referenceResolver = referenceResolver(namespace.getComplexC3Types());
         Map<String, ServiceDefinition> definitionsByQualifiedName = new HashMap<>();
         for (ServiceDefinition definition : namespace.getServices()) {

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -37,6 +37,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.ClassUtils;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
@@ -77,7 +78,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
 
     // Registrations arriving during startup are held here and published in ONE conversion session on
     // ApplicationReadyEvent, so model types shared between services are converted once per node
-    private final Map<ServiceIdentifier, Class<?>> pendingRegistrations = new HashMap<>();
+    private final Map<ServiceIdentifier, DirectoryRegistration> pendingRegistrations = new HashMap<>();
     private final Object registrationLock = new Object();
     private boolean startupComplete; // guarded by registrationLock
 
@@ -105,30 +106,31 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     }
 
     @Override
-    public void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface) {
-        if (!shouldPublishToDirectory(serviceInterface)) {
+    public void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation) {
+        DirectoryRegistration registration = new DirectoryRegistration(serviceInterface, serviceImplementation);
+        if (!shouldPublishToDirectory(registration)) {
             return;
         }
         boolean queued;
         synchronized (registrationLock) {
             queued = !startupComplete;
             if (queued) {
-                pendingRegistrations.put(serviceIdentifier, serviceInterface);
+                pendingRegistrations.put(serviceIdentifier, registration);
             }
         }
         if (!queued) {
             // a late registration (lazily created bean) cannot join a batch, publish it immediately.
             // The entry starts with online unset and its ACTIVE registration event may have fired before the
             // entry existed, so refresh from the verified cluster state after the upsert
-            publishAllToDirectory(Map.of(serviceIdentifier, serviceInterface))
+            publishAllToDirectory(Map.of(serviceIdentifier, registration))
                     .compose(v -> refreshOnline(serviceIdentifier))
                     .onFailure(throwable -> log.error("Failed to register service {} in the directory", serviceIdentifier, throwable));
         }
     }
 
     @Override
-    public void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface) {
-        if (!shouldPublishToDirectory(serviceInterface)) {
+    public void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation) {
+        if (!shouldPublishToDirectory(new DirectoryRegistration(serviceInterface, serviceImplementation))) {
             return;
         }
         // this node leaving says nothing about other instances of the service — verify, never
@@ -138,7 +140,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     }
 
     private void drainStartupRegistrations() {
-        Map<ServiceIdentifier, Class<?>> batch;
+        Map<ServiceIdentifier, DirectoryRegistration> batch;
         synchronized (registrationLock) {
             startupComplete = true;
             batch = new HashMap<>(pendingRegistrations);
@@ -170,8 +172,12 @@ public class DefaultServiceDirectory implements ServiceDirectory {
      * Converts and upserts entries for all given registrations in one conversion session, so model types shared
      * between services are converted once.
      */
-    private Future<Void> publishAllToDirectory(Map<ServiceIdentifier, Class<?>> registrations) {
-        NamespaceDefinition namespace = schemaFactory.createForServices(registrations.values());
+    private Future<Void> publishAllToDirectory(Map<ServiceIdentifier, DirectoryRegistration> registrations) {
+        Map<Class<?>, Class<?>> services = new HashMap<>();
+        for (DirectoryRegistration registration : registrations.values()) {
+            services.put(registration.contract(), registration.implementation());
+        }
+        NamespaceDefinition namespace = schemaFactory.createForServices(services);
         Map<String, ObjectC3Type> referenceResolver = referenceResolver(namespace.getComplexC3Types());
         Map<String, ServiceDefinition> definitionsByQualifiedName = new HashMap<>();
         for (ServiceDefinition definition : namespace.getServices()) {
@@ -179,11 +185,11 @@ public class DefaultServiceDirectory implements ServiceDirectory {
         }
 
         List<Future<Void>> writes = new ArrayList<>();
-        for (Map.Entry<ServiceIdentifier, Class<?>> registration : registrations.entrySet()) {
+        for (Map.Entry<ServiceIdentifier, DirectoryRegistration> registration : registrations.entrySet()) {
             try {
                 // the definition's qualified name is package + '.' + simpleName per the SchemaFactory
                 // contract — never Class.getName(), which uses '$' for nested types
-                Class<?> serviceInterface = registration.getValue();
+                Class<?> serviceInterface = registration.getValue().contract();
                 ServiceDefinition definition = definitionsByQualifiedName.get(
                         serviceInterface.getPackageName() + "." + serviceInterface.getSimpleName());
                 if (definition == null) {
@@ -322,8 +328,8 @@ public class DefaultServiceDirectory implements ServiceDirectory {
 
     // Directory inclusion is opt-in via @Publish(advertise = true); an @McpTool function is already
     // explicit intent to expose the service, so it implies inclusion
-    private boolean shouldPublishToDirectory(Class<?> serviceInterface) {
-        return isAdvertised(serviceInterface) || hasMcpToolFunction(serviceInterface);
+    private boolean shouldPublishToDirectory(DirectoryRegistration registration) {
+        return isAdvertised(registration.contract()) || hasMcpToolFunction(registration);
     }
 
     private boolean isAdvertised(Class<?> serviceInterface) {
@@ -331,10 +337,13 @@ public class DefaultServiceDirectory implements ServiceDirectory {
         return publish != null && publish.advertise();
     }
 
-    private boolean hasMcpToolFunction(Class<?> serviceInterface) {
+    private boolean hasMcpToolFunction(DirectoryRegistration registration) {
         boolean ret = false;
-        for (Method method : serviceInterface.getMethods()) {
-            if (method.isAnnotationPresent(McpTool.class)) {
+        for (Method method : registration.contract().getMethods()) {
+            // findAnnotation on the most specific method honors @McpTool declared on the contract method
+            // or only on the implementation's override, matching DefaultSchemaFactory's discovery
+            Method specificMethod = ClassUtils.getMostSpecificMethod(method, registration.implementation());
+            if (AnnotationUtils.findAnnotation(specificMethod, McpTool.class) != null) {
                 ret = true;
                 break;
             }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -23,6 +23,7 @@ import org.kinotic.idl.api.annotations.McpTool;
 import org.kinotic.idl.api.converter.IdlConverterFactory;
 import org.kinotic.idl.api.converter.jsonschema.McpJsonSchemaGenerator;
 import org.kinotic.idl.api.directory.SchemaFactory;
+import org.kinotic.idl.api.utils.IdlUtil;
 import org.kinotic.idl.api.schema.AsyncC3Type;
 import org.kinotic.idl.api.schema.C3Type;
 import org.kinotic.idl.api.schema.ComplexC3Type;
@@ -106,8 +107,9 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     }
 
     @Override
-    public void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation) {
-        DirectoryRegistration registration = new DirectoryRegistration(serviceInterface, serviceImplementation);
+    public void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Object instance) {
+        // the user class, so an AOP proxy never becomes the naming source
+        DirectoryRegistration registration = new DirectoryRegistration(serviceInterface, ClassUtils.getUserClass(instance));
         if (!shouldPublishToDirectory(registration)) {
             return;
         }
@@ -129,8 +131,8 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     }
 
     @Override
-    public void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation) {
-        if (!shouldPublishToDirectory(new DirectoryRegistration(serviceInterface, serviceImplementation))) {
+    public void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Object instance) {
+        if (!shouldPublishToDirectory(new DirectoryRegistration(serviceInterface, ClassUtils.getUserClass(instance)))) {
             return;
         }
         // this node leaving says nothing about other instances of the service — verify, never
@@ -341,7 +343,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
         // a type-level @McpTool marks every function a tool, so the contract alone decides
         boolean ret = AnnotationUtils.findAnnotation(registration.contract(), McpTool.class) != null;
         if (!ret) {
-            for (Method method : registration.contract().getMethods()) {
+            for (Method method : IdlUtil.serviceFunctions(registration.contract()).values()) {
                 // findAnnotation on the most specific method honors @McpTool declared on the contract method
                 // or only on the implementation's override, matching DefaultSchemaFactory's discovery
                 Method specificMethod = ClassUtils.getMostSpecificMethod(method, registration.implementation());

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -107,9 +107,9 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     }
 
     @Override
-    public void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Object instance) {
+    public void register(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation) {
         // the user class, so an AOP proxy never becomes the naming source
-        DirectoryRegistration registration = new DirectoryRegistration(serviceInterface, ClassUtils.getUserClass(instance));
+        DirectoryRegistration registration = new DirectoryRegistration(serviceInterface, ClassUtils.getUserClass(serviceImplementation));
         if (!shouldPublishToDirectory(registration)) {
             return;
         }
@@ -131,8 +131,8 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     }
 
     @Override
-    public void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Object instance) {
-        if (!shouldPublishToDirectory(new DirectoryRegistration(serviceInterface, ClassUtils.getUserClass(instance)))) {
+    public void unregister(ServiceIdentifier serviceIdentifier, Class<?> serviceInterface, Class<?> serviceImplementation) {
+        if (!shouldPublishToDirectory(new DirectoryRegistration(serviceInterface, ClassUtils.getUserClass(serviceImplementation)))) {
             return;
         }
         // this node leaving says nothing about other instances of the service — verify, never

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DirectoryRegistration.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DirectoryRegistration.java
@@ -1,0 +1,8 @@
+package org.kinotic.core.internal.api.directory;
+
+/**
+ * The class pair a service registers with: the {@code @Publish} contract deciding which functions exist, and
+ * the implementation whose most specific methods decide parameter names, generic bindings, and annotations.
+ */
+public record DirectoryRegistration(Class<?> contract, Class<?> implementation) {
+}

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DirectoryRegistration.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DirectoryRegistration.java
@@ -1,8 +1,8 @@
 package org.kinotic.core.internal.api.directory;
 
 /**
- * The class pair a service registers with: the {@code @Publish} contract deciding which functions exist, and
+ * The class pair a service registers with: the {@code @Publish} interface deciding which functions exist, and
  * the implementation whose most specific methods decide parameter names, generic bindings, and annotations.
  */
-public record DirectoryRegistration(Class<?> contract, Class<?> implementation) {
+public record DirectoryRegistration(Class<?> serviceInterface, Class<?> serviceImplementation) {
 }

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/SchemaFactoryTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/SchemaFactoryTests.java
@@ -3,7 +3,7 @@ package org.kinotic.core.internal.api;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.kinotic.core.internal.api.support.RpcTestService;
-import org.kinotic.idl.api.directory.DirectoryRegistration;
+import org.kinotic.idl.api.directory.ServiceDeclaration;
 import org.kinotic.idl.api.directory.SchemaFactory;
 import org.kinotic.idl.api.schema.AnyC3Type;
 import org.kinotic.idl.api.schema.ArrayC3Type;
@@ -50,7 +50,7 @@ public class SchemaFactoryTests {
     }
 
     private FunctionDefinition findFunction(String name) {
-        NamespaceDefinition namespace = schemaFactory.createForServices(List.of(new DirectoryRegistration(RpcTestService.class, RpcTestService.class)));
+        NamespaceDefinition namespace = schemaFactory.createForServices(List.of(new ServiceDeclaration(RpcTestService.class, RpcTestService.class)));
 
         // every type the RPC layer supports must convert, or the whole service is omitted
         ServiceDefinition service = namespace.getServices()

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/SchemaFactoryTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/SchemaFactoryTests.java
@@ -3,6 +3,7 @@ package org.kinotic.core.internal.api;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.kinotic.core.internal.api.support.RpcTestService;
+import org.kinotic.idl.api.directory.DirectoryRegistration;
 import org.kinotic.idl.api.directory.SchemaFactory;
 import org.kinotic.idl.api.schema.AnyC3Type;
 import org.kinotic.idl.api.schema.ArrayC3Type;
@@ -17,7 +18,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Verifies contract conversion against the full kinotic context, where adapters registered at runtime
@@ -50,7 +50,7 @@ public class SchemaFactoryTests {
     }
 
     private FunctionDefinition findFunction(String name) {
-        NamespaceDefinition namespace = schemaFactory.createForServices(Map.of(RpcTestService.class, RpcTestService.class));
+        NamespaceDefinition namespace = schemaFactory.createForServices(List.of(new DirectoryRegistration(RpcTestService.class, RpcTestService.class)));
 
         // every type the RPC layer supports must convert, or the whole service is omitted
         ServiceDefinition service = namespace.getServices()

--- a/kinotic-core/src/test/java/org/kinotic/core/internal/api/SchemaFactoryTests.java
+++ b/kinotic-core/src/test/java/org/kinotic/core/internal/api/SchemaFactoryTests.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Verifies contract conversion against the full kinotic context, where adapters registered at runtime
@@ -49,7 +50,7 @@ public class SchemaFactoryTests {
     }
 
     private FunctionDefinition findFunction(String name) {
-        NamespaceDefinition namespace = schemaFactory.createForServices(List.of(RpcTestService.class));
+        NamespaceDefinition namespace = schemaFactory.createForServices(Map.of(RpcTestService.class, RpcTestService.class));
 
         // every type the RPC layer supports must convert, or the whole service is omitted
         ServiceDefinition service = namespace.getServices()

--- a/kinotic-idl/build.gradle
+++ b/kinotic-idl/build.gradle
@@ -16,4 +16,8 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-json'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// McpToolDocProcessor lives in this module's main output; run it over the test fixtures so the
+	// Javadoc description resources exist for TestSchemaFactory
+	testAnnotationProcessor files(sourceSets.main.output)
 }

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/annotations/McpTool.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/annotations/McpTool.java
@@ -11,7 +11,8 @@ import java.lang.annotation.Target;
  * declared on the service interface or on the implementation's override — that method becomes a callable
  * tool whose {@link #description} and hints are surfaced to LLM callers. On the service interface itself,
  * every function becomes a tool carrying the type-level description and hints, and a method-level
- * {@code @McpTool} overrides them for that method.
+ * {@code @McpTool} overrides them for that method. An empty {@link #description} or {@link #title} is
+ * derived from the function name, so each tool stays individually recognizable to an LLM caller.
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
@@ -19,13 +20,16 @@ import java.lang.annotation.Target;
 public @interface McpTool {
 
     /**
-     * The LLM-facing description of what the tool does.
+     * The LLM-facing description of what the tool does. When empty, the function name is split into a
+     * sentence and used instead ({@code findByRepoFullName} becomes {@code "Find by repo full name"}).
      */
-    String description();
+    String description() default "";
 
     /**
-     * The human-readable display title for the tool. The tool name itself is always derived from the service's
-     * qualified name and the method name, so it is unique system wide.
+     * The human-readable display title for the tool. When empty, the function name is split into a
+     * capitalized phrase ({@code findByRepoFullName} becomes {@code "Find By Repo Full Name"}). The tool
+     * name itself is always derived from the service's qualified name and the method name, so it is
+     * unique system wide.
      */
     String title() default "";
 

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/annotations/McpTool.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/annotations/McpTool.java
@@ -7,11 +7,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a method on a published ({@code @Publish}) service interface as a Model Context Protocol tool.
- * A service is MCP-exposed when at least one of its methods carries this annotation, and each annotated method
- * becomes a callable tool whose {@link #description} and hints are surfaced to LLM callers.
+ * Marks a published ({@code @Publish}) service's functions as Model Context Protocol tools. On a method —
+ * declared on the service interface or on the implementation's override — that method becomes a callable
+ * tool whose {@link #description} and hints are surfaced to LLM callers. On the service interface itself,
+ * every function becomes a tool carrying the type-level description and hints, and a method-level
+ * {@code @McpTool} overrides them for that method.
  */
-@Target({ElementType.METHOD,})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface McpTool {

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/DirectoryRegistration.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/DirectoryRegistration.java
@@ -1,8 +1,9 @@
-package org.kinotic.core.internal.api.directory;
+package org.kinotic.idl.api.directory;
 
 /**
  * The class pair a service registers with: the {@code @Publish} interface deciding which functions exist, and
  * the implementation whose most specific methods decide parameter names, generic bindings, and annotations.
+ * Pass the interface itself as the implementation when no separate implementation exists.
  */
 public record DirectoryRegistration(Class<?> serviceInterface, Class<?> serviceImplementation) {
 }

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/DirectoryRegistration.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/DirectoryRegistration.java
@@ -1,9 +1,0 @@
-package org.kinotic.idl.api.directory;
-
-/**
- * The class pair a service registers with: the {@code @Publish} interface deciding which functions exist, and
- * the implementation whose most specific methods decide parameter names, generic bindings, and annotations.
- * Pass the interface itself as the implementation when no separate implementation exists.
- */
-public record DirectoryRegistration(Class<?> serviceInterface, Class<?> serviceImplementation) {
-}

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/SchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/SchemaFactory.java
@@ -6,7 +6,7 @@ import org.kinotic.idl.api.schema.C3Type;
 import org.kinotic.idl.api.schema.NamespaceDefinition;
 import org.kinotic.idl.api.schema.ServiceDefinition;
 
-import java.util.Collection;
+import java.util.Map;
 
 /**
  * Provides the ability to create {@link C3Type}'s
@@ -17,7 +17,7 @@ public interface SchemaFactory {
     /**
      * Creates a {@link C3Type} for the given {@link Class}
      * This method treats the class as a standard POJO or basic type.
-     * If you need to convert classes that are "services" use {@link SchemaFactory#createForServices(Collection)}
+     * If you need to convert classes that are "services" use {@link SchemaFactory#createForServices(Map)}
      *
      * @param clazz the class to create the schema for
      * @return the newly created {@link C3Type}
@@ -25,15 +25,18 @@ public interface SchemaFactory {
     C3Type createForClass(Class<?> clazz);
 
     /**
-     * Creates a {@link NamespaceDefinition} containing a {@link ServiceDefinition} for each given {@link Class},
-     * treating each class as a java "service". All services are converted in one session, so complex types shared
-     * between services are converted once and appear once in the returned namespace. A service that fails to
-     * convert is omitted from the result rather than failing the batch. Each definition's qualified name is the
-     * class's package name and simple name joined with {@code '.'}.
+     * Creates a {@link NamespaceDefinition} containing a {@link ServiceDefinition} for each given service. The
+     * contract decides which functions the definition carries, while each function's parameter names, generic
+     * bindings, and annotations resolve against the implementation's most specific method — the same method
+     * invoked at runtime. Pass the contract itself as the implementation when no separate implementation exists.
+     * All services are converted in one session, so complex types shared between services are converted once and
+     * appear once in the returned namespace. A service that fails to convert is omitted from the result rather
+     * than failing the batch. Each definition's qualified name is the contract's package name and simple name
+     * joined with {@code '.'}.
      *
-     * @param serviceInterfaces the classes to create service definitions for, duplicates ignored
+     * @param services the services to create definitions for, keyed contract to implementation
      * @return the newly created {@link NamespaceDefinition} with every converted service and every referenced complex type
      */
-    NamespaceDefinition createForServices(Collection<Class<?>> serviceInterfaces);
+    NamespaceDefinition createForServices(Map<Class<?>, Class<?>> services);
 
 }

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/SchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/SchemaFactory.java
@@ -6,7 +6,7 @@ import org.kinotic.idl.api.schema.C3Type;
 import org.kinotic.idl.api.schema.NamespaceDefinition;
 import org.kinotic.idl.api.schema.ServiceDefinition;
 
-import java.util.Map;
+import java.util.Collection;
 
 /**
  * Provides the ability to create {@link C3Type}'s
@@ -17,7 +17,7 @@ public interface SchemaFactory {
     /**
      * Creates a {@link C3Type} for the given {@link Class}
      * This method treats the class as a standard POJO or basic type.
-     * If you need to convert classes that are "services" use {@link SchemaFactory#createForServices(Map)}
+     * If you need to convert classes that are "services" use {@link SchemaFactory#createForServices(Collection)}
      *
      * @param clazz the class to create the schema for
      * @return the newly created {@link C3Type}
@@ -25,19 +25,19 @@ public interface SchemaFactory {
     C3Type createForClass(Class<?> clazz);
 
     /**
-     * Creates a {@link NamespaceDefinition} containing a {@link ServiceDefinition} for each given service. The
-     * contract decides which functions the definition carries — one function per method name, overloading is
-     * not supported — while each function's parameter names, generic
+     * Creates a {@link NamespaceDefinition} containing a {@link ServiceDefinition} for each given
+     * {@link DirectoryRegistration}. The interface decides which functions the definition carries — one function
+     * per method name, overloading is not supported — while each function's parameter names, generic
      * bindings, and annotations resolve against the implementation's most specific method — the same method
-     * invoked at runtime. Pass the contract itself as the implementation when no separate implementation exists.
+     * invoked at runtime.
      * All services are converted in one session, so complex types shared between services are converted once and
-     * appear once in the returned namespace. A service that fails to convert is omitted from the result rather
-     * than failing the batch. Each definition's qualified name is the contract's package name and simple name
-     * joined with {@code '.'}.
+     * appear once in the returned namespace. Equal registrations convert once, and a service that fails to
+     * convert is omitted from the result rather than failing the batch. Each definition's qualified name is the
+     * interface's package name and simple name joined with {@code '.'}.
      *
-     * @param services the services to create definitions for, keyed contract to implementation
+     * @param services the services to create definitions for
      * @return the newly created {@link NamespaceDefinition} with every converted service and every referenced complex type
      */
-    NamespaceDefinition createForServices(Map<Class<?>, Class<?>> services);
+    NamespaceDefinition createForServices(Collection<DirectoryRegistration> services);
 
 }

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/SchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/SchemaFactory.java
@@ -26,18 +26,18 @@ public interface SchemaFactory {
 
     /**
      * Creates a {@link NamespaceDefinition} containing a {@link ServiceDefinition} for each given
-     * {@link DirectoryRegistration}. The interface decides which functions the definition carries — one function
+     * {@link ServiceDeclaration}. The interface decides which functions the definition carries — one function
      * per method name, overloading is not supported — while each function's parameter names, generic
      * bindings, and annotations resolve against the implementation's most specific method — the same method
      * invoked at runtime.
      * All services are converted in one session, so complex types shared between services are converted once and
-     * appear once in the returned namespace. Equal registrations convert once, and a service that fails to
+     * appear once in the returned namespace. Equal declarations convert once, and a service that fails to
      * convert is omitted from the result rather than failing the batch. Each definition's qualified name is the
      * interface's package name and simple name joined with {@code '.'}.
      *
      * @param services the services to create definitions for
      * @return the newly created {@link NamespaceDefinition} with every converted service and every referenced complex type
      */
-    NamespaceDefinition createForServices(Collection<DirectoryRegistration> services);
+    NamespaceDefinition createForServices(Collection<ServiceDeclaration> services);
 
 }

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/SchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/SchemaFactory.java
@@ -26,7 +26,8 @@ public interface SchemaFactory {
 
     /**
      * Creates a {@link NamespaceDefinition} containing a {@link ServiceDefinition} for each given service. The
-     * contract decides which functions the definition carries, while each function's parameter names, generic
+     * contract decides which functions the definition carries — one function per method name, overloading is
+     * not supported — while each function's parameter names, generic
      * bindings, and annotations resolve against the implementation's most specific method — the same method
      * invoked at runtime. Pass the contract itself as the implementation when no separate implementation exists.
      * All services are converted in one session, so complex types shared between services are converted once and

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/ServiceDeclaration.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/directory/ServiceDeclaration.java
@@ -1,0 +1,10 @@
+package org.kinotic.idl.api.directory;
+
+/**
+ * The class pair a {@code ServiceDefinition} is created from: the {@code @Publish} interface deciding which
+ * functions exist, and the implementation whose most specific methods decide parameter names, generic
+ * bindings, and annotations. Pass the interface itself as the implementation when no separate
+ * implementation exists.
+ */
+public record ServiceDeclaration(Class<?> serviceInterface, Class<?> serviceImplementation) {
+}

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/utils/IdlUtil.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/utils/IdlUtil.java
@@ -1,14 +1,45 @@
 package org.kinotic.idl.api.utils;
 
+import lombok.extern.slf4j.Slf4j;
 import org.kinotic.idl.api.annotations.Name;
 import org.springframework.core.MethodParameter;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Static helpers shared across IDL conversion and its consumers.
  */
+@Slf4j
 public final class IdlUtil {
 
     private IdlUtil() {
+    }
+
+    /**
+     * Resolves the functions a service contract declares: every user-declared method keyed by function name.
+     * Overloading is not supported; when a name is declared more than once only one method is kept. Schema
+     * generation and service registration must both use this rule, so a published schema never carries a
+     * function the registry does not serve.
+     *
+     * @param serviceClass the service contract to introspect
+     * @return the contract's functions keyed by name
+     */
+    public static Map<String, Method> serviceFunctions(Class<?> serviceClass) {
+        Map<String, Method> ret = new LinkedHashMap<>();
+        ReflectionUtils.doWithMethods(serviceClass, method -> {
+            Method existing = ret.putIfAbsent(method.getName(), method);
+            // a default method can be visited twice; only a genuinely different signature is an overload
+            if (existing != null && !existing.equals(method)) {
+                log.warn("{} has overloaded method {} overloading is not supported. \n {} will be ignored",
+                         serviceClass.getName(),
+                         method.getName(),
+                         method.toGenericString());
+            }
+        }, ReflectionUtils.USER_DECLARED_METHODS);
+        return ret;
     }
 
     /**

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
@@ -23,10 +23,21 @@ import org.springframework.util.ClassUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-
-import java.lang.reflect.Method;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Provides the ability to create {@link C3Type}'s
@@ -39,6 +50,8 @@ import java.lang.reflect.Method;
 public class DefaultSchemaFactory implements SchemaFactory {
 
     private final GenericTypeConverter typeConverter;
+    // extracted Javadoc resources by type; a type without a resource caches an empty map
+    private final Map<Class<?>, Map<String, String>> javadocCache = new ConcurrentHashMap<>();
 
     public DefaultSchemaFactory(GenericTypeConverter typeConverter) {
         this.typeConverter = typeConverter;
@@ -133,10 +146,10 @@ public class DefaultSchemaFactory implements SchemaFactory {
             }
             if(mcpTool != null){
                 // an LLM caller decides which tool to invoke by its description, so an empty description
-                // or title falls back to one derived from the function name rather than staying blank
+                // falls back to the compile-time extracted Javadoc, then to the function name
                 functionDefinition.setDecorators(List.of(new McpToolC3Decorator()
                         .setTitle(mcpTool.title().isEmpty() ? deriveTitle(function.getKey()) : mcpTool.title())
-                        .setDescription(mcpTool.description().isEmpty() ? deriveDescription(function.getKey()) : mcpTool.description())
+                        .setDescription(resolveDescription(mcpTool, function.getValue(), specificMethod, function.getKey()))
                         .setReadOnlyHint(mcpTool.readOnlyHint())
                         .setDestructiveHint(mcpTool.destructiveHint())
                         .setIdempotentHint(mcpTool.idempotentHint())));
@@ -146,6 +159,61 @@ public class DefaultSchemaFactory implements SchemaFactory {
         }
 
         return serviceDefinition;
+    }
+
+    private String resolveDescription(McpTool mcpTool, Method contractMethod, Method specificMethod, String functionName) {
+        String ret = mcpTool.description();
+        if (ret.isEmpty()) {
+            ret = javadocDescription(specificMethod, contractMethod);
+        }
+        if (ret == null || ret.isEmpty()) {
+            ret = deriveDescription(functionName);
+        }
+        return ret;
+    }
+
+    /**
+     * Looks up the compile-time extracted Javadoc description for a function, walking the most specific
+     * declaration first: the implementation's override, the contract's declaration, then the contract's
+     * ancestors — so an inherited CRUD function finds the doc written on the generic base.
+     */
+    private String javadocDescription(Method specificMethod, Method contractMethod) {
+        String ret = null;
+        String functionName = contractMethod.getName();
+        Deque<Class<?>> queue = new ArrayDeque<>(List.of(specificMethod.getDeclaringClass(),
+                                                         contractMethod.getDeclaringClass()));
+        Set<Class<?>> visited = new HashSet<>();
+        while (ret == null && !queue.isEmpty()) {
+            Class<?> type = queue.poll();
+            if (visited.add(type)) {
+                ret = javadocFor(type).get(functionName);
+                if (type.getSuperclass() != null && type.getSuperclass() != Object.class) {
+                    queue.add(type.getSuperclass());
+                }
+                queue.addAll(Arrays.asList(type.getInterfaces()));
+            }
+        }
+        return ret;
+    }
+
+    private Map<String, String> javadocFor(Class<?> type) {
+        return javadocCache.computeIfAbsent(type, clazz -> {
+            Map<String, String> ret = Map.of();
+            try (InputStream in = clazz.getResourceAsStream(
+                    "/" + McpToolDocProcessor.DOCS_RESOURCE_DIRECTORY + clazz.getName() + ".properties")) {
+                if (in != null) {
+                    Properties properties = new Properties();
+                    // load(Reader), the InputStream overload assumes ISO-8859-1 and mangles UTF-8 docs
+                    properties.load(new InputStreamReader(in, StandardCharsets.UTF_8));
+                    Map<String, String> docs = new HashMap<>();
+                    properties.forEach((key, value) -> docs.put((String) key, (String) value));
+                    ret = docs;
+                }
+            } catch (IOException e) {
+                log.warn("Failed to read the Javadoc description resource for {}", clazz.getName(), e);
+            }
+            return ret;
+        });
     }
 
     // createApplicationIfNotExist -> "Create Application If Not Exist"

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
@@ -14,15 +14,19 @@ import org.kinotic.idl.api.schema.FunctionDefinition;
 import org.kinotic.idl.api.schema.NamespaceDefinition;
 import org.kinotic.idl.api.schema.ServiceDefinition;
 import org.kinotic.idl.api.schema.decorators.McpToolC3Decorator;
+import org.springframework.core.BridgeMethodResolver;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ResolvableType;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.ClassUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 
-import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+
+import java.lang.reflect.Method;
 
 /**
  * Provides the ability to create {@link C3Type}'s
@@ -63,42 +67,50 @@ public class DefaultSchemaFactory implements SchemaFactory {
     }
 
     @Override
-    public NamespaceDefinition createForServices(Collection<Class<?>> serviceInterfaces) {
-        Assert.notNull(serviceInterfaces, "serviceInterfaces cannot be null");
+    public NamespaceDefinition createForServices(Map<Class<?>, Class<?>> services) {
+        Assert.notNull(services, "services cannot be null");
         // one conversion context for the whole batch, so complex types shared between services convert once
         DefaultConversionContext conversionContext = new DefaultConversionContext(typeConverter, true);
 
         NamespaceDefinition ret = new NamespaceDefinition();
-        for (Class<?> clazz : new LinkedHashSet<>(serviceInterfaces)) {
+        for (Map.Entry<Class<?>, Class<?>> service : services.entrySet()) {
             // a service with an unconvertible type is omitted so the rest of the batch still converts;
             // ObjectC3Types are cached only after converting completely, so a failure leaves no partial types
             try {
-                ret.addServiceDefinition(createForService(clazz, conversionContext));
+                ret.addServiceDefinition(createForService(service.getKey(), service.getValue(), conversionContext));
             } catch (Exception e) {
-                log.error("Failed to create ServiceDefinition for {}", clazz.getName(), e);
+                log.error("Failed to create ServiceDefinition for {}", service.getKey().getName(), e);
             }
         }
         ret.setComplexC3Types(conversionContext.getComplexC3Types());
         return ret;
     }
 
-    private ServiceDefinition createForService(Class<?> clazz, ConversionContext conversionContext) {
-        Assert.notNull(clazz, "Class cannot be null");
+    private ServiceDefinition createForService(Class<?> contract,
+                                               Class<?> implementation,
+                                               ConversionContext conversionContext) {
+        Assert.notNull(contract, "contract cannot be null");
+        Assert.notNull(implementation, "implementation cannot be null");
 
         ServiceDefinition serviceDefinition = new ServiceDefinition();
-        serviceDefinition.setNamespace(clazz.getPackage().getName());
-        serviceDefinition.setName(clazz.getSimpleName());
+        serviceDefinition.setNamespace(contract.getPackage().getName());
+        serviceDefinition.setName(contract.getSimpleName());
 
-        ReflectionUtils.doWithMethods(clazz, method -> {
+        ReflectionUtils.doWithMethods(contract, method -> {
+
+            // the contract decides WHICH functions exist; the implementation's override decides parameter
+            // names, generic bindings, and annotations — the same method the invocation-side named-argument
+            // binding resolves, so the published schema and the runtime binding cannot drift
+            Method specificMethod = BridgeMethodResolver.findBridgedMethod(
+                    ClassUtils.getMostSpecificMethod(method, implementation));
 
             FunctionDefinition functionDefinition = new FunctionDefinition();
-            // resolving against clazz binds type variables a generic parent declares, so an inherited
-            // CompletableFuture<T> save(T entity) converts with T bound instead of failing as ?
-            functionDefinition.setReturnType(conversionContext.convert(ResolvableType.forMethodReturnType(method, clazz)));
+            functionDefinition.setReturnType(conversionContext.convert(
+                    ResolvableType.forMethodReturnType(specificMethod, implementation)));
 
-            for (int i = 0; i < method.getParameterCount(); i++) {
+            for (int i = 0; i < specificMethod.getParameterCount(); i++) {
 
-                MethodParameter methodParameter = new MethodParameter(method, i).withContainingClass(clazz);
+                MethodParameter methodParameter = new MethodParameter(specificMethod, i).withContainingClass(implementation);
 
                 C3Type c3Type = conversionContext.convert(ResolvableType.forMethodParameter(methodParameter));
 
@@ -107,7 +119,9 @@ public class DefaultSchemaFactory implements SchemaFactory {
 
             functionDefinition.setName(method.getName());
 
-            McpTool mcpTool = method.getAnnotation(McpTool.class);
+            // findAnnotation walks super methods, so @McpTool applies whether declared on the contract
+            // method or only on the implementation's override (e.g. an inherited CRUD method)
+            McpTool mcpTool = AnnotationUtils.findAnnotation(specificMethod, McpTool.class);
             if(mcpTool != null){
                 functionDefinition.setDecorators(List.of(new McpToolC3Decorator()
                         .setTitle(mcpTool.title().isEmpty() ? null : mcpTool.title())

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
@@ -6,6 +6,7 @@ import org.kinotic.idl.api.directory.ConversionContext;
 import org.kinotic.idl.api.directory.GenericTypeConverter;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.kinotic.idl.api.annotations.McpTool;
 import org.kinotic.idl.api.directory.SchemaFactory;
 import org.kinotic.idl.api.utils.IdlUtil;
@@ -131,9 +132,11 @@ public class DefaultSchemaFactory implements SchemaFactory {
                 mcpTool = typeLevelMcpTool;
             }
             if(mcpTool != null){
+                // an LLM caller decides which tool to invoke by its description, so an empty description
+                // or title falls back to one derived from the function name rather than staying blank
                 functionDefinition.setDecorators(List.of(new McpToolC3Decorator()
-                        .setTitle(mcpTool.title().isEmpty() ? null : mcpTool.title())
-                        .setDescription(mcpTool.description())
+                        .setTitle(mcpTool.title().isEmpty() ? deriveTitle(function.getKey()) : mcpTool.title())
+                        .setDescription(mcpTool.description().isEmpty() ? deriveDescription(function.getKey()) : mcpTool.description())
                         .setReadOnlyHint(mcpTool.readOnlyHint())
                         .setDestructiveHint(mcpTool.destructiveHint())
                         .setIdempotentHint(mcpTool.idempotentHint())));
@@ -143,6 +146,33 @@ public class DefaultSchemaFactory implements SchemaFactory {
         }
 
         return serviceDefinition;
+    }
+
+    // createApplicationIfNotExist -> "Create Application If Not Exist"
+    private static String deriveTitle(String functionName) {
+        StringBuilder ret = new StringBuilder();
+        for (String word : StringUtils.splitByCharacterTypeCamelCase(functionName)) {
+            if (!ret.isEmpty()) {
+                ret.append(' ');
+            }
+            ret.append(StringUtils.capitalize(word));
+        }
+        return ret.toString();
+    }
+
+    // createApplicationIfNotExist -> "Create application if not exist"
+    private static String deriveDescription(String functionName) {
+        StringBuilder ret = new StringBuilder();
+        for (String word : StringUtils.splitByCharacterTypeCamelCase(functionName)) {
+            if (ret.isEmpty()) {
+                ret.append(StringUtils.capitalize(word));
+            } else {
+                ret.append(' ');
+                // an all-caps word is an acronym (CRI, OIDC) and keeps its case
+                ret.append(StringUtils.isAllUpperCase(word) ? word : StringUtils.uncapitalize(word));
+            }
+        }
+        return ret.toString();
     }
 
 }

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
@@ -96,6 +96,9 @@ public class DefaultSchemaFactory implements SchemaFactory {
         serviceDefinition.setNamespace(contract.getPackage().getName());
         serviceDefinition.setName(contract.getSimpleName());
 
+        // a type-level @McpTool marks every function a tool with these defaults
+        McpTool typeLevelMcpTool = AnnotationUtils.findAnnotation(contract, McpTool.class);
+
         ReflectionUtils.doWithMethods(contract, method -> {
 
             // the contract decides WHICH functions exist; the implementation's override decides parameter
@@ -120,8 +123,12 @@ public class DefaultSchemaFactory implements SchemaFactory {
             functionDefinition.setName(method.getName());
 
             // findAnnotation walks super methods, so @McpTool applies whether declared on the contract
-            // method or only on the implementation's override (e.g. an inherited CRUD method)
+            // method or only on the implementation's override (e.g. an inherited CRUD method); a
+            // method-level annotation overrides the type-level defaults for that method
             McpTool mcpTool = AnnotationUtils.findAnnotation(specificMethod, McpTool.class);
+            if (mcpTool == null) {
+                mcpTool = typeLevelMcpTool;
+            }
             if(mcpTool != null){
                 functionDefinition.setDecorators(List.of(new McpToolC3Decorator()
                         .setTitle(mcpTool.title().isEmpty() ? null : mcpTool.title())

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
@@ -3,7 +3,7 @@
 package org.kinotic.idl.internal.directory;
 
 import org.kinotic.idl.api.directory.ConversionContext;
-import org.kinotic.idl.api.directory.DirectoryRegistration;
+import org.kinotic.idl.api.directory.ServiceDeclaration;
 import org.kinotic.idl.api.directory.GenericTypeConverter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -83,22 +83,22 @@ public class DefaultSchemaFactory implements SchemaFactory {
     }
 
     @Override
-    public NamespaceDefinition createForServices(Collection<DirectoryRegistration> services) {
+    public NamespaceDefinition createForServices(Collection<ServiceDeclaration> services) {
         Assert.notNull(services, "services cannot be null");
         // one conversion context for the whole batch, so complex types shared between services convert once
         DefaultConversionContext conversionContext = new DefaultConversionContext(typeConverter, true);
 
         NamespaceDefinition ret = new NamespaceDefinition();
-        // record equality collapses duplicates, so a service registered twice converts once
-        for (DirectoryRegistration registration : new LinkedHashSet<>(services)) {
+        // record equality collapses duplicates, so a service declared twice converts once
+        for (ServiceDeclaration declaration : new LinkedHashSet<>(services)) {
             // a service with an unconvertible type is omitted so the rest of the batch still converts;
             // ObjectC3Types are cached only after converting completely, so a failure leaves no partial types
             try {
-                ret.addServiceDefinition(createForService(registration.serviceInterface(),
-                                                          registration.serviceImplementation(),
+                ret.addServiceDefinition(createForService(declaration.serviceInterface(),
+                                                          declaration.serviceImplementation(),
                                                           conversionContext));
             } catch (Exception e) {
-                log.error("Failed to create ServiceDefinition for {}", registration.serviceInterface().getName(), e);
+                log.error("Failed to create ServiceDefinition for {}", declaration.serviceInterface().getName(), e);
             }
         }
         ret.setComplexC3Types(conversionContext.getComplexC3Types());

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
@@ -21,7 +21,6 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ClassUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
-import org.springframework.util.ReflectionUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -99,13 +98,15 @@ public class DefaultSchemaFactory implements SchemaFactory {
         // a type-level @McpTool marks every function a tool with these defaults
         McpTool typeLevelMcpTool = AnnotationUtils.findAnnotation(contract, McpTool.class);
 
-        ReflectionUtils.doWithMethods(contract, method -> {
+        // IdlUtil.serviceFunctions decides WHICH functions exist — the same walk ReflectiveServiceDescriptor
+        // registers with the ServiceRegistry, so the schema carries exactly the functions the registry serves
+        for (Map.Entry<String, Method> function : IdlUtil.serviceFunctions(contract).entrySet()) {
 
-            // the contract decides WHICH functions exist; the implementation's override decides parameter
-            // names, generic bindings, and annotations — the same method the invocation-side named-argument
-            // binding resolves, so the published schema and the runtime binding cannot drift
+            // the implementation's override decides parameter names, generic bindings, and annotations —
+            // the same method the invocation-side named-argument binding resolves, so the published schema
+            // and the runtime binding cannot drift
             Method specificMethod = BridgeMethodResolver.findBridgedMethod(
-                    ClassUtils.getMostSpecificMethod(method, implementation));
+                    ClassUtils.getMostSpecificMethod(function.getValue(), implementation));
 
             FunctionDefinition functionDefinition = new FunctionDefinition();
             functionDefinition.setReturnType(conversionContext.convert(
@@ -120,7 +121,7 @@ public class DefaultSchemaFactory implements SchemaFactory {
                 functionDefinition.addParameter(IdlUtil.parameterName(methodParameter), c3Type);
             }
 
-            functionDefinition.setName(method.getName());
+            functionDefinition.setName(function.getKey());
 
             // findAnnotation walks super methods, so @McpTool applies whether declared on the contract
             // method or only on the implementation's override (e.g. an inherited CRUD method); a
@@ -139,8 +140,7 @@ public class DefaultSchemaFactory implements SchemaFactory {
             }
 
             serviceDefinition.addFunction(functionDefinition);
-
-        }, ReflectionUtils.USER_DECLARED_METHODS);
+        }
 
         return serviceDefinition;
     }

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
@@ -3,6 +3,7 @@
 package org.kinotic.idl.internal.directory;
 
 import org.kinotic.idl.api.directory.ConversionContext;
+import org.kinotic.idl.api.directory.DirectoryRegistration;
 import org.kinotic.idl.api.directory.GenericTypeConverter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -30,9 +31,11 @@ import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -80,41 +83,44 @@ public class DefaultSchemaFactory implements SchemaFactory {
     }
 
     @Override
-    public NamespaceDefinition createForServices(Map<Class<?>, Class<?>> services) {
+    public NamespaceDefinition createForServices(Collection<DirectoryRegistration> services) {
         Assert.notNull(services, "services cannot be null");
         // one conversion context for the whole batch, so complex types shared between services convert once
         DefaultConversionContext conversionContext = new DefaultConversionContext(typeConverter, true);
 
         NamespaceDefinition ret = new NamespaceDefinition();
-        for (Map.Entry<Class<?>, Class<?>> service : services.entrySet()) {
+        // record equality collapses duplicates, so a service registered twice converts once
+        for (DirectoryRegistration registration : new LinkedHashSet<>(services)) {
             // a service with an unconvertible type is omitted so the rest of the batch still converts;
             // ObjectC3Types are cached only after converting completely, so a failure leaves no partial types
             try {
-                ret.addServiceDefinition(createForService(service.getKey(), service.getValue(), conversionContext));
+                ret.addServiceDefinition(createForService(registration.serviceInterface(),
+                                                          registration.serviceImplementation(),
+                                                          conversionContext));
             } catch (Exception e) {
-                log.error("Failed to create ServiceDefinition for {}", service.getKey().getName(), e);
+                log.error("Failed to create ServiceDefinition for {}", registration.serviceInterface().getName(), e);
             }
         }
         ret.setComplexC3Types(conversionContext.getComplexC3Types());
         return ret;
     }
 
-    private ServiceDefinition createForService(Class<?> contract,
+    private ServiceDefinition createForService(Class<?> serviceInterface,
                                                Class<?> implementation,
                                                ConversionContext conversionContext) {
-        Assert.notNull(contract, "contract cannot be null");
+        Assert.notNull(serviceInterface, "serviceInterface cannot be null");
         Assert.notNull(implementation, "implementation cannot be null");
 
         ServiceDefinition serviceDefinition = new ServiceDefinition();
-        serviceDefinition.setNamespace(contract.getPackage().getName());
-        serviceDefinition.setName(contract.getSimpleName());
+        serviceDefinition.setNamespace(serviceInterface.getPackage().getName());
+        serviceDefinition.setName(serviceInterface.getSimpleName());
 
         // a type-level @McpTool marks every function a tool with these defaults
-        McpTool typeLevelMcpTool = AnnotationUtils.findAnnotation(contract, McpTool.class);
+        McpTool typeLevelMcpTool = AnnotationUtils.findAnnotation(serviceInterface, McpTool.class);
 
         // IdlUtil.serviceFunctions decides WHICH functions exist — the same walk ReflectiveServiceDescriptor
         // registers with the ServiceRegistry, so the schema carries exactly the functions the registry serves
-        for (Map.Entry<String, Method> function : IdlUtil.serviceFunctions(contract).entrySet()) {
+        for (Map.Entry<String, Method> function : IdlUtil.serviceFunctions(serviceInterface).entrySet()) {
 
             // the implementation's override decides parameter names, generic bindings, and annotations —
             // the same method the invocation-side named-argument binding resolves, so the published schema

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/McpToolDocProcessor.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/McpToolDocProcessor.java
@@ -20,12 +20,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Extracts method Javadoc at compile time into a jar resource per type, so MCP tool descriptions can come
- * from the comments a service already carries. Every documented interface is captured — a generic CRUD base
- * only becomes tool-relevant when a subtype is swept, long after the base compiled — while classes are
- * captured only when a method carries {@link McpTool} (an implementation override). The resource holds one
- * {@code methodName=description} line per documented method, where the description is the Javadoc main
- * description with inline tags resolved and HTML stripped.
+ * Annotation processor that extracts method Javadoc at compile time into a resource under
+ * {@link #DOCS_RESOURCE_DIRECTORY}, one {@code methodName=description} line per documented method.
+ * The description is the Javadoc main description with inline tags resolved and HTML stripped.
+ * {@code DefaultSchemaFactory} reads these resources to describe MCP tools whose {@link McpTool}
+ * declares no description.
  * Created by Navíd Mitchell 🤪 on 7/27/26.
  */
 public class McpToolDocProcessor extends AbstractProcessor {
@@ -65,6 +64,8 @@ public class McpToolDocProcessor extends AbstractProcessor {
     }
 
     private void processType(TypeElement typeElement) throws IOException {
+        // every documented interface is captured, because a generic base (e.g. CrudService) cannot know at
+        // its own compile time that a subtype will later be swept; classes matter only as @McpTool overrides
         boolean isInterface = typeElement.getKind() == ElementKind.INTERFACE;
         Map<String, String> docs = new TreeMap<>();
         for (Element enclosed : typeElement.getEnclosedElements()) {

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/McpToolDocProcessor.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/McpToolDocProcessor.java
@@ -1,0 +1,164 @@
+package org.kinotic.idl.internal.directory;
+
+import org.kinotic.idl.api.annotations.McpTool;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import javax.tools.StandardLocation;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Extracts method Javadoc at compile time into a jar resource per type, so MCP tool descriptions can come
+ * from the comments a service already carries. Every documented interface is captured — a generic CRUD base
+ * only becomes tool-relevant when a subtype is swept, long after the base compiled — while classes are
+ * captured only when a method carries {@link McpTool} (an implementation override). The resource holds one
+ * {@code methodName=description} line per documented method, where the description is the Javadoc main
+ * description with inline tags resolved and HTML stripped.
+ * Created by Navíd Mitchell 🤪 on 7/27/26.
+ */
+public class McpToolDocProcessor extends AbstractProcessor {
+
+    /**
+     * Classpath directory holding one {@code <binary-name>.properties} resource per extracted type.
+     */
+    public static final String DOCS_RESOURCE_DIRECTORY = "META-INF/kinotic/docs/";
+
+    private static final Pattern INLINE_TAG = Pattern.compile("\\{@(\\w+)(?:\\s+([^}]*))?}");
+    private static final Pattern HTML_TAG = Pattern.compile("<[^>]+>");
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of("*");
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (Element element : roundEnv.getRootElements()) {
+            if (element instanceof TypeElement typeElement) {
+                try {
+                    processType(typeElement);
+                } catch (Exception e) {
+                    // extraction is best effort; a failed type falls back to name-derived descriptions
+                    processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING,
+                                                             "Failed to extract Javadoc descriptions: " + e, typeElement);
+                }
+            }
+        }
+        return false;
+    }
+
+    private void processType(TypeElement typeElement) throws IOException {
+        boolean isInterface = typeElement.getKind() == ElementKind.INTERFACE;
+        Map<String, String> docs = new TreeMap<>();
+        for (Element enclosed : typeElement.getEnclosedElements()) {
+            if (enclosed.getKind() == ElementKind.METHOD
+                    && (isInterface || enclosed.getAnnotation(McpTool.class) != null)) {
+                String docComment = processingEnv.getElementUtils().getDocComment(enclosed);
+                if (docComment != null) {
+                    String description = mainDescription(docComment);
+                    if (!description.isEmpty()) {
+                        // overloads collapse to one entry, matching IdlUtil.serviceFunctions
+                        docs.put(((ExecutableElement) enclosed).getSimpleName().toString(), description);
+                    }
+                }
+            }
+        }
+        if (!docs.isEmpty()) {
+            write(typeElement, docs);
+        }
+    }
+
+    /**
+     * Returns the Javadoc main description: the text before the first block tag, with inline tags resolved
+     * to their content, HTML removed, and whitespace collapsed.
+     */
+    private static String mainDescription(String docComment) {
+        StringBuilder text = new StringBuilder();
+        for (String line : docComment.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("@")) {
+                break;
+            }
+            text.append(trimmed).append(' ');
+        }
+        String ret = resolveInlineTags(text.toString());
+        ret = HTML_TAG.matcher(ret).replaceAll(" ");
+        ret = ret.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">").replace("&nbsp;", " ");
+        return ret.replaceAll("\\s+", " ").trim();
+    }
+
+    private static String resolveInlineTags(String text) {
+        Matcher matcher = INLINE_TAG.matcher(text);
+        StringBuilder ret = new StringBuilder();
+        while (matcher.find()) {
+            String tag = matcher.group(1);
+            String content = matcher.group(2) == null ? "" : matcher.group(2).trim();
+            String replacement;
+            if (tag.equals("link") || tag.equals("linkplain")) {
+                replacement = linkText(content);
+            } else if (tag.equals("code") || tag.equals("literal") || tag.equals("value")) {
+                replacement = content;
+            } else {
+                // inheritDoc, docRoot, and unknown tags carry no readable text
+                replacement = "";
+            }
+            matcher.appendReplacement(ret, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(ret);
+        return ret.toString();
+    }
+
+    // "package.Class#member label" -> "label"; "package.Class#member" -> "member"; "package.Class" -> "Class"
+    private static String linkText(String content) {
+        String ret;
+        int labelStart = content.indexOf(' ');
+        if (labelStart >= 0) {
+            ret = content.substring(labelStart + 1);
+        } else {
+            String reference = content;
+            int member = reference.indexOf('#');
+            if (member >= 0) {
+                ret = reference.substring(member + 1);
+            } else {
+                ret = reference.substring(reference.lastIndexOf('.') + 1);
+            }
+        }
+        return ret;
+    }
+
+    private void write(TypeElement typeElement, Map<String, String> docs) throws IOException {
+        String binaryName = processingEnv.getElementUtils().getBinaryName(typeElement).toString();
+        // written by hand instead of Properties.store, whose timestamp comment breaks reproducible jars
+        try (Writer writer = processingEnv.getFiler()
+                                          .createResource(StandardLocation.CLASS_OUTPUT,
+                                                          "",
+                                                          DOCS_RESOURCE_DIRECTORY + binaryName + ".properties",
+                                                          typeElement)
+                                          .openWriter()) {
+            for (Map.Entry<String, String> doc : docs.entrySet()) {
+                writer.write(doc.getKey());
+                writer.write('=');
+                writer.write(doc.getValue().replace("\\", "\\\\"));
+                writer.write('\n');
+            }
+        }
+    }
+
+}

--- a/kinotic-idl/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/kinotic-idl/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+org.kinotic.idl.internal.directory.McpToolDocProcessor,isolating

--- a/kinotic-idl/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/kinotic-idl/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.kinotic.idl.internal.directory.McpToolDocProcessor

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
@@ -22,6 +22,7 @@ import org.kinotic.idl.internal.support.TestObject;
 import org.kinotic.idl.internal.support.TestObjectCrudService;
 import org.kinotic.idl.internal.support.TestService;
 import org.kinotic.idl.internal.support.TestStatus;
+import org.kinotic.idl.internal.support.TestSweptService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -132,6 +133,27 @@ public class TestSchemaFactory {
         McpToolC3Decorator decorator = greet.findDecorator(McpToolC3Decorator.class);
         Assertions.assertNotNull(decorator);
         Assertions.assertEquals("Greets the recipient", decorator.getDescription());
+    }
+
+    @Test
+    public void testTypeLevelMcpToolMarksEveryFunction() {
+        NamespaceDefinition namespaceDefinition =
+                schemaFactory.createForServices(Map.of(TestSweptService.class, TestSweptService.class));
+
+        ServiceDefinition service = findService(namespaceDefinition, TestSweptService.class);
+
+        // an unannotated method inherits the type-level description and hints
+        McpToolC3Decorator swept = findFunction(service, "findByName").findDecorator(McpToolC3Decorator.class);
+        Assertions.assertNotNull(swept);
+        Assertions.assertEquals("Looks up test objects", swept.getDescription());
+        Assertions.assertTrue(swept.isReadOnlyHint());
+
+        // a method-level @McpTool overrides the type-level defaults for that method
+        McpToolC3Decorator specific = findFunction(service, "countAll").findDecorator(McpToolC3Decorator.class);
+        Assertions.assertNotNull(specific);
+        Assertions.assertEquals("Counts every test object", specific.getDescription());
+        Assertions.assertEquals("Count Objects", specific.getTitle());
+        Assertions.assertFalse(specific.isReadOnlyHint());
     }
 
     @Test

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
@@ -2,6 +2,7 @@ package org.kinotic.idl.internal;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.kinotic.idl.api.directory.DirectoryRegistration;
 import org.kinotic.idl.api.directory.SchemaFactory;
 import org.kinotic.idl.api.schema.AsyncC3Type;
 import org.kinotic.idl.api.schema.C3Type;
@@ -32,7 +33,6 @@ import org.springframework.test.context.ActiveProfiles;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Created by Navíd Mitchell 🤪 on 4/14/23.
@@ -51,8 +51,8 @@ public class TestSchemaFactory {
 
     @Test
     public void testSchemaFactory() throws Exception {
-        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(Map.of(TestService.class, TestService.class,
-                                                                                         OtherTestService.class, OtherTestService.class));
+        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(new DirectoryRegistration(TestService.class, TestService.class),
+                                                                                          new DirectoryRegistration(OtherTestService.class, OtherTestService.class)));
 
         Assertions.assertEquals(2, namespaceDefinition.getServices().size());
 
@@ -100,7 +100,7 @@ public class TestSchemaFactory {
 
     @Test
     public void testInheritedGenericSignaturesResolve() {
-        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(Map.of(TestObjectCrudService.class, TestObjectCrudService.class));
+        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(new DirectoryRegistration(TestObjectCrudService.class, TestObjectCrudService.class)));
 
         ServiceDefinition crudService = findService(namespaceDefinition, TestObjectCrudService.class);
         Assertions.assertEquals(2, crudService.getFunctions().size());
@@ -129,7 +129,7 @@ public class TestSchemaFactory {
     @Test
     public void testImplementationDecidesNamesAndAnnotations() {
         NamespaceDefinition namespaceDefinition =
-                schemaFactory.createForServices(Map.of(TestRenamedService.class, DefaultTestRenamedService.class));
+                schemaFactory.createForServices(List.of(new DirectoryRegistration(TestRenamedService.class, DefaultTestRenamedService.class)));
 
         ServiceDefinition service = findService(namespaceDefinition, TestRenamedService.class);
         FunctionDefinition greet = findFunction(service, "greet");
@@ -147,7 +147,7 @@ public class TestSchemaFactory {
     @Test
     public void testTypeLevelMcpToolMarksEveryFunction() {
         NamespaceDefinition namespaceDefinition =
-                schemaFactory.createForServices(Map.of(TestSweptService.class, TestSweptService.class));
+                schemaFactory.createForServices(List.of(new DirectoryRegistration(TestSweptService.class, TestSweptService.class)));
 
         ServiceDefinition service = findService(namespaceDefinition, TestSweptService.class);
 
@@ -176,7 +176,7 @@ public class TestSchemaFactory {
     @Test
     public void testOverloadedFunctionPublishesOnce() {
         NamespaceDefinition namespaceDefinition =
-                schemaFactory.createForServices(Map.of(TestOverloadedService.class, TestOverloadedService.class));
+                schemaFactory.createForServices(List.of(new DirectoryRegistration(TestOverloadedService.class, TestOverloadedService.class)));
 
         ServiceDefinition service = findService(namespaceDefinition, TestOverloadedService.class);
         // IdlUtil.serviceFunctions keeps one method per name, the same rule ReflectiveServiceDescriptor
@@ -187,9 +187,9 @@ public class TestSchemaFactory {
 
     @Test
     public void testUnconvertibleServiceOmitted() {
-        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(Map.of(TestService.class, TestService.class,
-                                                                                         BrokenTestService.class, BrokenTestService.class,
-                                                                                         OtherTestService.class, OtherTestService.class));
+        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(new DirectoryRegistration(TestService.class, TestService.class),
+                                                                                          new DirectoryRegistration(BrokenTestService.class, BrokenTestService.class),
+                                                                                          new DirectoryRegistration(OtherTestService.class, OtherTestService.class)));
 
         // BrokenTestService fails to convert and is omitted; the rest of the batch is unaffected
         Assertions.assertEquals(2, namespaceDefinition.getServices().size());

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
@@ -20,6 +20,7 @@ import org.kinotic.idl.internal.support.TestRenamedService;
 import org.kinotic.idl.internal.support.OtherTestService;
 import org.kinotic.idl.internal.support.TestObject;
 import org.kinotic.idl.internal.support.TestObjectCrudService;
+import org.kinotic.idl.internal.support.TestOverloadedService;
 import org.kinotic.idl.internal.support.TestService;
 import org.kinotic.idl.internal.support.TestStatus;
 import org.kinotic.idl.internal.support.TestSweptService;
@@ -154,6 +155,18 @@ public class TestSchemaFactory {
         Assertions.assertEquals("Counts every test object", specific.getDescription());
         Assertions.assertEquals("Count Objects", specific.getTitle());
         Assertions.assertFalse(specific.isReadOnlyHint());
+    }
+
+    @Test
+    public void testOverloadedFunctionPublishesOnce() {
+        NamespaceDefinition namespaceDefinition =
+                schemaFactory.createForServices(Map.of(TestOverloadedService.class, TestOverloadedService.class));
+
+        ServiceDefinition service = findService(namespaceDefinition, TestOverloadedService.class);
+        // IdlUtil.serviceFunctions keeps one method per name, the same rule ReflectiveServiceDescriptor
+        // registers with, so the schema never advertises an overload the registry does not serve
+        Assertions.assertEquals(1, service.getFunctions().size());
+        findFunction(service, "find");
     }
 
     @Test

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
@@ -2,7 +2,7 @@ package org.kinotic.idl.internal;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.kinotic.idl.api.directory.DirectoryRegistration;
+import org.kinotic.idl.api.directory.ServiceDeclaration;
 import org.kinotic.idl.api.directory.SchemaFactory;
 import org.kinotic.idl.api.schema.AsyncC3Type;
 import org.kinotic.idl.api.schema.C3Type;
@@ -51,8 +51,8 @@ public class TestSchemaFactory {
 
     @Test
     public void testSchemaFactory() throws Exception {
-        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(new DirectoryRegistration(TestService.class, TestService.class),
-                                                                                          new DirectoryRegistration(OtherTestService.class, OtherTestService.class)));
+        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(new ServiceDeclaration(TestService.class, TestService.class),
+                                                                                          new ServiceDeclaration(OtherTestService.class, OtherTestService.class)));
 
         Assertions.assertEquals(2, namespaceDefinition.getServices().size());
 
@@ -100,7 +100,7 @@ public class TestSchemaFactory {
 
     @Test
     public void testInheritedGenericSignaturesResolve() {
-        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(new DirectoryRegistration(TestObjectCrudService.class, TestObjectCrudService.class)));
+        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(new ServiceDeclaration(TestObjectCrudService.class, TestObjectCrudService.class)));
 
         ServiceDefinition crudService = findService(namespaceDefinition, TestObjectCrudService.class);
         Assertions.assertEquals(2, crudService.getFunctions().size());
@@ -129,7 +129,7 @@ public class TestSchemaFactory {
     @Test
     public void testImplementationDecidesNamesAndAnnotations() {
         NamespaceDefinition namespaceDefinition =
-                schemaFactory.createForServices(List.of(new DirectoryRegistration(TestRenamedService.class, DefaultTestRenamedService.class)));
+                schemaFactory.createForServices(List.of(new ServiceDeclaration(TestRenamedService.class, DefaultTestRenamedService.class)));
 
         ServiceDefinition service = findService(namespaceDefinition, TestRenamedService.class);
         FunctionDefinition greet = findFunction(service, "greet");
@@ -147,7 +147,7 @@ public class TestSchemaFactory {
     @Test
     public void testTypeLevelMcpToolMarksEveryFunction() {
         NamespaceDefinition namespaceDefinition =
-                schemaFactory.createForServices(List.of(new DirectoryRegistration(TestSweptService.class, TestSweptService.class)));
+                schemaFactory.createForServices(List.of(new ServiceDeclaration(TestSweptService.class, TestSweptService.class)));
 
         ServiceDefinition service = findService(namespaceDefinition, TestSweptService.class);
 
@@ -176,7 +176,7 @@ public class TestSchemaFactory {
     @Test
     public void testOverloadedFunctionPublishesOnce() {
         NamespaceDefinition namespaceDefinition =
-                schemaFactory.createForServices(List.of(new DirectoryRegistration(TestOverloadedService.class, TestOverloadedService.class)));
+                schemaFactory.createForServices(List.of(new ServiceDeclaration(TestOverloadedService.class, TestOverloadedService.class)));
 
         ServiceDefinition service = findService(namespaceDefinition, TestOverloadedService.class);
         // IdlUtil.serviceFunctions keeps one method per name, the same rule ReflectiveServiceDescriptor
@@ -187,9 +187,9 @@ public class TestSchemaFactory {
 
     @Test
     public void testUnconvertibleServiceOmitted() {
-        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(new DirectoryRegistration(TestService.class, TestService.class),
-                                                                                          new DirectoryRegistration(BrokenTestService.class, BrokenTestService.class),
-                                                                                          new DirectoryRegistration(OtherTestService.class, OtherTestService.class)));
+        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(new ServiceDeclaration(TestService.class, TestService.class),
+                                                                                          new ServiceDeclaration(BrokenTestService.class, BrokenTestService.class),
+                                                                                          new ServiceDeclaration(OtherTestService.class, OtherTestService.class)));
 
         // BrokenTestService fails to convert and is omitted; the rest of the batch is unaffected
         Assertions.assertEquals(2, namespaceDefinition.getServices().size());

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
@@ -118,6 +118,12 @@ public class TestSchemaFactory {
         Assertions.assertEquals(new AsyncC3Type(testObjectReference), findById.getReturnType());
         Assertions.assertEquals(new StringC3Type(), findById.getParameters().getFirst().getType());
         Assertions.assertEquals("id", findById.getParameters().getFirst().getName());
+
+        // an inherited function's description comes from the Javadoc on the generic base declaring it,
+        // even though GenericCrudService itself carries no annotations
+        McpToolC3Decorator inherited = findById.findDecorator(McpToolC3Decorator.class);
+        Assertions.assertNotNull(inherited);
+        Assertions.assertEquals("Finds the entity with the given id.", inherited.getDescription());
     }
 
     @Test
@@ -145,13 +151,19 @@ public class TestSchemaFactory {
 
         ServiceDefinition service = findService(namespaceDefinition, TestSweptService.class);
 
-        // an unannotated method inherits the type-level hints, and with no description declared
-        // anywhere the description and title derive from the function name
-        McpToolC3Decorator swept = findFunction(service, "findByName").findDecorator(McpToolC3Decorator.class);
-        Assertions.assertNotNull(swept);
-        Assertions.assertEquals("Find by name", swept.getDescription());
-        Assertions.assertEquals("Find By Name", swept.getTitle());
-        Assertions.assertTrue(swept.isReadOnlyHint());
+        // a documented method's description is the Javadoc main description extracted at compile time,
+        // with inline tags resolved; the title still derives from the function name
+        McpToolC3Decorator documented = findFunction(service, "findByName").findDecorator(McpToolC3Decorator.class);
+        Assertions.assertNotNull(documented);
+        Assertions.assertEquals("Finds the test object with the given name.", documented.getDescription());
+        Assertions.assertEquals("Find By Name", documented.getTitle());
+        Assertions.assertTrue(documented.isReadOnlyHint());
+
+        // no annotation description and no Javadoc: description and title derive from the function name
+        McpToolC3Decorator derived = findFunction(service, "countByName").findDecorator(McpToolC3Decorator.class);
+        Assertions.assertNotNull(derived);
+        Assertions.assertEquals("Count by name", derived.getDescription());
+        Assertions.assertEquals("Count By Name", derived.getTitle());
 
         // a method-level @McpTool overrides the type-level defaults for that method
         McpToolC3Decorator specific = findFunction(service, "countAll").findDecorator(McpToolC3Decorator.class);

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
@@ -13,7 +13,10 @@ import org.kinotic.idl.api.schema.ReferenceC3Type;
 import org.kinotic.idl.api.schema.ServiceDefinition;
 import org.kinotic.idl.api.schema.StreamC3Type;
 import org.kinotic.idl.api.schema.StringC3Type;
+import org.kinotic.idl.api.schema.decorators.McpToolC3Decorator;
 import org.kinotic.idl.internal.support.BrokenTestService;
+import org.kinotic.idl.internal.support.DefaultTestRenamedService;
+import org.kinotic.idl.internal.support.TestRenamedService;
 import org.kinotic.idl.internal.support.OtherTestService;
 import org.kinotic.idl.internal.support.TestObject;
 import org.kinotic.idl.internal.support.TestObjectCrudService;
@@ -27,6 +30,7 @@ import org.springframework.test.context.ActiveProfiles;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by Navíd Mitchell 🤪 on 4/14/23.
@@ -45,8 +49,8 @@ public class TestSchemaFactory {
 
     @Test
     public void testSchemaFactory() throws Exception {
-        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(TestService.class,
-                                                                                          OtherTestService.class));
+        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(Map.of(TestService.class, TestService.class,
+                                                                                         OtherTestService.class, OtherTestService.class));
 
         Assertions.assertEquals(2, namespaceDefinition.getServices().size());
 
@@ -94,7 +98,7 @@ public class TestSchemaFactory {
 
     @Test
     public void testInheritedGenericSignaturesResolve() {
-        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(TestObjectCrudService.class));
+        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(Map.of(TestObjectCrudService.class, TestObjectCrudService.class));
 
         ServiceDefinition crudService = findService(namespaceDefinition, TestObjectCrudService.class);
         Assertions.assertEquals(2, crudService.getFunctions().size());
@@ -115,10 +119,26 @@ public class TestSchemaFactory {
     }
 
     @Test
+    public void testImplementationDecidesNamesAndAnnotations() {
+        NamespaceDefinition namespaceDefinition =
+                schemaFactory.createForServices(Map.of(TestRenamedService.class, DefaultTestRenamedService.class));
+
+        ServiceDefinition service = findService(namespaceDefinition, TestRenamedService.class);
+        FunctionDefinition greet = findFunction(service, "greet");
+        // the implementation's parameter name is what the named-argument binding resolves at invocation,
+        // so it is the name the schema publishes — not the interface's "recipientName"
+        Assertions.assertEquals("name", greet.getParameters().getFirst().getName());
+        // @McpTool declared only on the implementation's override still marks the function
+        McpToolC3Decorator decorator = greet.findDecorator(McpToolC3Decorator.class);
+        Assertions.assertNotNull(decorator);
+        Assertions.assertEquals("Greets the recipient", decorator.getDescription());
+    }
+
+    @Test
     public void testUnconvertibleServiceOmitted() {
-        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(List.of(TestService.class,
-                                                                                          BrokenTestService.class,
-                                                                                          OtherTestService.class));
+        NamespaceDefinition namespaceDefinition = schemaFactory.createForServices(Map.of(TestService.class, TestService.class,
+                                                                                         BrokenTestService.class, BrokenTestService.class,
+                                                                                         OtherTestService.class, OtherTestService.class));
 
         // BrokenTestService fails to convert and is omitted; the rest of the batch is unaffected
         Assertions.assertEquals(2, namespaceDefinition.getServices().size());

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/TestSchemaFactory.java
@@ -134,6 +134,8 @@ public class TestSchemaFactory {
         McpToolC3Decorator decorator = greet.findDecorator(McpToolC3Decorator.class);
         Assertions.assertNotNull(decorator);
         Assertions.assertEquals("Greets the recipient", decorator.getDescription());
+        // an explicit description with no title still gets a derived title
+        Assertions.assertEquals("Greet", decorator.getTitle());
     }
 
     @Test
@@ -143,10 +145,12 @@ public class TestSchemaFactory {
 
         ServiceDefinition service = findService(namespaceDefinition, TestSweptService.class);
 
-        // an unannotated method inherits the type-level description and hints
+        // an unannotated method inherits the type-level hints, and with no description declared
+        // anywhere the description and title derive from the function name
         McpToolC3Decorator swept = findFunction(service, "findByName").findDecorator(McpToolC3Decorator.class);
         Assertions.assertNotNull(swept);
-        Assertions.assertEquals("Looks up test objects", swept.getDescription());
+        Assertions.assertEquals("Find by name", swept.getDescription());
+        Assertions.assertEquals("Find By Name", swept.getTitle());
         Assertions.assertTrue(swept.isReadOnlyHint());
 
         // a method-level @McpTool overrides the type-level defaults for that method

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/DefaultTestRenamedService.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/DefaultTestRenamedService.java
@@ -1,0 +1,18 @@
+package org.kinotic.idl.internal.support;
+
+import org.kinotic.idl.api.annotations.McpTool;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Created by Navíd Mitchell 🤪 on 7/27/26.
+ */
+public class DefaultTestRenamedService implements TestRenamedService {
+
+    @Override
+    @McpTool(description = "Greets the recipient")
+    public CompletableFuture<String> greet(String name) {
+        return CompletableFuture.completedFuture("Hello " + name);
+    }
+
+}

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/GenericCrudService.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/GenericCrudService.java
@@ -9,6 +9,9 @@ public interface GenericCrudService<T, ID> {
 
     CompletableFuture<T> save(T entity);
 
+    /**
+     * Finds the entity with the given id.
+     */
     CompletableFuture<T> findById(ID id);
 
 }

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestObjectCrudService.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestObjectCrudService.java
@@ -1,7 +1,10 @@
 package org.kinotic.idl.internal.support;
 
+import org.kinotic.idl.api.annotations.McpTool;
+
 /**
  * Created by Navíd Mitchell 🤪 on 7/26/26.
  */
+@McpTool
 public interface TestObjectCrudService extends GenericCrudService<TestObject, String> {
 }

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestOverloadedService.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestOverloadedService.java
@@ -1,0 +1,14 @@
+package org.kinotic.idl.internal.support;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Created by Navíd Mitchell 🤪 on 7/27/26.
+ */
+public interface TestOverloadedService {
+
+    CompletableFuture<TestObject> find(String name);
+
+    CompletableFuture<TestObject> find(String name, int limit);
+
+}

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestRenamedService.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestRenamedService.java
@@ -1,0 +1,12 @@
+package org.kinotic.idl.internal.support;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Created by Navíd Mitchell 🤪 on 7/27/26.
+ */
+public interface TestRenamedService {
+
+    CompletableFuture<String> greet(String recipientName);
+
+}

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestSweptService.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestSweptService.java
@@ -1,0 +1,18 @@
+package org.kinotic.idl.internal.support;
+
+import org.kinotic.idl.api.annotations.McpTool;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Created by Navíd Mitchell 🤪 on 7/27/26.
+ */
+@McpTool(description = "Looks up test objects", readOnlyHint = true)
+public interface TestSweptService {
+
+    CompletableFuture<TestObject> findByName(String name);
+
+    @McpTool(description = "Counts every test object", title = "Count Objects")
+    CompletableFuture<Long> countAll();
+
+}

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestSweptService.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestSweptService.java
@@ -10,7 +10,12 @@ import java.util.concurrent.CompletableFuture;
 @McpTool(readOnlyHint = true)
 public interface TestSweptService {
 
+    /**
+     * Finds the test object with the given {@code name}.
+     */
     CompletableFuture<TestObject> findByName(String name);
+
+    CompletableFuture<Long> countByName(String name);
 
     @McpTool(description = "Counts every test object", title = "Count Objects")
     CompletableFuture<Long> countAll();

--- a/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestSweptService.java
+++ b/kinotic-idl/src/test/java/org/kinotic/idl/internal/support/TestSweptService.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Created by Navíd Mitchell 🤪 on 7/27/26.
  */
-@McpTool(description = "Looks up test objects", readOnlyHint = true)
+@McpTool(readOnlyHint = true)
 public interface TestSweptService {
 
     CompletableFuture<TestObject> findByName(String name);

--- a/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
@@ -2,7 +2,7 @@ package org.kinotic.os.api.services;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.kinotic.idl.api.directory.DirectoryRegistration;
+import org.kinotic.idl.api.directory.ServiceDeclaration;
 import org.kinotic.idl.api.directory.ResolvableTypeConverter;
 import org.kinotic.os.internal.api.services.DefaultApplicationService;
 import org.kinotic.os.internal.api.services.DefaultProjectService;
@@ -46,8 +46,8 @@ public class McpServiceSchemaTest {
     @Test
     public void mcpExposedServicesConvert() {
         NamespaceDefinition namespaceDefinition =
-                schemaFactory().createForServices(List.of(new DirectoryRegistration(ProjectService.class, DefaultProjectService.class),
-                                                           new DirectoryRegistration(ApplicationService.class, DefaultApplicationService.class)));
+                schemaFactory().createForServices(List.of(new ServiceDeclaration(ProjectService.class, DefaultProjectService.class),
+                                                           new ServiceDeclaration(ApplicationService.class, DefaultApplicationService.class)));
 
         // createForServices omits any service that fails conversion, so a shrunken count is the failure signal
         Assertions.assertEquals(2, namespaceDefinition.getServices().size());
@@ -56,7 +56,7 @@ public class McpServiceSchemaTest {
     @Test
     public void inheritedJavadocDescriptionsResolveAcrossModules() {
         NamespaceDefinition namespaceDefinition =
-                schemaFactory().createForServices(List.of(new DirectoryRegistration(TestCrudSweptService.class, TestCrudSweptService.class)));
+                schemaFactory().createForServices(List.of(new ServiceDeclaration(TestCrudSweptService.class, TestCrudSweptService.class)));
 
         ServiceDefinition service = namespaceDefinition.getServices()
                                                        .stream()

--- a/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
@@ -2,6 +2,7 @@ package org.kinotic.os.api.services;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.kinotic.idl.api.directory.DirectoryRegistration;
 import org.kinotic.idl.api.directory.ResolvableTypeConverter;
 import org.kinotic.os.internal.api.services.DefaultApplicationService;
 import org.kinotic.os.internal.api.services.DefaultProjectService;
@@ -34,7 +35,6 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.ReactiveAdapterRegistry;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Verifies every MCP-exposed os-api service converts to a ServiceDefinition with the same converter set
@@ -46,8 +46,8 @@ public class McpServiceSchemaTest {
     @Test
     public void mcpExposedServicesConvert() {
         NamespaceDefinition namespaceDefinition =
-                schemaFactory().createForServices(Map.of(ProjectService.class, DefaultProjectService.class,
-                                                         ApplicationService.class, DefaultApplicationService.class));
+                schemaFactory().createForServices(List.of(new DirectoryRegistration(ProjectService.class, DefaultProjectService.class),
+                                                           new DirectoryRegistration(ApplicationService.class, DefaultApplicationService.class)));
 
         // createForServices omits any service that fails conversion, so a shrunken count is the failure signal
         Assertions.assertEquals(2, namespaceDefinition.getServices().size());
@@ -56,7 +56,7 @@ public class McpServiceSchemaTest {
     @Test
     public void inheritedJavadocDescriptionsResolveAcrossModules() {
         NamespaceDefinition namespaceDefinition =
-                schemaFactory().createForServices(Map.of(TestCrudSweptService.class, TestCrudSweptService.class));
+                schemaFactory().createForServices(List.of(new DirectoryRegistration(TestCrudSweptService.class, TestCrudSweptService.class)));
 
         ServiceDefinition service = namespaceDefinition.getServices()
                                                        .stream()

--- a/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.kinotic.idl.api.directory.ResolvableTypeConverter;
 import org.kinotic.os.internal.api.services.DefaultApplicationService;
 import org.kinotic.os.internal.api.services.DefaultProjectService;
+import org.kinotic.idl.api.schema.FunctionDefinition;
 import org.kinotic.idl.api.schema.NamespaceDefinition;
+import org.kinotic.idl.api.schema.ServiceDefinition;
+import org.kinotic.idl.api.schema.decorators.McpToolC3Decorator;
 import org.kinotic.idl.internal.directory.DefaultResolvableTypeConverter;
 import org.kinotic.idl.internal.directory.DefaultSchemaFactory;
 import org.kinotic.idl.internal.directory.ReactiveTypeConverter;
@@ -42,6 +45,38 @@ public class McpServiceSchemaTest {
 
     @Test
     public void mcpExposedServicesConvert() {
+        NamespaceDefinition namespaceDefinition =
+                schemaFactory().createForServices(Map.of(ProjectService.class, DefaultProjectService.class,
+                                                         ApplicationService.class, DefaultApplicationService.class));
+
+        // createForServices omits any service that fails conversion, so a shrunken count is the failure signal
+        Assertions.assertEquals(2, namespaceDefinition.getServices().size());
+    }
+
+    @Test
+    public void inheritedJavadocDescriptionsResolveAcrossModules() {
+        NamespaceDefinition namespaceDefinition =
+                schemaFactory().createForServices(Map.of(TestCrudSweptService.class, TestCrudSweptService.class));
+
+        ServiceDefinition service = namespaceDefinition.getServices()
+                                                       .stream()
+                                                       .findFirst()
+                                                       .orElseThrow();
+        FunctionDefinition findById = service.getFunctions()
+                                             .stream()
+                                             .filter(function -> function.getName().equals("findById"))
+                                             .findFirst()
+                                             .orElseThrow();
+
+        // the description is CrudService.findById's Javadoc, read from the kinotic-core jar resource the
+        // McpToolDocProcessor emitted when kinotic-core compiled — guarding the conventions wiring and the
+        // cross-module ancestor walk together
+        McpToolC3Decorator decorator = findById.findDecorator(McpToolC3Decorator.class);
+        Assertions.assertNotNull(decorator);
+        Assertions.assertEquals("Retrieves an entity by its id.", decorator.getDescription());
+    }
+
+    private static DefaultSchemaFactory schemaFactory() {
         List<ResolvableTypeConverter> converters = List.of(new ArrayTypeConverter(),
                                                            new BooleanTypeConverter(),
                                                            new ByteTypeConverter(),
@@ -61,14 +96,7 @@ public class McpServiceSchemaTest {
                                                            new VoidTypeConverter(),
                                                            new TokenBufferTypeConverter(),
                                                            new ReactiveTypeConverter(sharedRegistryProvider()));
-        DefaultSchemaFactory schemaFactory = new DefaultSchemaFactory(new DefaultResolvableTypeConverter(converters));
-
-        NamespaceDefinition namespaceDefinition =
-                schemaFactory.createForServices(Map.of(ProjectService.class, DefaultProjectService.class,
-                                                       ApplicationService.class, DefaultApplicationService.class));
-
-        // createForServices omits any service that fails conversion, so a shrunken count is the failure signal
-        Assertions.assertEquals(2, namespaceDefinition.getServices().size());
+        return new DefaultSchemaFactory(new DefaultResolvableTypeConverter(converters));
     }
 
     // resolves to the shared ReactiveAdapterRegistry, as ReactiveTypeConverter falls back to outside a Spring context

--- a/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
@@ -3,6 +3,8 @@ package org.kinotic.os.api.services;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.kinotic.idl.api.directory.ResolvableTypeConverter;
+import org.kinotic.os.internal.api.services.DefaultApplicationService;
+import org.kinotic.os.internal.api.services.DefaultProjectService;
 import org.kinotic.idl.api.schema.NamespaceDefinition;
 import org.kinotic.idl.internal.directory.DefaultResolvableTypeConverter;
 import org.kinotic.idl.internal.directory.DefaultSchemaFactory;
@@ -29,6 +31,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.ReactiveAdapterRegistry;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Verifies every MCP-exposed os-api service converts to a ServiceDefinition with the same converter set
@@ -61,7 +64,8 @@ public class McpServiceSchemaTest {
         DefaultSchemaFactory schemaFactory = new DefaultSchemaFactory(new DefaultResolvableTypeConverter(converters));
 
         NamespaceDefinition namespaceDefinition =
-                schemaFactory.createForServices(List.of(ProjectService.class, ApplicationService.class));
+                schemaFactory.createForServices(Map.of(ProjectService.class, DefaultProjectService.class,
+                                                       ApplicationService.class, DefaultApplicationService.class));
 
         // createForServices omits any service that fails conversion, so a shrunken count is the failure signal
         Assertions.assertEquals(2, namespaceDefinition.getServices().size());

--- a/kinotic-os-api/src/test/java/org/kinotic/os/api/services/TestCrudSweptService.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/api/services/TestCrudSweptService.java
@@ -1,0 +1,12 @@
+package org.kinotic.os.api.services;
+
+import org.kinotic.core.api.crud.CrudService;
+import org.kinotic.domain.api.model.Application;
+import org.kinotic.idl.api.annotations.McpTool;
+
+/**
+ * Created by Navíd Mitchell 🤪 on 7/27/26.
+ */
+@McpTool
+public interface TestCrudSweptService extends CrudService<Application, String> {
+}

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -23,13 +23,18 @@ public interface OrderService {
 }
 ```
 
-`description` is what the LLM reads to decide when to call the tool. When it is empty, the function name is split into a sentence and used instead — `findByRepoFullName` becomes `Find by repo full name` — so every tool stays individually recognizable even when a whole service is swept with one annotation. `title` is a human-readable display name surfaced in tool listings; when empty it derives the same way (`Find By Repo Full Name`) and it never affects the tool name. The three hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`) are served as MCP tool annotations.
+`description` is what the LLM reads to decide when to call the tool. When it is empty, the description resolves in order:
+
+1. **The method's Javadoc.** An annotation processor shipped in `kinotic-idl` extracts each method's Javadoc main description at compile time (inline tags resolved, HTML stripped) into a `META-INF/kinotic/docs/` jar resource. Lookup follows the most specific declaration first — the implementation's override, the contract's declaration, then the contract's ancestors — so a function inherited from a generic CRUD base finds the doc written on the base, even across modules. Modules in this repo are wired automatically; an external project enables extraction with `annotationProcessor 'org.kinotic:kinotic-idl'`.
+2. **The function name**, split into a sentence — `findByRepoFullName` becomes `Find by repo full name` — so every tool stays individually recognizable even with no docs at all.
+
+`title` is a human-readable display name surfaced in tool listings; when empty it derives from the function name (`Find By Repo Full Name`) and it never affects the tool name. The three hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`) are served as MCP tool annotations.
 
 The input schema's property names are the implementing method's Java parameter names (`orderId` above), retained in the class file at compile time — the same method the invocation binds against, so the published schema and the runtime binding cannot drift even when an implementation renames a parameter. A single parameter can carry a different contract name with `@Name("...")`.
 
 `@McpTool` is honored in three places, mirroring how `@Publish` marks the interface while the implementation supplies the methods:
 
-- **On the service interface itself** — every function becomes a tool, carrying the type-level hints (and `description`, if one is declared) as defaults. A bare `@McpTool` on the interface exposes a whole service, including functions inherited from a CRUD parent, with per-function descriptions derived from the function names. Declare a type-level hint only when it holds for every function: `readOnlyHint = true` on a service whose sweep includes mutating functions mislabels them, so put hints on the individual methods instead.
+- **On the service interface itself** — every function becomes a tool, carrying the type-level hints (and `description`, if one is declared) as defaults. A bare `@McpTool` on the interface exposes a whole service, including functions inherited from a CRUD parent, with per-function descriptions from each function's Javadoc (or its name). Declare a type-level hint only when it holds for every function: `readOnlyHint = true` on a service whose sweep includes mutating functions mislabels them, so put hints on the individual methods instead.
 - **On an interface method** — that method becomes a tool (or overrides the type-level defaults for it).
 - **On the implementation's override** — same as an interface method, without touching the interface. This is how a single inherited function becomes a tool without redeclaring it.
 

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -25,7 +25,9 @@ public interface OrderService {
 
 `description` is required — it is what the LLM reads to decide when to call the tool. The optional `title` is a human-readable display name surfaced in tool listings; it never affects the tool name. The three hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`) are served as MCP tool annotations.
 
-The input schema's property names are the function's Java parameter names (`orderId` above), retained in the class file at compile time. A single parameter can carry a different contract name with `@Name("...")`.
+The input schema's property names are the implementing method's Java parameter names (`orderId` above), retained in the class file at compile time — the same method the invocation binds against, so the published schema and the runtime binding cannot drift even when an implementation renames a parameter. A single parameter can carry a different contract name with `@Name("...")`.
+
+`@McpTool` is honored on the interface method or on the implementation's override. Annotating the override is how a method inherited from a shared interface (a CRUD parent, for example) becomes a tool without redeclaring it on the service interface.
 
 A function with a streaming return type (`Flux`, `Publisher`) cannot be a tool — registration fails with an error naming the function. Single-value async returns (`CompletableFuture`, `Mono`) are fine.
 

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -23,13 +23,13 @@ public interface OrderService {
 }
 ```
 
-`description` is required — it is what the LLM reads to decide when to call the tool. The optional `title` is a human-readable display name surfaced in tool listings; it never affects the tool name. The three hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`) are served as MCP tool annotations.
+`description` is what the LLM reads to decide when to call the tool. When it is empty, the function name is split into a sentence and used instead — `findByRepoFullName` becomes `Find by repo full name` — so every tool stays individually recognizable even when a whole service is swept with one annotation. `title` is a human-readable display name surfaced in tool listings; when empty it derives the same way (`Find By Repo Full Name`) and it never affects the tool name. The three hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`) are served as MCP tool annotations.
 
 The input schema's property names are the implementing method's Java parameter names (`orderId` above), retained in the class file at compile time — the same method the invocation binds against, so the published schema and the runtime binding cannot drift even when an implementation renames a parameter. A single parameter can carry a different contract name with `@Name("...")`.
 
 `@McpTool` is honored in three places, mirroring how `@Publish` marks the interface while the implementation supplies the methods:
 
-- **On the service interface itself** — every function becomes a tool, carrying the type-level `description` and hints as defaults. This is how a whole service, including functions inherited from a CRUD parent, is exposed with one declaration.
+- **On the service interface itself** — every function becomes a tool, carrying the type-level hints (and `description`, if one is declared) as defaults. A bare `@McpTool` on the interface exposes a whole service, including functions inherited from a CRUD parent, with per-function descriptions derived from the function names.
 - **On an interface method** — that method becomes a tool (or overrides the type-level defaults for it).
 - **On the implementation's override** — same as an interface method, without touching the interface. This is how a single inherited function becomes a tool without redeclaring it.
 

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -29,7 +29,7 @@ The input schema's property names are the implementing method's Java parameter n
 
 `@McpTool` is honored in three places, mirroring how `@Publish` marks the interface while the implementation supplies the methods:
 
-- **On the service interface itself** — every function becomes a tool, carrying the type-level hints (and `description`, if one is declared) as defaults. A bare `@McpTool` on the interface exposes a whole service, including functions inherited from a CRUD parent, with per-function descriptions derived from the function names.
+- **On the service interface itself** — every function becomes a tool, carrying the type-level hints (and `description`, if one is declared) as defaults. A bare `@McpTool` on the interface exposes a whole service, including functions inherited from a CRUD parent, with per-function descriptions derived from the function names. Declare a type-level hint only when it holds for every function: `readOnlyHint = true` on a service whose sweep includes mutating functions mislabels them, so put hints on the individual methods instead.
 - **On an interface method** — that method becomes a tool (or overrides the type-level defaults for it).
 - **On the implementation's override** — same as an interface method, without touching the interface. This is how a single inherited function becomes a tool without redeclaring it.
 

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -27,7 +27,11 @@ public interface OrderService {
 
 The input schema's property names are the implementing method's Java parameter names (`orderId` above), retained in the class file at compile time — the same method the invocation binds against, so the published schema and the runtime binding cannot drift even when an implementation renames a parameter. A single parameter can carry a different contract name with `@Name("...")`.
 
-`@McpTool` is honored on the interface method or on the implementation's override. Annotating the override is how a method inherited from a shared interface (a CRUD parent, for example) becomes a tool without redeclaring it on the service interface.
+`@McpTool` is honored in three places, mirroring how `@Publish` marks the interface while the implementation supplies the methods:
+
+- **On the service interface itself** — every function becomes a tool, carrying the type-level `description` and hints as defaults. This is how a whole service, including functions inherited from a CRUD parent, is exposed with one declaration.
+- **On an interface method** — that method becomes a tool (or overrides the type-level defaults for it).
+- **On the implementation's override** — same as an interface method, without touching the interface. This is how a single inherited function becomes a tool without redeclaring it.
 
 A function with a streaming return type (`Flux`, `Publisher`) cannot be a tool — registration fails with an error naming the function. Single-value async returns (`CompletableFuture`, `Mono`) are fine.
 


### PR DESCRIPTION
Fixes the schema/binding name split and makes `@McpTool` work like `@Publish`: declared on the interface, resolved through the implementation.

## The defect

The schema published names from the `@Publish` interface while `NamedJsonArgumentResolver` bound them from the implementation&#39;s most specific method, so this compiled and then rejected its own published contract:

```java
public interface ITodoService {
    @McpTool(description = "…")
    CompletableFuture findById(String todoId);   // schema property: "todoId"
}

public class DefaultTodoService implements ITodoService {
    @Override
    public CompletableFuture findById(String id) { … }   // binder expects: "id"
}

// POST {"todoId": "abc"}  — exactly what the inputSchema asks for
// -> IllegalArgumentException: Received argument 'todoId' which matches no parameter of findById
```

## One naming source: the implementation

`createForService` now takes the contract *and* the implementation. The contract decides **which** functions exist; every function then resolves to the implementation&#39;s most specific method for names, generic bindings, and annotations — the same method `AopUtils.selectInvocableMethod` gives the binder:

```java
// DefaultSchemaFactory — mirrors the invocation-side resolution
Method specificMethod = BridgeMethodResolver.findBridgedMethod(
        ClassUtils.getMostSpecificMethod(method, implementation));
```

## Aligned with the ServiceRegistry pattern

`IdlUtil.serviceFunctions` is the single home for which functions a contract declares (user-declared methods, one per name — overloading unsupported). `ReflectiveServiceDescriptor` and `DefaultSchemaFactory` both delegate to it, so a published schema carries exactly the functions the registry serves; previously an overloaded contract registered one function but published two same-named definitions.

The directory API mirrors the registry, differing only where their needs differ — the registry invokes, the directory only reflects:

```java
// ServiceRegistry                                                    // ServiceDirectory
register(si, Class<?> serviceInterface, Object instance);             register(si, Class<?> serviceInterface, Class<?> serviceImplementation);
unregister(si);                                                       unregister(si);
```

`DefaultServiceDirectory` unwraps an AOP proxy class itself (`ClassUtils.getUserClass`), and remembers which identifiers it registered so `unregister` needs only the identifier instead of re-supplying the classes to re-run the publish check.

## `@McpTool` mirrors `@Publish`

The annotation now targets `TYPE` as well and `description` is optional — so a bare sweep still gives an LLM caller distinct, recognizable tools:

```java
@Publish
@McpTool   // every function becomes a tool
public interface ApplicationService extends IdentifiableCrudService {

    @McpTool(description = "Returns the enabled OIDC configurations registered on the given application",
             readOnlyHint = true)   // explicit values override, hints declared on the methods they are true for
    CompletableFuture getOidcConfigurations(String applicationId);
}

// tools/list =>
//   ...ApplicationService.findById               "Retrieves an entity by its id."   (CrudService Javadoc)
//   ...ApplicationService.getOidcConfigurations  "Returns the enabled OIDC configurations…"  readOnly
```

Honored in three places:

- **Interface type level** — every contract function (inherited CRUD methods included) becomes a tool; type-level hints/description apply as defaults, so only declare a type-level hint when it holds for every function.
- **Interface method** — per-method tool, or a per-method override of the type-level defaults.
- **Implementation override** — same as an interface method without touching the interface; `AnnotationUtils.findAnnotation` walks super methods, so a single inherited function becomes a tool by annotating its override.

## Description resolution: annotation → Javadoc → name

An empty `description` resolves through `McpToolDocProcessor`, a JDK-only annotation processor shipped in `kinotic-idl` that extracts each method&#39;s Javadoc main description at compile time (inline tags resolved, HTML stripped) into deterministic `META-INF/kinotic/docs/<type>.properties` jar resources — no timestamps, so reproducible-jar CI keys are unaffected. Every documented interface is captured, because a generic CRUD base only becomes tool-relevant when a subtype is swept long after the base compiled; classes are captured only for `@McpTool` overrides.

Runtime lookup walks the most specific declaration first — implementation override, contract declaration, then the contract&#39;s ancestors — so inherited CRUD functions find the doc written on the base across module boundaries (`CrudService.findById` → `"Retrieves an entity by its id."`). With no Javadoc either, the function name derives the text (`findByRepoFullName` → `"Find by repo full name"`); an empty `title` always derives from the name (`"Find By Repo Full Name"`). Hints are never derived — inferring `readOnlyHint` from a name prefix would let a misnamed method skip host confirmation, so `false` stays the default until declared.

Repo modules are wired through `java-common-conventions`; external projects opt in with `annotationProcessor 'org.kinotic:kinotic-idl'`. Extraction is best effort — a type that fails to extract falls back to name-derived text with a compiler warning, never a build failure.

## Tests

- `TestRenamedService`/`DefaultTestRenamedService`: interface declares `greet(String recipientName)`, impl renames to `name` and carries `@McpTool` only on the override — schema publishes `name`, decorator lands, title derives (`"Greet"`).
- `TestSweptService`: bare type-level `@McpTool(readOnlyHint = true)` (all functions are reads) — the documented method&#39;s description is its extracted Javadoc with `{@code}` resolved, the undocumented method falls back to name-derived, the method-level annotation overrides for its method.
- `TestObjectCrudService`/`GenericCrudService`: an inherited function&#39;s description comes from the Javadoc on the unannotated generic base declaring it, proving the ancestor walk.
- `TestOverloadedService`: an overloaded contract publishes a single function, matching what `ReflectiveServiceDescriptor` registers.
- `McpServiceSchemaTest` converts the real production pairs (`ProjectService`/`DefaultProjectService`, `ApplicationService`/`DefaultApplicationService`).
- Existing name assertions unchanged; explicit production descriptions/titles are untouched.
- Docs: `07.mcp-tools.md` documents the three declaration sites, implementation-resolved naming, the description resolution order, and the type-level-hint caution.

## Verification

idl, core, os-api, domain, gateway suites green on current develop; `:kinotic-test:compileTestJava` clean; docs resources verified in the built `kinotic-core` jar (30 types, including `CrudService`). Production services untouched — applying the type-level sweep to `ApplicationService` and friends is a product decision left to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKofxjoWDAqyomJbGcNmkw