### PR TITLE
Add GitHub OAuth2 provider support to OIDC flow orchestrator

### DIFF
--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/OidcFlowOrchestrator.java
@@ -5,16 +5,21 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.oauth2.*;
+import io.vertx.ext.auth.oauth2.providers.GithubAuth;
 import io.vertx.ext.auth.oauth2.providers.OpenIDConnectAuth;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
+import io.vertx.ext.web.client.WebClient;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kinotic.core.api.secret.SecretReferenceResolver;
 import org.kinotic.domain.api.model.iam.BaseOidcConfiguration;
+import org.kinotic.domain.api.model.iam.OidcProviderKind;
 import org.kinotic.domain.internal.api.rest.OidcErrorCodes;
 import org.springframework.stereotype.Component;
 
@@ -31,6 +36,11 @@ import java.util.function.Function;
  * code exchange, claim extraction, issuer validation. Handlers compose it with their
  * own per-route config resolver — the orchestrator itself knows nothing about IamUser
  * provisioning, JWT minting, or which entity table the configuration came from.
+ *
+ * <p>GitHub ({@link OidcProviderKind#GITHUB}) runs the same flow as a plain OAuth2
+ * provider: it publishes no OIDC discovery document and issues no id_token, so its
+ * identity claims are read from the GitHub REST API into the standard claim names
+ * ({@code sub}, {@code email}, {@code name}) — callers see one claims shape either way.
  */
 @Slf4j
 @Component
@@ -38,6 +48,10 @@ import java.util.function.Function;
 public class OidcFlowOrchestrator {
 
     private static final String OIDC_FLOW_SESSION_KEY = "oidcFlow";
+    private static final List<String> GITHUB_SCOPES = List.of("read:user", "user:email");
+    private static final String GITHUB_EMAILS_URL = "https://api.github.com/user/emails";
+    private static final String GITHUB_ACCEPT = "application/vnd.github+json";
+    private static final String GITHUB_USER_AGENT = "kinotic-platform";
 
     private final AsyncCache<String, OAuth2Auth> oauth2AuthCache =
             Caffeine.newBuilder()
@@ -49,11 +63,17 @@ public class OidcFlowOrchestrator {
                     .buildAsync();
     private final SecretReferenceResolver secretReferenceResolver;
     private final Vertx vertx;
+    private WebClient webClient;
+
+    @PostConstruct
+    void start() {
+        webClient = WebClient.create(vertx);
+    }
 
     /**
      * Validates the callback (state match, no IdP error), exchanges the code, validates the
-     * issuer, audience and nonce, and returns the configuration along with the verified
-     * id_token claims.
+     * identity, and returns the configuration along with the verified identity claims —
+     * id_token claims for OIDC providers, REST-derived claims under the same names for GitHub.
      * The handler decides what to do with the claims (look up an IamUser, create a
      * {@code PendingSignUp}, etc.).
      *
@@ -101,27 +121,11 @@ public class OidcFlowOrchestrator {
                              return Future.failedFuture(new OidcCallbackException(OidcErrorCodes.CONFIG_NOT_FOUND));
                          }
                          return getOAuth2Auth(config)
-                                 .compose(oauth2 -> exchangeCode(oauth2, code, callbackUrl, flowSession.pkceVerifier()))
-                                 .map(user -> {
-                                     Map<String, Object> claims = flattenClaims(user);
-                                     if (!OAuth2Util.isIssuerValid(claims, config.getAuthority())) {
-                                         log.warn("OIDC issuer validation failed for config {}: iss={}, tid={}",
-                                                  config.getId(), claims.get("iss"), claims.get("tid"));
-                                         throw new OidcCallbackException(OidcErrorCodes.INVALID_TOKEN);
-                                     }
-                                     if (!OAuth2Util.isAudienceValid(claims, config.getAudience())) {
-                                         log.warn("OIDC audience validation failed for config {}: expected={}, aud={}",
-                                                  config.getId(), config.getAudience(), claims.get("aud"));
-                                         throw new OidcCallbackException(OidcErrorCodes.INVALID_TOKEN);
-                                     }
-                                     // startFlow always sends a nonce, so OIDC Core 3.1.3.7 requires the
-                                     // id_token to echo it — an absent claim fails the equals and is rejected
-                                     if (!flowSession.nonce().equals(OAuth2Util.stringClaim(claims, "nonce"))) {
-                                         log.warn("OIDC nonce validation failed for config {}", config.getId());
-                                         throw new OidcCallbackException(OidcErrorCodes.INVALID_TOKEN);
-                                     }
-                                     return new CallbackResult<>(config, claims, flowSession.orgId(), flowSession.inviteToken());
-                                 });
+                                 .compose(oauth2 -> exchangeCode(oauth2, code, callbackUrl, flowSession.pkceVerifier())
+                                         .compose(user -> config.getProvider() == OidcProviderKind.GITHUB
+                                                 ? githubClaims(oauth2, user)
+                                                 : Future.succeededFuture(validatedIdTokenClaims(config, flowSession, user))))
+                                 .map(claims -> new CallbackResult<>(config, claims, flowSession.orgId(), flowSession.inviteToken()));
                      });
     }
 
@@ -150,71 +154,96 @@ public class OidcFlowOrchestrator {
                                     String orgId,
                                     String inviteToken) {
         String state = OAuth2Util.randomUrlSafe(32);
-        String nonce = OAuth2Util.randomUrlSafe(32);
-        String pkceVerifier = OAuth2Util.randomUrlSafe(64);
-        String pkceChallenge = OAuth2Util.s256Challenge(pkceVerifier);
-
         Session session = ctx.session();
         session.regenerateId();
-        session.put(OIDC_FLOW_SESSION_KEY, new OidcFlowSession(state, nonce, pkceVerifier, config.getId(), orgId, inviteToken));
 
-        return getOAuth2Auth(config)
-                .map(oauth2 -> oauth2.authorizeURL(
-                        new OAuth2AuthorizationURL()
-                                .setRedirectUri(callbackUrl)
-                                .setScopes(List.of("openid", "email", "profile"))
-                                .setState(state)
-                                .setCodeChallenge(pkceChallenge)
-                                .setCodeChallengeMethod("S256")
-                                .putAdditionalParameter("nonce", nonce)));
+        Future<String> ret;
+        if (config.getProvider() == OidcProviderKind.GITHUB) {
+            // GitHub issues no id_token (nothing to echo a nonce in) and does not support PKCE —
+            // the state check plus the confidential client secret protect the code exchange.
+            session.put(OIDC_FLOW_SESSION_KEY, new OidcFlowSession(state, null, null, config.getId(), orgId, inviteToken));
+            ret = getOAuth2Auth(config)
+                    .map(oauth2 -> oauth2.authorizeURL(
+                            new OAuth2AuthorizationURL()
+                                    .setRedirectUri(callbackUrl)
+                                    .setScopes(GITHUB_SCOPES)
+                                    .setState(state)));
+        } else {
+            String nonce = OAuth2Util.randomUrlSafe(32);
+            String pkceVerifier = OAuth2Util.randomUrlSafe(64);
+            String pkceChallenge = OAuth2Util.s256Challenge(pkceVerifier);
+            session.put(OIDC_FLOW_SESSION_KEY, new OidcFlowSession(state, nonce, pkceVerifier, config.getId(), orgId, inviteToken));
+            ret = getOAuth2Auth(config)
+                    .map(oauth2 -> oauth2.authorizeURL(
+                            new OAuth2AuthorizationURL()
+                                    .setRedirectUri(callbackUrl)
+                                    .setScopes(List.of("openid", "email", "profile"))
+                                    .setState(state)
+                                    .setCodeChallenge(pkceChallenge)
+                                    .setCodeChallengeMethod("S256")
+                                    .putAdditionalParameter("nonce", nonce)));
+        }
+        return ret;
     }
 
     /**
-     * @param config       the persisted OIDC configuration (must have authority set)
+     * @param config       the persisted OIDC configuration (must have authority set, except for
+     *                     GitHub whose endpoints are fixed)
      * @param clientSecret resolved client secret, or null for public-client flows
      */
     private Future<OAuth2Auth> createOAuth2Auth(BaseOidcConfiguration config, String clientSecret) {
-        if (config.getAuthority() == null || config.getAuthority().isBlank()) {
-            return Future.failedFuture(new IllegalArgumentException(
+        Future<OAuth2Auth> ret;
+        if (config.getProvider() == OidcProviderKind.GITHUB) {
+            if (clientSecret == null || clientSecret.isBlank()) {
+                // Fail here rather than at the token endpoint: GitHub has no PKCE public-client
+                // fallback, so a missing secret can never complete an exchange.
+                ret = Future.failedFuture(new IllegalArgumentException(
+                        "OidcConfiguration " + config.getId() + " resolved no client secret; required for GitHub"));
+            } else {
+                ret = Future.succeededFuture(GithubAuth.create(vertx, config.getClientId(), clientSecret));
+            }
+        } else if (config.getAuthority() == null || config.getAuthority().isBlank()) {
+            ret = Future.failedFuture(new IllegalArgumentException(
                     "OidcConfiguration " + config.getId() + " has no authority; required for OIDC discovery"));
-        }
+        } else {
+            OAuth2Options options = new OAuth2Options()
+                    .setClientId(config.getClientId())
+                    .setSite(config.getAuthority())
+                    // Microsoft /common returns a discovery doc whose `issuer` is the literal template
+                    // "https://login.microsoftonline.com/{tenantid}/v2.0" — Vert.x's strict
+                    // {site == issuer} comparison fails. JWKS-backed signature verification remains
+                    // the real security check.
+                    .setValidateIssuer(false);
+            if (clientSecret != null) {
+                options.setClientSecret(clientSecret);
+            }
 
-        OAuth2Options options = new OAuth2Options()
-                .setClientId(config.getClientId())
-                .setSite(config.getAuthority())
-                // Microsoft /common returns a discovery doc whose `issuer` is the literal template
-                // "https://login.microsoftonline.com/{tenantid}/v2.0" — Vert.x's strict
-                // {site == issuer} comparison fails. JWKS-backed signature verification remains
-                // the real security check.
-                .setValidateIssuer(false);
-        if (clientSecret != null) {
-            options.setClientSecret(clientSecret);
+            ret = OpenIDConnectAuth.discover(vertx, options)
+                                   .map(oauth -> {
+                                       if (options.getJWTOptions() != null) {
+                                           // Discovery mutates JWTOptions.issuer with the
+                                           // {tenantid}-templated string — Vert.x would then fail every
+                                           // per-JWT validation because the real JWT carries the
+                                           // substituted tid. Clear it for the multi-tenant case; we
+                                           // re-validate the issuer ourselves post-exchange using the
+                                           // JWT's signed tid claim.
+                                           String jwtIssuer = options.getJWTOptions().getIssuer();
+                                           if (jwtIssuer != null && jwtIssuer.contains("{tenantid}")) {
+                                               options.getJWTOptions().setIssuer(null);
+                                           }
+                                           // Belt-and-suspenders audience check: when configured, push
+                                           // the expected audience into Vert.x's JWTOptions so the aud
+                                           // claim is validated during token-exchange JWT processing.
+                                           // The orchestrator re-validates post-exchange so coverage
+                                           // holds across Vert.x version drift.
+                                           if (config.getAudience() != null && !config.getAudience().isBlank()) {
+                                               options.getJWTOptions().addAudience(config.getAudience());
+                                           }
+                                       }
+                                       return oauth;
+                                   });
         }
-
-        return OpenIDConnectAuth.discover(vertx, options)
-                                .map(oauth -> {
-                                    if (options.getJWTOptions() != null) {
-                                        // Discovery mutates JWTOptions.issuer with the
-                                        // {tenantid}-templated string — Vert.x would then fail every
-                                        // per-JWT validation because the real JWT carries the
-                                        // substituted tid. Clear it for the multi-tenant case; we
-                                        // re-validate the issuer ourselves post-exchange using the
-                                        // JWT's signed tid claim.
-                                        String jwtIssuer = options.getJWTOptions().getIssuer();
-                                        if (jwtIssuer != null && jwtIssuer.contains("{tenantid}")) {
-                                            options.getJWTOptions().setIssuer(null);
-                                        }
-                                        // Belt-and-suspenders audience check: when configured, push
-                                        // the expected audience into Vert.x's JWTOptions so the aud
-                                        // claim is validated during token-exchange JWT processing.
-                                        // The orchestrator re-validates post-exchange so coverage
-                                        // holds across Vert.x version drift.
-                                        if (config.getAudience() != null && !config.getAudience().isBlank()) {
-                                            options.getJWTOptions().addAudience(config.getAudience());
-                                        }
-                                    }
-                                    return oauth;
-                                });
+        return ret;
     }
 
     private Future<User> exchangeCode(OAuth2Auth oauth2, String code, String callbackUrl, String pkceVerifier) {
@@ -223,6 +252,93 @@ public class OidcFlowOrchestrator {
                                            .setCode(code)
                                            .setRedirectUri(callbackUrl)
                                            .setCodeVerifier(pkceVerifier));
+    }
+
+    /**
+     * The flattened id_token claims of {@code user}, validated against the flow: issuer,
+     * audience, and nonce. Throws {@link OidcCallbackException} on any failure, which the
+     * enclosing {@code compose} surfaces as a failed callback.
+     */
+    private Map<String, Object> validatedIdTokenClaims(BaseOidcConfiguration config, OidcFlowSession flowSession, User user) {
+        Map<String, Object> claims = flattenClaims(user);
+        if (!OAuth2Util.isIssuerValid(claims, config.getAuthority())) {
+            log.warn("OIDC issuer validation failed for config {}: iss={}, tid={}",
+                     config.getId(), claims.get("iss"), claims.get("tid"));
+            throw new OidcCallbackException(OidcErrorCodes.INVALID_TOKEN);
+        }
+        if (!OAuth2Util.isAudienceValid(claims, config.getAudience())) {
+            log.warn("OIDC audience validation failed for config {}: expected={}, aud={}",
+                     config.getId(), config.getAudience(), claims.get("aud"));
+            throw new OidcCallbackException(OidcErrorCodes.INVALID_TOKEN);
+        }
+        // startFlow always sends a nonce, so OIDC Core 3.1.3.7 requires the
+        // id_token to echo it — an absent claim fails the equals and is rejected
+        if (!flowSession.nonce().equals(OAuth2Util.stringClaim(claims, "nonce"))) {
+            log.warn("OIDC nonce validation failed for config {}", config.getId());
+            throw new OidcCallbackException(OidcErrorCodes.INVALID_TOKEN);
+        }
+        return claims;
+    }
+
+    /**
+     * Builds the standard claims map for a GitHub identity from the REST API: {@code sub} is
+     * GitHub's immutable numeric account id, {@code name}/{@code preferred_username} come from
+     * the profile, and {@code email}/{@code email_verified} are set only when GitHub reports a
+     * verified primary email — so the caller's {@link OAuth2Util#isEmailVerified} check fails
+     * closed on unverified or inaccessible emails.
+     */
+    private Future<Map<String, Object>> githubClaims(OAuth2Auth oauth2, User user) {
+        String accessToken = user.principal().getString("access_token");
+        return oauth2.userInfo(user)
+                     .compose(profile -> githubPrimaryEmail(accessToken).map(email -> {
+                         Map<String, Object> claims = new HashMap<>();
+                         // Guard against String.valueOf(null) — a literal "null" sub would collide
+                         // every malformed profile on one identity key instead of being rejected.
+                         Object id = profile.getValue("id");
+                         if (id != null) {
+                             claims.put("sub", String.valueOf(id));
+                         }
+                         String name = profile.getString("name");
+                         if (name != null && !name.isBlank()) {
+                             claims.put("name", name);
+                         }
+                         claims.put("preferred_username", profile.getString("login"));
+                         if (email != null) {
+                             claims.put("email", email);
+                             claims.put("email_verified", true);
+                         }
+                         return claims;
+                     }));
+    }
+
+    /**
+     * The user's primary email per GitHub's emails API, or {@code null} when it is unverified
+     * or the token cannot read emails. The emails endpoint is used because the profile's
+     * {@code email} field only carries an email the user chose to show publicly.
+     */
+    private Future<String> githubPrimaryEmail(String accessToken) {
+        return webClient.getAbs(GITHUB_EMAILS_URL)
+                        .putHeader("Authorization", "Bearer " + accessToken)
+                        .putHeader("Accept", GITHUB_ACCEPT)
+                        .putHeader("User-Agent", GITHUB_USER_AGENT)
+                        .send()
+                        .map(resp -> {
+                            String ret = null;
+                            if (resp.statusCode() == 200) {
+                                JsonArray emails = resp.bodyAsJsonArray();
+                                for (int i = 0; i < emails.size(); i++) {
+                                    JsonObject entry = emails.getJsonObject(i);
+                                    if (Boolean.TRUE.equals(entry.getBoolean("primary"))
+                                            && Boolean.TRUE.equals(entry.getBoolean("verified"))) {
+                                        ret = entry.getString("email");
+                                        break;
+                                    }
+                                }
+                            } else {
+                                log.warn("GitHub emails API answered {}: {}", resp.statusCode(), resp.bodyAsString());
+                            }
+                            return ret;
+                        });
     }
 
     /**
@@ -247,10 +363,10 @@ public class OidcFlowOrchestrator {
     }
 
     /**
-     * The {@link OAuth2Auth} for {@code config} as it is currently persisted, discovered against its
-     * authority on first use and cached until an hour passes with no flow using it. Saving the
-     * configuration takes effect on the next flow. A discovery that fails is not cached, so the next
-     * flow retries it.
+     * The {@link OAuth2Auth} for {@code config} as it is currently persisted, built on first use
+     * (OIDC discovery against its authority, or the fixed-endpoint factory for GitHub) and cached
+     * until an hour passes with no flow using it. Saving the configuration takes effect on the next
+     * flow. A build that fails is not cached, so the next flow retries it.
      */
     private Future<OAuth2Auth> getOAuth2Auth(BaseOidcConfiguration config) {
         // Keying on updated as well as id is what picks up an edited clientId/authority/secretNameRef:

--- a/kinotic-migration/src/main/resources/migrations/V8__github_signup_provider.sql
+++ b/kinotic-migration/src/main/resources/migrations/V8__github_signup_provider.sql
@@ -1,0 +1,18 @@
+-- GitHub as a Kinotic-curated provider for org signup and login. GitHub publishes no OIDC
+-- discovery document and issues no id_token, so OidcFlowOrchestrator branches on
+-- provider = 'github' to run its fixed OAuth2 endpoints and read the identity from the
+-- GitHub REST API (GET /user + GET /user/emails). authority/audience are absent —
+-- nothing is discovered or validated against them for this provider.
+--
+-- clientId is the OAuth client id of the Kinotic GitHub App (kinotic.github.appSlug); the
+-- client secret is resolved via SecretReferenceResolver from secretNameRef — Azure Key
+-- Vault in prod, KINOTIC_AKV_GITHUB_PLATFORM env var in dev.
+--
+-- The GitHub App registration must list both callback URLs:
+--   <apiBaseUrl>/api/auth/org/signup/social/callback/github-platform
+--   <apiBaseUrl>/api/auth/org/login/social/callback/github-platform
+-- and grant the account permission "Email addresses: Read-only" so user/emails is
+-- readable with user tokens (a classic OAuth App relies on the requested user:email
+-- scope instead).
+
+INSERT INTO kinotic_org_signup_oidc_configuration (id, name, provider, clientId, secretNameRef, enabled, created, updated) VALUES ('github-platform', 'GitHub', 'github', 'REPLACE_WITH_GITHUB_APP_CLIENT_ID', 'github-platform', true, '2026-08-01', '2026-08-01') WITH REFRESH;

--- a/website/content/02.platform/04.organization-management.md
+++ b/website/content/02.platform/04.organization-management.md
@@ -17,7 +17,7 @@ Four persistent entities carry the auth state, and one short-lived entity bridge
 
 | Entity | Purpose | Lifecycle |
 |---|---|---|
-| `OrgSignupOidcConfiguration` | A Kinotic-curated social provider (Google, Microsoft) shown as a login/signup button to everyone. Belongs to no organization | Seeded by SQL migration |
+| `OrgSignupOidcConfiguration` | A Kinotic-curated social provider (Google, Microsoft, GitHub) shown as a login/signup button to everyone. Belongs to no organization | Seeded by SQL migration |
 | `Organization` | A customer org. `ssoConfigId` names its single enterprise SSO provider, or null | Created at the end of signup |
 | `OidcConfiguration` | A provider record (clientId, authority, …) owned by one organization | Created by org admins |
 | `IamUser` | A scoped identity carried structurally by `organizationId` / `applicationId`. One row per (person, scope) | Created during signup, by invitation, or by an admin |
@@ -98,6 +98,8 @@ Email verification is the security gate — no `Organization` or `IamUser` exist
 
 The `PendingSignUp` is consumed once. The `?token=` in the redirect to `/register` is the short-lived `PendingSignUp` verification token, not an auth credential — the actual login is established by the session cookie set when the org-naming POST succeeds.
 
+GitHub follows the same steps but is not OIDC: it publishes no discovery document and issues no id_token. `OidcFlowOrchestrator` branches on `provider = "github"` to run GitHub's fixed OAuth2 endpoints — state is the CSRF protection (GitHub supports neither nonce nor PKCE; the client is confidential) — and builds the verified identity from the REST API instead of id_token claims: `sub` is the immutable numeric account id from `GET /user`, and the email comes from `GET /user/emails`, accepted only when GitHub reports the primary email verified. From step 6 on, nothing differs.
+
 ## User Login
 
 Once an org exists, members log in through one of three converging paths:
@@ -169,6 +171,8 @@ The buttons are populated from `GET /api/auth/org/login/providers`, which lists 
    connection, authenticated by that cookie.
 ```
 
+For `github` the same provider branch applies as at signup — a state-only OAuth2 flow with the identity read from the REST API — before the `(oidcSubject, oidcConfigId)` lookup runs unchanged.
+
 The email-first SSO branch (`type: "sso"`) returns to `GET /api/auth/org/login/sso/callback/:configId` instead, but finishes the same way — `establishSession` + `redirectSuccess`.
 
 ### The WebSocket upgrade (the final step in every path)
@@ -193,9 +197,10 @@ OIDC is a standard, but providers diverge on a few details. The validation helpe
 | `azure-ad` (single tenant) | Fixed `https://login.microsoftonline.com/<tenant-id>/v2.0` | Not emitted — email-presence is treated as verified (Entra verifies via tenant domain ownership) | Used by per-org SSO configs that pin to a specific Entra tenant |
 | `azure-ad` (multi-tenant `/common` or `/organizations`) | Per-user — substitutes user's home tenant id; we re-validate by extracting `tid` from the same signed JWT | Same as single-tenant — not emitted, presence trusted | Discovery doc returns a literal `{tenantid}` placeholder; we set `validateIssuer=false` and clear `jwtOptions.issuer` for this case so Vert.x's strict comparison doesn't reject |
 | `apple` | Fixed `https://appleid.apple.com` | Not emitted — presence trusted | Email is **only present on first sign-in**; later tokens omit it. Returning users are recognised by stable `sub`. May be a `…@privaterelay.appleid.com` private-relay address — still verified |
+| `github` | No `iss` — not OIDC | Synthesised — set `true` only when `GET /user/emails` reports the primary email verified | OAuth2-only: fixed endpoints, no discovery, no id_token, no nonce/PKCE. `sub` is the immutable numeric account id from `GET /user`. The GitHub App registration needs the "Email addresses: Read-only" account permission (or the `user:email` scope for a classic OAuth App) |
 | `keycloak`, `auth0`, `okta`, `salesforce`, `amazon-cognito`, `oidc` (generic) | Fixed (issuer URL of the realm/tenant) | Emitted as boolean — required `true` | Discovery + standard validation |
 
-`isEmailVerified` and `isIssuerValid` are the only places these differences live. Adding a new provider that follows the standard set of conventions doesn't require code changes; only providers with non-standard quirks (Apple's first-login-only email, Microsoft's `/common` issuer template) need to be classified explicitly in those helpers.
+For OIDC providers, `isEmailVerified` and `isIssuerValid` are the only places these differences live. Adding a new provider that follows the standard set of conventions doesn't require code changes; only providers with non-standard quirks (Apple's first-login-only email, Microsoft's `/common` issuer template) need to be classified explicitly in those helpers. GitHub is the one non-OIDC provider, so `OidcFlowOrchestrator` branches on its provider kind instead: the `GithubAuth` factory replaces discovery, and REST calls replace id_token claims.
 
 ## Per-Org SSO Configuration
 

--- a/website/content/02.platform/05.system-security.md
+++ b/website/content/02.platform/05.system-security.md
@@ -66,7 +66,7 @@ Provider configurations come in two types that share a shape but not a scope. Bo
 | `OrgSignupOidcConfiguration` | `kinotic_org_signup_oidc_configuration` | Platform-wide, unscoped | Seeded by SQL migration; not editable through the org admin UI |
 | `OidcConfiguration` | `kinotic_oidc_configuration` | Owned by one organization (`organizationId` enforced by `AbstractCrudService`) | Managed by the owning org |
 
-The Kinotic-curated social providers (Google, Microsoft) are the first type — they power the "Continue with X" buttons on org signup and org login, and they belong to no organization because signup happens before one exists. Everything an organization configures for itself is the second type.
+The Kinotic-curated social providers (Google, Microsoft, GitHub) are the first type — they power the "Continue with X" buttons on org signup and org login, and they belong to no organization because signup happens before one exists. Everything an organization configures for itself is the second type.
 
 ### Why two types rather than one with a flag
 


### PR DESCRIPTION
Extends the OIDC flow orchestrator to support GitHub as a social login/signup provider alongside standard OIDC providers (Google, Microsoft). GitHub does not publish an OIDC discovery document or issue an id_token, so the flow branches on provider kind to handle it as a plain OAuth2 provider with identity claims read from the GitHub REST API.

## Key Changes

- **Provider-specific flow branching**: `OidcFlowOrchestrator.startFlow()` and `handleCallback()` now branch on `config.getProvider() == OidcProviderKind.GITHUB` to skip nonce and PKCE (GitHub's confidential client secret provides sufficient protection) and use GitHub's fixed OAuth2 endpoints via `GithubAuth.create()`.

- **GitHub identity claims extraction**: New `githubClaims()` method calls `oauth2.userInfo()` for the profile, then `githubPrimaryEmail()` to fetch the user's verified primary email from GitHub's `/user/emails` REST endpoint. Claims are normalized to standard OIDC names (`sub`, `email`, `email_verified`, `name`, `preferred_username`) so callers see one claims shape regardless of provider.

- **Validation refactoring**: Extracted id_token validation (issuer, audience, nonce checks) into `validatedIdTokenClaims()` so the callback handler can conditionally apply it only to OIDC providers, not GitHub.

- **WebClient initialization**: Added `@PostConstruct` method to create a `WebClient` instance for GitHub REST API calls.

- **Configuration updates**: Updated `createOAuth2Auth()` to handle GitHub's fixed endpoints (no discovery needed) and fail fast if the client secret is missing (GitHub has no public-client fallback). Updated javadoc to reflect that authority/audience are not required for GitHub.

- **SQL migration**: Added `V8__github_signup_provider.sql` to seed the `github-platform` org signup provider with placeholder client ID and secret reference.

- **Documentation**: Updated platform docs to list GitHub as a curated signup provider alongside Google and Microsoft.

## Implementation Details

GitHub's `/user/emails` endpoint is called with the access token to retrieve the primary verified email, since the profile's `email` field only contains publicly-visible addresses. The email lookup is defensive: if the endpoint returns non-200 or no verified primary email exists, the `email` and `email_verified` claims are omitted and the caller's email verification gate fails closed.

The `OidcFlowSession` record now stores `null` for nonce and pkceVerifier when the provider is GitHub, avoiding unnecessary generation and validation overhead.

https://claude.ai/code/session_01GX693aCS2LRkgJHcPz1KH4