### PR TITLE
Bump kinotic-cli to 5.1.0

### DIFF
--- a/kinotic-js/kinotic-cli/package.json
+++ b/kinotic-js/kinotic-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kinotic-ai/kinotic-cli",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "description": "Kinotic CLI provides the ability to build, deploy, and manage Kinotic applications that run on the Kinotic OS.",
     "author": "Kinotic Developers",
     "bin": {


### PR DESCRIPTION
## What

```jsonc
// kinotic-js/kinotic-cli/package.json
"version": "5.1.0"   // was 5.0.0, which is already published
```

The entity-discovery change from #357 (merged) ships as 5.1.0.

Note on the template: `kinotic-tpl-isomorphic-ts` pins `"@kinotic-ai/kinotic-cli": "^5.0.0"`, which ranges to 5.1.0 automatically once published — the pin is deliberately left alone so projects created before the npm publish still install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pfUEHkWYPqt9g6WWrTQHG

---
_Generated by [Claude Code](https://claude.ai/code/session_014pfUEHkWYPqt9g6WWrTQHG)_