### PR TITLE
Replace ConcurrentHashMap with Caffeine AsyncCache for OAuth2Auth

### DIFF
--- a/docs/NavidNotes.md
+++ b/docs/NavidNotes.md
@@ -88,6 +88,21 @@ the label need to not silently accept an implementation that drops it.
 `200` from `POST /mcp`. That assertion is the marker: restoring the check should turn it back into a
 `401` with a `WWW-Authenticate` challenge.
 
+### Outstanding requests count in a system UI
+
+Nothing that dispatches a request and waits for a reply bounds how long it waits. `McpToolInvoker`
+holds a `Promise` in `pendingCalls` until the reply arrives, and `DefaultRpcServiceProxyHandle` does
+the same with `responseMap`. `sendWithAck` only acks receipt, so a service that accepts a request and
+then dies leaves the entry there for the life of the process, and for MCP that also means the HTTP
+response is never written.
+
+A global timeout is the wrong answer — we do not know how long a published service is entitled to
+take, and any number we pick is wrong for somebody. Instead expose the size of those maps as a
+counted metric in a system UI, per node. Then we can see whether outstanding requests actually
+accumulate in practice, and how, before deciding whether anything needs bounding at all. If the
+count is flat under real load the whole concern is theoretical; if it climbs monotonically, the shape
+of the climb tells us what the right mechanism is.
+
 ### Outstanding
 * Move secret storage stuff out of the kinotic-core
 * Fix OidcFlowOrchestrator.java to not secretReferenceResolver.resolve for finding secrets. This won't work for our customers’ configs and should be done differently for our signup configs. 

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/ApplicationLoginHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/ApplicationLoginHandler.java
@@ -86,8 +86,11 @@ public class ApplicationLoginHandler implements SuppliesGatewayRoutes {
     private void handleLookup(RoutingContext ctx) {
         String orgId = ctx.pathParam("orgId");
         String appId = ctx.pathParam("appId");
-        JsonObject body = ctx.body().asJsonObject();
-        String email = body == null ? null : body.getString("email");
+        JsonObject body = authEndpointSupport.readJsonBody(ctx);
+        if (body == null) {
+            return;
+        }
+        String email = body.getString("email");
         if (email == null || email.isBlank()) {
             authEndpointSupport.respondError(ctx, 400, "email is required");
             return;

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/InviteHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/InviteHandler.java
@@ -101,16 +101,13 @@ public class InviteHandler implements SuppliesGatewayRoutes {
      * page uses for its confirmation state since the web app is not their UI.
      */
     private void handleLocalAccept(RoutingContext ctx) {
-        JsonObject body;
-        try {
-            body = ctx.body().asJsonObject();
-        } catch (Exception e) {
-            authEndpointSupport.respondError(ctx, 400, "Invalid request body");
+        JsonObject body = authEndpointSupport.readJsonBody(ctx);
+        if (body == null) {
             return;
         }
-        String token = body == null ? null : body.getString("token");
-        String password = body == null ? null : body.getString("password");
-        String displayName = body == null ? null : body.getString("displayName");
+        String token = body.getString("token");
+        String password = body.getString("password");
+        String displayName = body.getString("displayName");
         if (token == null || token.isBlank() || password == null || password.isBlank()) {
             authEndpointSupport.respondError(ctx, 400, "token and password are required");
             return;

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OidcErrorCodes.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OidcErrorCodes.java
@@ -18,7 +18,7 @@ public final class OidcErrorCodes {
     /** {@code :configId} resolves to no enabled OIDC configuration for the flow's scope. */
     public static final String CONFIG_NOT_FOUND = "config_not_found";
 
-    /** id_token failed validation (issuer, audience, sub missing, etc.). */
+    /** id_token failed validation (issuer, audience, nonce, sub missing, etc.). */
     public static final String INVALID_TOKEN = "invalid_token";
 
     /** id_token's email_verified claim is false (or missing for providers that require it). */

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationLoginHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationLoginHandler.java
@@ -60,8 +60,11 @@ public class OrganizationLoginHandler implements SuppliesGatewayRoutes {
      * for an OIDC org member whose org has a live login config, otherwise "use password".
      */
     private void handleLookup(RoutingContext ctx) {
-        JsonObject body = ctx.body().asJsonObject();
-        String email = body == null ? null : body.getString("email");
+        JsonObject body = authEndpointSupport.readJsonBody(ctx);
+        if (body == null) {
+            return;
+        }
+        String email = body.getString("email");
         if (email == null || email.isBlank()) {
             authEndpointSupport.respondError(ctx, 400, "email is required");
             return;

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationSignupHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OrganizationSignupHandler.java
@@ -219,10 +219,13 @@ public class OrganizationSignupHandler implements SuppliesGatewayRoutes {
      * sign-up identified by the token.
      */
     private void handleSocialCompleteOrg(RoutingContext ctx) {
-        JsonObject body = ctx.body().asJsonObject();
-        String token = body == null ? null : body.getString("token");
-        String orgName = body == null ? null : body.getString("orgName");
-        String orgDescription = body == null ? null : body.getString("orgDescription");
+        JsonObject body = authEndpointSupport.readJsonBody(ctx);
+        if (body == null) {
+            return;
+        }
+        String token = body.getString("token");
+        String orgName = body.getString("orgName");
+        String orgDescription = body.getString("orgDescription");
 
         if (token == null || token.isBlank()) {
             authEndpointSupport.respondError(ctx, 400, "token is required");

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
@@ -132,6 +132,28 @@ public class AuthEndpointSupport {
            .end(new JsonObject().put("error", message).encode());
     }
 
+    // ── Request bodies ────────────────────────────────────────────────────────
+
+    /**
+     * The request body parsed as JSON, or {@code null} when the body is absent or is not JSON — in
+     * which case a {@code 400} has already been written and the caller must return immediately.
+     * A non-null result lets the caller read its fields without null-checking the body itself.
+     */
+    public JsonObject readJsonBody(RoutingContext ctx) {
+        JsonObject ret;
+        try {
+            ret = ctx.body().asJsonObject();
+        } catch (Exception e) {
+            // a malformed body raises DecodeException, which would otherwise reach the router's
+            // failure handler and render as a 500
+            ret = null;
+        }
+        if (ret == null) {
+            respondError(ctx, 400, "Invalid request body");
+        }
+        return ret;
+    }
+
     // ── Token issuance ────────────────────────────────────────────────────────
 
     /**
@@ -212,15 +234,12 @@ public class AuthEndpointSupport {
      */
     public void handlePasswordLogin(RoutingContext ctx,
                                     BiFunction<String, String, CompletionStage<IamUser>> authenticate) {
-        JsonObject body;
-        try {
-            body = ctx.body().asJsonObject();
-        } catch (Exception e) {
-            respondError(ctx, 400, "Invalid request body");
+        JsonObject body = readJsonBody(ctx);
+        if (body == null) {
             return;
         }
-        String email = body == null ? null : body.getString("email");
-        String password = body == null ? null : body.getString("password");
+        String email = body.getString("email");
+        String password = body.getString("password");
         if (email == null || email.isBlank() || password == null || password.isBlank()) {
             respondError(ctx, 400, "email and password are required");
             return;

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
@@ -237,15 +237,20 @@ public class OidcFlowOrchestrator {
     }
 
     /**
-     * The {@link OAuth2Auth} for {@code config}, discovered against its authority on first use and
-     * cached until an hour passes with no flow using it. A discovery that fails is not cached, so
-     * the next flow retries it.
+     * The {@link OAuth2Auth} for {@code config} as it is currently persisted, discovered against its
+     * authority on first use and cached until an hour passes with no flow using it. Saving the
+     * configuration takes effect on the next flow. A discovery that fails is not cached, so the next
+     * flow retries it.
      */
     private Future<OAuth2Auth> getOAuth2Auth(BaseOidcConfiguration config) {
+        // Keying on updated as well as id is what picks up an edited clientId/authority/secretNameRef:
+        // both call sites pass a row read for this request, so a save misses the cache on every node
+        // without an invalidation message, and the superseded entry ages out on its own.
+        String key = config.getId() + ':' + (config.getUpdated() != null ? config.getUpdated().getTime() : 0);
         // AsyncCache evicts an entry whose future completes exceptionally, which is what keeps a
         // transient discovery failure from being cached — the loader must not touch the cache itself
         CompletableFuture<OAuth2Auth> cached =
-                oauth2AuthCache.get(config.getId(),
+                oauth2AuthCache.get(key,
                                     (id, executor) -> secretReferenceResolver.resolve(config.getSecretNameRef())
                                                                              .thenCompose(secret -> createOAuth2Auth(config, secret)
                                                                                      .toCompletionStage()));

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
@@ -18,6 +18,7 @@ import org.kinotic.domain.api.model.iam.BaseOidcConfiguration;
 import org.kinotic.domain.internal.api.rest.OidcErrorCodes;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,15 +39,13 @@ public class OidcFlowOrchestrator {
 
     private static final String OIDC_FLOW_SESSION_KEY = "oidcFlow";
 
-    /** Bounds the providers held live; the key space is OIDC configuration ids across every organization. */
-    private static final int MAX_CACHED_PROVIDERS = 1_000;
-
     private final AsyncCache<String, OAuth2Auth> oauth2AuthCache =
             Caffeine.newBuilder()
                     // OpenIDConnectAuth.discover leaves each provider holding a periodic JWKS refresh timer;
-                    // close() cancels it, so an evicted entry does not leak one for the life of the process
+                    // close() cancels it, so an entry dropped by either policy does not leak one
                     .removalListener((String id, OAuth2Auth oauth2Auth, RemovalCause cause) -> oauth2Auth.close())
-                    .maximumSize(MAX_CACHED_PROVIDERS)
+                    .expireAfterAccess(Duration.ofHours(1))
+                    .maximumSize(1_000)
                     .buildAsync();
     private final SecretReferenceResolver secretReferenceResolver;
     private final Vertx vertx;
@@ -239,7 +238,8 @@ public class OidcFlowOrchestrator {
 
     /**
      * The {@link OAuth2Auth} for {@code config}, discovered against its authority on first use and
-     * cached thereafter. A discovery that fails is not cached, so the next flow retries it.
+     * cached until an hour passes with no flow using it. A discovery that fails is not cached, so
+     * the next flow retries it.
      */
     private Future<OAuth2Auth> getOAuth2Auth(BaseOidcConfiguration config) {
         // AsyncCache evicts an entry whose future completes exceptionally, which is what keeps a

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
@@ -1,5 +1,8 @@
 package org.kinotic.domain.internal.api.rest.support;
 
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -19,8 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
 /**
@@ -37,7 +38,16 @@ public class OidcFlowOrchestrator {
 
     private static final String OIDC_FLOW_SESSION_KEY = "oidcFlow";
 
-    private final ConcurrentMap<String, Future<OAuth2Auth>> oauth2AuthCache = new ConcurrentHashMap<>();
+    /** Bounds the providers held live; the key space is OIDC configuration ids across every organization. */
+    private static final int MAX_CACHED_PROVIDERS = 1_000;
+
+    private final AsyncCache<String, OAuth2Auth> oauth2AuthCache =
+            Caffeine.newBuilder()
+                    // OpenIDConnectAuth.discover leaves each provider holding a periodic JWKS refresh timer;
+                    // close() cancels it, so an evicted entry does not leak one for the life of the process
+                    .removalListener((String id, OAuth2Auth oauth2Auth, RemovalCause cause) -> oauth2Auth.close())
+                    .maximumSize(MAX_CACHED_PROVIDERS)
+                    .buildAsync();
     private final SecretReferenceResolver secretReferenceResolver;
     private final Vertx vertx;
 
@@ -227,14 +237,20 @@ public class OidcFlowOrchestrator {
         return map;
     }
 
+    /**
+     * The {@link OAuth2Auth} for {@code config}, discovered against its authority on first use and
+     * cached thereafter. A discovery that fails is not cached, so the next flow retries it.
+     */
     private Future<OAuth2Auth> getOAuth2Auth(BaseOidcConfiguration config) {
-        return oauth2AuthCache.computeIfAbsent(config.getId(), id ->
-                Future.fromCompletionStage(secretReferenceResolver.resolve(config.getSecretNameRef()))
-                      .compose(secret -> createOAuth2Auth(config, secret))
-                      .onFailure(err -> {
-                          log.error("Failed to initialize OAuth2Auth for config {}", config.getId(), err);
-                          oauth2AuthCache.remove(config.getId());
-                      }));
+        // AsyncCache evicts an entry whose future completes exceptionally, which is what keeps a
+        // transient discovery failure from being cached — the loader must not touch the cache itself
+        CompletableFuture<OAuth2Auth> cached =
+                oauth2AuthCache.get(config.getId(),
+                                    (id, executor) -> secretReferenceResolver.resolve(config.getSecretNameRef())
+                                                                             .thenCompose(secret -> createOAuth2Auth(config, secret)
+                                                                                     .toCompletionStage()));
+        return Future.fromCompletionStage(cached, vertx.getOrCreateContext())
+                     .onFailure(err -> log.error("Failed to initialize OAuth2Auth for config {}", config.getId(), err));
     }
 
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
@@ -51,8 +51,9 @@ public class OidcFlowOrchestrator {
     private final Vertx vertx;
 
     /**
-     * Validates the callback (state match, no IdP error), exchanges the code, validates
-     * the issuer, and returns the configuration along with the verified id_token claims.
+     * Validates the callback (state match, no IdP error), exchanges the code, validates the
+     * issuer, audience and nonce, and returns the configuration along with the verified
+     * id_token claims.
      * The handler decides what to do with the claims (look up an IamUser, create a
      * {@code PendingSignUp}, etc.).
      *
@@ -108,6 +109,12 @@ public class OidcFlowOrchestrator {
                                      if (!OAuth2Util.isAudienceValid(claims, config.getAudience())) {
                                          log.warn("OIDC audience validation failed for config {}: expected={}, aud={}",
                                                   config.getId(), config.getAudience(), claims.get("aud"));
+                                         throw new OidcCallbackException(OidcErrorCodes.INVALID_TOKEN);
+                                     }
+                                     // startFlow always sends a nonce, so OIDC Core 3.1.3.7 requires the
+                                     // id_token to echo it — an absent claim fails the equals and is rejected
+                                     if (!flowSession.nonce().equals(OAuth2Util.stringClaim(claims, "nonce"))) {
+                                         log.warn("OIDC nonce validation failed for config {}", config.getId());
                                          throw new OidcCallbackException(OidcErrorCodes.INVALID_TOKEN);
                                      }
                                      return new CallbackResult<>(config, claims, flowSession.orgId(), flowSession.inviteToken());

--- a/website/content/02.platform/04.organization-management.md
+++ b/website/content/02.platform/04.organization-management.md
@@ -78,7 +78,7 @@ Email verification is the security gate — no `Organization` or `IamUser` exist
 4. User authenticates at the IdP
 5. IdP returns to GET /api/auth/org/signup/social/callback/<configId>
 6. OrganizationSignupHandler.handleSocialCallback → createPendingSignUp:
-   - validates state/PKCE, exchanges code for id_token + access_token
+   - validates state/nonce/PKCE, exchanges code for id_token + access_token
    - rejects if email_verified=false in the id_token
    - rejects with AccountExistsException if an IamUser already exists for (sub, configId)
    - creates a PendingRegistration with the verified subject, configId, email, displayName
@@ -156,10 +156,10 @@ The buttons are populated from `GET /api/auth/org/login/providers`, which lists 
 2. OrganizationLoginHandler.handleSocialStart:
    - finds the platform OidcConfiguration with provider="google"
      (orgSignupOidcConfigurationService.findEnabledByProvider)
-   - same state/PKCE setup as signup, then 302 to the IdP
+   - same state/nonce/PKCE setup as signup, then 302 to the IdP
 3. IdP returns to GET /api/auth/org/login/social/callback/<configId>
 4. OrganizationLoginHandler.handleSocialCallback → AuthEndpointSupport.completeOidcLogin:
-   - validates state, exchanges code, validates id_token (sub + email_verified)
+   - validates state/nonce, exchanges code, validates id_token (sub + email_verified)
    - looks up an IamUser by (oidcSubject, oidcConfigId)
    - if none exists: 302 /login?error=no_account so the frontend can show
                      a "no account, sign up?" CTA (signup is a separate flow)
@@ -186,7 +186,7 @@ The browser SPA never holds a JWT — its login establishes a session cookie and
 
 ## Provider-Specific Quirks
 
-OIDC is a standard, but providers diverge on a few details. The validation helpers in `OAuth2AuthFactory` (`isIssuerValid`, `isEmailVerified`) handle these declaratively — the provider key on `OidcConfiguration` selects the right behaviour. No provider needs handler-level branching.
+OIDC is a standard, but providers diverge on a few details. The validation helpers in `OAuth2Util` (`isIssuerValid`, `isEmailVerified`) handle these declaratively — the provider key on `OidcConfiguration` selects the right behaviour. No provider needs handler-level branching.
 
 | Provider key | `iss` shape | `email_verified` claim | Other notes |
 |---|---|---|---|


### PR DESCRIPTION
Replace the manual `ConcurrentHashMap`-based caching of `OAuth2Auth` instances with Caffeine's `AsyncCache`, adding automatic expiration, size limits, and proper resource cleanup.

## Summary

The `OidcFlowOrchestrator` previously cached `OAuth2Auth` instances indefinitely in a `ConcurrentHashMap`. This change introduces Caffeine's `AsyncCache` to manage the cache lifecycle with three improvements:

1. **Resource cleanup**: Each `OAuth2Auth` holds a periodic JWKS refresh timer (via `OpenIDConnectAuth.discover`). The cache now calls `close()` on evicted entries to cancel these timers and prevent leaks.
2. **Automatic expiration**: Entries expire after 1 hour of inactivity, preventing stale provider configurations from persisting indefinitely.
3. **Size bounds**: Maximum 1,000 entries prevents unbounded growth across many OIDC providers.

## Key Changes

- **Cache implementation** (`OidcFlowOrchestrator:42-49`): Replaced `ConcurrentMap<String, Future<OAuth2Auth>>` with `AsyncCache<String, OAuth2Auth>` configured with:
  - `removalListener` that calls `close()` on evicted `OAuth2Auth` instances
  - `expireAfterAccess(Duration.ofHours(1))` for automatic cleanup of unused entries
  - `maximumSize(1_000)` to bound memory usage

- **Cache key strategy** (`OidcFlowOrchestrator:248`): Changed from `config.getId()` alone to `config.getId() + ':' + config.getUpdated().getTime()`. This ensures edits to a configuration (clientId, authority, secretNameRef) bypass the cache on the next flow, since each request reads a fresh row. The superseded entry ages out naturally without requiring explicit invalidation.

- **Loader implementation** (`OidcFlowOrchestrator:251-254`): Switched from `computeIfAbsent` with manual error handling to `AsyncCache.get()` with a loader function. Caffeine automatically evicts entries whose futures complete exceptionally, preventing transient discovery failures from being cached.

- **Error handling** (`OidcFlowOrchestrator:255-256`): Removed the manual `oauth2AuthCache.remove()` call on discovery failure. Caffeine's eviction of failed futures replaces this.

## Implementation Notes

The cache key includes the `updated` timestamp to pick up configuration changes without requiring an explicit invalidation message. In a distributed system, each node reads the current row for its request, so a save misses the cache on every node independently, and the old entry ages out on its own.

The loader function returns a `CompletableFuture` (via `toCompletionStage()`) rather than a `Future`, matching Caffeine's async loader contract. The result is wrapped back into a Vert.x `Future` with the current context to maintain compatibility with the rest of the orchestrator.

https://claude.ai/code/session_01P122TqUURqmFdfawRw67ya