### PR TITLE
Pin CLI-generated projects to the CLI's own @kinotic-ai ranges

### DIFF
--- a/kinotic-js/kinotic-cli/src/internal/spawn/FileSystemSpawnEngine.ts
+++ b/kinotic-js/kinotic-cli/src/internal/spawn/FileSystemSpawnEngine.ts
@@ -1,6 +1,42 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
 import {NodeSpawnRenderer} from '@kinotic-ai/spawn/node'
 import {InquirerPropertyResolver} from './InquirerPropertyResolver'
 import {spawnResolver, SpawnResolver} from './SpawnResolver'
+
+const cliPackageJson = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../package.json')
+
+/**
+ * Turns an npm package name into the spawn global a template pins it through,
+ * dropping the scope and a kinotic- prefix on the name: @kinotic-ai/os-api
+ * becomes kinoticOsApiVersion and @kinotic-ai/kinotic-cli becomes
+ * kinoticCliVersion.
+ */
+function globalNameFor(packageName: string): string {
+  const unscoped: string = packageName.replace(/^@[^/]+\//, '').replace(/^kinotic-/, '')
+  const camelCased: string = unscoped.replace(/-(.)/g, (_, c: string) => c.toUpperCase())
+  return `kinotic${camelCased.charAt(0).toUpperCase()}${camelCased.slice(1)}Version`
+}
+
+/**
+ * The @kinotic-ai version ranges every rendered spawn is given, taken from this
+ * CLI's own dependency ranges so a generated project resolves the packages the
+ * CLI was built against, and follows along when those ranges are bumped.
+ */
+function npmPackageVersions(): Record<string, string> {
+  const pkg = JSON.parse(fs.readFileSync(cliPackageJson, 'utf8')) as
+      {name: string, version: string, dependencies: Record<string, string>}
+  const ret: Record<string, string> = {[globalNameFor(pkg.name)]: `^${pkg.version}`}
+  for (const [name, range] of Object.entries(pkg.dependencies)) {
+    if (name.startsWith('@kinotic-ai/')) {
+      ret[globalNameFor(name)] = range
+    }
+  }
+  return ret
+}
+
+const versions: Record<string, string> = npmPackageVersions()
 
 /**
  * Renders Spawns bundled with the CLI to the local filesystem, prompting on
@@ -8,6 +44,10 @@ import {spawnResolver, SpawnResolver} from './SpawnResolver'
  * the context. Resolves a spawn by name to its bundled directory and delegates
  * the disk load/render/write (and its directory-traversal guards) to
  * {@link NodeSpawnRenderer}.
+ * <p>
+ * Every render is given a version range for each @kinotic-ai package this CLI
+ * depends on, keyed by the spawn global a template pins it through
+ * ({@code kinoticCoreVersion}, {@code kinoticCliVersion}, ...).
  */
 export class FileSystemSpawnEngine {
 
@@ -29,7 +69,9 @@ export class FileSystemSpawnEngine {
   public async renderSpawn(spawn: string, destination: string, context?: Record<string, unknown>): Promise<Record<string, unknown>> {
     const source: string = await this.spawnResolver.resolveSpawn(spawn)
     return this.renderer.render(source, destination, {
-      context,
+      // The versions seed the context, so a spawn that also declares them as globals
+      // renders with this CLI's ranges instead of its own defaults.
+      context: {...versions, ...context},
       propertyResolver: new InquirerPropertyResolver()
     })
   }

--- a/kinotic-js/kinotic-cli/src/templates/spawns/project/package.json.liquid
+++ b/kinotic-js/kinotic-cli/src/templates/spawns/project/package.json.liquid
@@ -4,9 +4,12 @@
     "scripts": {
         "build": "bunup",
         "dev": "bunup --watch",
+        "generate": "kinotic generate",
         "type-check": "bun run --filter '*' type-check"
     },
     "devDependencies": {
+        "@kinotic-ai/kinotic-cli": "{{ kinoticCliVersion }}",
+        "@kinotic-ai/os-api": "{{ kinoticOsApiVersion }}",
         "@types/bun": "^1.3.10",
         "bunup": "^0.16.31",
         "typescript": "^5.9.3"

--- a/kinotic-js/kinotic-cli/src/templates/spawns/project/spawn.json
+++ b/kinotic-js/kinotic-cli/src/templates/spawns/project/spawn.json
@@ -1,7 +1,9 @@
 {
     "globals": {
-        "kinoticCoreVersion": "^1.9.1",
-        "kinoticPersistenceVersion": "^2.0.0"
+        "kinoticCliVersion": "^4.0.0",
+        "kinoticCoreVersion": "^4.0.0",
+        "kinoticOsApiVersion": "^4.0.0",
+        "kinoticPersistenceVersion": "^4.0.0"
     },
     "propertySchema":{
         "projectName": {

--- a/kinotic-js/kinotic-cli/test/internal/FileSystemSpawnEngine.test.ts
+++ b/kinotic-js/kinotic-cli/test/internal/FileSystemSpawnEngine.test.ts
@@ -2,19 +2,25 @@ import {expect} from 'chai'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import {fileSystemSpawnEngine} from '../../src/internal/spawn/FileSystemSpawnEngine.js'
+import {FileSystemSpawnEngine, fileSystemSpawnEngine} from '../../src/internal/spawn/FileSystemSpawnEngine.js'
 
 describe('FileSystemSpawnEngine', () => {
 
     it('renders the bundled project spawn to disk', async () => {
         const destination = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-test-')), 'acme')
 
-        const context = await fileSystemSpawnEngine.renderSpawn('project', destination,
+        await fileSystemSpawnEngine.renderSpawn('project', destination,
             {projectName: 'acme', organization: 'acme-org', application: 'acme-app'})
 
         const rootPackage = JSON.parse(fs.readFileSync(path.join(destination, 'package.json'), 'utf8'))
         expect(rootPackage.name).to.equal('acme')
-        expect(rootPackage.catalog['@kinotic-ai/core']).to.equal(context.kinoticApiVersion)
+
+        // the generated project pins what the CLI itself depends on, not the spawn.json globals
+        const cliPackage = JSON.parse(fs.readFileSync(path.join(import.meta.dirname, '../../package.json'), 'utf8'))
+        expect(rootPackage.catalog['@kinotic-ai/core']).to.equal(cliPackage.dependencies['@kinotic-ai/core'])
+        expect(rootPackage.catalog['@kinotic-ai/persistence']).to.equal(cliPackage.dependencies['@kinotic-ai/persistence'])
+        expect(rootPackage.devDependencies['@kinotic-ai/os-api']).to.equal(cliPackage.dependencies['@kinotic-ai/os-api'])
+        expect(rootPackage.devDependencies['@kinotic-ai/kinotic-cli']).to.equal(`^${cliPackage.version}`)
 
         const domainPackage = JSON.parse(fs.readFileSync(path.join(destination, 'packages/domain/package.json'), 'utf8'))
         expect(domainPackage.name).to.equal('acme/domain')
@@ -27,6 +33,21 @@ describe('FileSystemSpawnEngine', () => {
         expect(fs.existsSync(path.join(destination, '.gitignore'))).to.be.true
         expect(fs.existsSync(path.join(destination, 'spawn.json'))).to.be.false
         expect(fs.existsSync(path.join(destination, 'package.json.liquid'))).to.be.false
+    })
+
+    it('overrides a spawn global with the CLI dependency range', async () => {
+        const spawnDir = fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-src-'))
+        fs.writeFileSync(path.join(spawnDir, 'spawn.json'),
+            JSON.stringify({globals: {kinoticCoreVersion: '^0.0.1'}}))
+        fs.writeFileSync(path.join(spawnDir, 'core.txt.liquid'), '{{ kinoticCoreVersion }}')
+        const engine = new FileSystemSpawnEngine({resolveSpawn: async () => spawnDir})
+
+        const destination = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-test-')), 'out')
+        await engine.renderSpawn('stale', destination)
+
+        const cliPackage = JSON.parse(fs.readFileSync(path.join(import.meta.dirname, '../../package.json'), 'utf8'))
+        expect(fs.readFileSync(path.join(destination, 'core.txt'), 'utf8'))
+            .to.equal(cliPackage.dependencies['@kinotic-ai/core']).and.not.equal('^0.0.1')
     })
 
     it('renders the bundled library spawn to disk', async () => {

--- a/kinotic-js/workspace/packages/spawn/README.md
+++ b/kinotic-js/workspace/packages/spawn/README.md
@@ -218,16 +218,17 @@ The name drops the `@kinotic-ai` scope and a `kinotic-` prefix on the package
 name, so `@kinotic-ai/os-api` is `kinoticOsApiVersion` and
 `@kinotic-ai/kinotic-cli` is `kinoticCliVersion`.
 
-When the Kinotic server renders a spawn it supplies every one of these globals
-from a build-time projection of this repo's `package.json` files, and a context
-value beats a global — so a provisioned project pins the package versions that
-server ships with, whatever the spawn's own `globals` say. Keep declaring them in
-`spawn.json` anyway: the values are what `kinotic create project` renders with,
-and `lint` reports an undeclared global even when a host happens to supply it.
+Both hosts supply these globals themselves, and a context value beats a global —
+so a generated project pins the versions the host ships with, whatever the
+spawn's own `globals` say:
 
-Because the server supplies them from the packages it knows about, a spawn adding
-a global for a package that server predates falls back to the `spawn.json` value
-rather than failing to render.
+- the server, from a build-time projection of this repo's `package.json` files
+- the CLI, from its own `@kinotic-ai` dependency ranges
+
+Keep declaring them in `spawn.json` anyway. `lint` reports an undeclared global
+whatever a host supplies at render time, and the declared value is the fallback:
+a spawn adding a global for a package its host predates renders with the
+`spawn.json` value rather than failing.
 
 ## Examples in this repo
 


### PR DESCRIPTION
Stacked on #353 — base is `claude/zealous-dijkstra-adg4p7`, so the diff here is only the CLI change. #353 gave the server a version source; this gives the CLI one, and fixes the two defects that surfaced while doing it.

## The bug

`kinotic-js/kinotic-cli/src/templates/spawns/project/spawn.json`

```jsonc
"globals": {
    "kinoticCoreVersion": "^1.9.1",       // CLI itself depends on ^4.0.0
    "kinoticPersistenceVersion": "^2.0.0" // CLI itself depends on ^4.0.0
}
```

The CLI injected nothing, so those globals were the pins. `kinotic create project` generated a project against a two-major-old API — one that still expects legacy decorators.

## The fix

The CLI's own `package.json` is already an accurate, maintained record of the versions it pairs with — it compiles against them:

```jsonc
"dependencies": {
    "@kinotic-ai/core": "^4.0.0",
    "@kinotic-ai/os-api": "^4.0.0",
    "@kinotic-ai/persistence": "^4.0.0"
}
```

`FileSystemSpawnEngine` seeds every render from it, keyed by the global each package is pinned through:

```ts
return this.renderer.render(source, destination, {
  // The versions seed the context, so a spawn that also declares them as globals
  // renders with this CLI's ranges instead of its own defaults.
  context: {...versions, ...context},
  propertyResolver: new InquirerPropertyResolver()
})
```

Same shape as the server side in #353, same naming rule (`@kinotic-ai/os-api` → `kinoticOsApiVersion`, `@kinotic-ai/kinotic-cli` → `kinoticCliVersion`), and `SpawnEngine` makes seeding rather than merging the whole mechanism:

```ts
let context: Record<string, unknown> = {...globals, ...options?.context}  // context wins
```

The spawn's globals move to 4.x too — they are what `kinotic spawn lint` checks against, and the fallback for a package the host predates.

## Two adjacent defects this covers

**`.config/kinotic.config.ts` didn't resolve.** It imports `KinoticProjectConfig` from `@kinotic-ai/os-api`, which the generated `package.json` never declared, and there was no `generate` script:

```jsonc
"scripts": {
    "generate": "kinotic generate"                          // added
},
"devDependencies": {
    "@kinotic-ai/kinotic-cli": "{{ kinoticCliVersion }}",   // added
    "@kinotic-ai/os-api": "{{ kinoticOsApiVersion }}"       // added
}
```

**The test asserted nothing.** `test/internal/FileSystemSpawnEngine.test.ts:17`:

```ts
expect(rootPackage.catalog['@kinotic-ai/core']).to.equal(context.kinoticApiVersion)
// kinoticApiVersion was split into kinoticCoreVersion; no spawn declares it, so RHS is undefined
```

It fails on `develop` today:

```
AssertionError: expected '^1.9.1' to equal undefined
  at Context.<anonymous> (test/internal/FileSystemSpawnEngine.test.ts:17:60)
```

It now asserts against the CLI's declared ranges. A second test proves the override rather than assuming it, since the globals and the CLI's ranges agree today and the first test can't distinguish them:

```ts
fs.writeFileSync(path.join(spawnDir, 'spawn.json'),
    JSON.stringify({globals: {kinoticCoreVersion: '^0.0.1'}}))
```

Verified load-bearing — with the seeding removed it fails `expected '^0.0.1' to equal '^4.0.0'`.

## Verification

`bunx mocha test/internal/FileSystemSpawnEngine.test.ts` — 3 passing.

Two pre-existing failures on `develop`, untouched here and unrelated to this diff:

- `test/commands/GqlConversion.test.ts` imports `src/internal/converter/graphql/GqlConversionState.js`; there is no `graphql/` directory under `src/internal/converter/`, so the whole suite aborts with `ERR_MODULE_NOT_FOUND`.
- `tsc --noEmit`: `src/internal/CliAuthenticator.ts(125,39): error TS2345` — `refresh_token: string | null` against a `Record<string, string>` parameter.

## Not addressed

The bundled spawn has drifted from `kinotic-tpl-isomorphic-ts` in ways beyond versions, and both are maintained by hand:

- `packages/domain/package.json.liquid` renders `"name": "{{ projectName }}/domain"` → `acme/domain`, not a valid npm name. The template repo fixed this with `@{{ projectSlug }}/domain`; the CLI has no `projectSlug` in its context.
- `.config/kinotic.config.ts.liquid` sets `repositoryPath: "packages/domain/repository"` while the spawn ships `packages/domain/repositories/`.
- No root `tsconfig.json` and no `README.md.liquid`, both of which the template repo has.

Worth deciding whether the CLI should keep its own copy of the project spawn at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dxmp56HiVJM1YZvJ6YYEbH)_