### PR TITLE
Decouple entity discovery from the project tsconfig file list

### DIFF
--- a/kinotic-js/kinotic-cli/src/internal/Utils.ts
+++ b/kinotic-js/kinotic-cli/src/internal/Utils.ts
@@ -56,7 +56,9 @@ function getEntityDecoratorIfExists(node: Node){
 }
 
 export function pathToTsGlobPath(path: string): string{
-    return path.endsWith('.ts') ? path : (path.endsWith('/') ? path + '*.ts' : path + '/*.ts')
+    // Recursive so nested entity folders (mirrorFolderStructure) are found without
+    // relying on the tsconfig include globs.
+    return path.endsWith('.ts') ? path : (path.endsWith('/') ? path + '**/*.ts' : path + '/**/*.ts')
 }
 
 export function createTsMorphProject(): Project {
@@ -64,8 +66,13 @@ export function createTsMorphProject(): Project {
     if(!fs.existsSync(tsConfigFilePath)){
         throw new Error(`No tsconfig.json found in working directory: ${process.cwd()}`)
     }
+    // The tsconfig supplies compilerOptions only. Source files are added explicitly
+    // from the configured entitiesPaths, and the TypeScript program pulls in their
+    // transitive imports on its own — so generation cost scales with the number of
+    // entities, not with how much other code the tsconfig includes.
     return new Project({
        tsConfigFilePath: tsConfigFilePath,
+       skipAddingFilesFromTsConfig: true,
        manipulationSettings: {
            indentationText: IndentationText.TwoSpaces
        }

--- a/kinotic-js/kinotic-cli/test/internal/EntityCodeGenerationService.test.ts
+++ b/kinotic-js/kinotic-cli/test/internal/EntityCodeGenerationService.test.ts
@@ -61,6 +61,8 @@ describe('EntityCodeGenerationService', () => {
         fs.mkdirSync(path.join(projectDir, 'src/model'), {recursive: true})
         fs.mkdirSync(path.join(projectDir, 'src/repository'), {recursive: true})
         fs.writeFileSync(path.join(projectDir, 'src/model/Todo.ts'), ENTITY_SOURCE)
+        // No "files"/"include" on purpose: generation reads compilerOptions from the
+        // tsconfig but must discover entities from entitiesPaths alone.
         fs.writeFileSync(path.join(projectDir, 'tsconfig.json'), JSON.stringify({
             compilerOptions: {
                 target: 'esnext',
@@ -69,7 +71,7 @@ describe('EntityCodeGenerationService', () => {
                 experimentalDecorators: true,
                 skipLibCheck: true
             },
-            include: ['src/**/*']
+            files: []
         }))
 
         projectConfig.applicationId = 'my.app'
@@ -116,6 +118,22 @@ describe('EntityCodeGenerationService', () => {
 
         expect(readIfExists('src/repository/TodoRepository.ts'), 'Repository').to.not.be.null
         expect(readIfExists('src/repository/generated/BaseTodoRepository.ts'), 'Base Repository').to.not.be.null
+    })
+
+    it('discovers entities in nested folders and mirrors the folder structure', async () => {
+        fs.mkdirSync(path.join(projectDir, 'src/model/billing'), {recursive: true})
+        fs.writeFileSync(path.join(projectDir, 'src/model/billing/Invoice.ts'), ENTITY_SOURCE.replace(/Todo/g, 'Invoice'))
+        projectConfig.entitiesPaths = [{
+            path: 'src/model',
+            repositoryPath: 'src/repository',
+            mirrorFolderStructure: true
+        }]
+
+        await generate()
+
+        expect(readIfExists('.config/c3/entities/my.app.Invoice.json'), 'nested entity C3Type json').to.not.be.null
+        expect(readIfExists('src/repository/billing/InvoiceRepository.ts'), 'nested Repository').to.not.be.null
+        expect(readIfExists('src/repository/billing/generated/BaseInvoiceRepository.ts'), 'nested Base Repository').to.not.be.null
     })
 
     it('writes the named queries json and removes it once the last query is deleted', async () => {


### PR DESCRIPTION
## What

`kinotic generate` no longer depends on the project root tsconfig's `include` globs. The tsconfig contributes `compilerOptions` only; source files enter the generation program solely from `entitiesPaths`.

```ts
// kinotic-js/kinotic-cli/src/internal/Utils.ts
return new Project({
   tsConfigFilePath: tsConfigFilePath,
   skipAddingFilesFromTsConfig: true,   // <- tsconfig supplies compilerOptions only
   ...
})
```

```ts
export function pathToTsGlobPath(path: string): string{
    return path.endsWith('.ts') ? path : (path.endsWith('/') ? path + '**/*.ts' : path + '/**/*.ts')
    //                                                                 ^ recursive; was <path>/*.ts (top level only)
}
```

## Why

The old glob was non-recursive, so nested entity folders — which `mirrorFolderStructure: true` exists to support — were only discovered because the template's root tsconfig happened to include them. This silently skipped entities when the globs weren't mirrored:

```ts
// packages/domain/model/billing/Invoice.ts — @Entity, but never generated
// unless the root tsconfig contained "include": ["packages/domain/model/**/*"]
```

It also meant the tsconfig file list was loaded wholesale into the ts-morph program, so generation cost grew with everything the tsconfig included (UI, microservices) rather than with the number of entities. Type resolution is unaffected: the TypeScript program pulls in transitive imports of the entity files on its own.

The repository file consumed by named-query processing is already added explicitly (`EntityCodeGenerationService.ts` → `addSourceFileAtPath(entityServicePath)`), so nothing else relied on tsconfig-added files.

## Tests

- Fixture tsconfig now has `"files": []` and no `include`, locking in that discovery works without a tsconfig file list.
- New test: nested entity (`src/model/billing/Invoice.ts`) with `mirrorFolderStructure: true` — fails against the old glob with `nested entity C3Type json: expected null not to be null`, passes with this change.
- Verified end-to-end with the built CLI against a rendered `kinotic-tpl-isomorphic-ts` project: top-level and nested entities generate; a deliberately non-type-checking file in `packages/microservices/` has no effect despite the root tsconfig including `packages/**/*`.

Companion template cleanup (root tsconfig drops the mirrored globs): kinotic-ai/kinotic-tpl-isomorphic-ts#5 — backward compatible with currently published CLIs, safe to merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pfUEHkWYPqt9g6WWrTQHG