### PR TITLE
Support MCP OAuth probe requests and document allowed clients

### DIFF
--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/iam/KinoticSecurityService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/iam/KinoticSecurityService.java
@@ -72,12 +72,19 @@ public class KinoticSecurityService implements SecurityService {
         }
 
         String authHeader = authInfo.get("Authorization");
+        String email = authInfo.get("clientId");
+        String password = authInfo.get("clientSecret");
 
         Future<Participant> ret;
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             ret = authenticateKinoticJwt(authHeader.substring(7));
+        } else if (email != null || password != null) {
+            ret = authenticateEmailPassword(organizationId, applicationId, email, password);
         } else {
-            ret = authenticateEmailPassword(organizationId, applicationId, authInfo);
+            // MCP hosts probe POST /mcp with no credentials to collect the RFC 9728 challenge, so
+            // this is a routine step of the OAuth flow rather than a malformed credential attempt
+            ret = Future.failedFuture(new AuthenticationException(
+                    "Authorization Bearer token, or clientId and clientSecret headers, are required"));
         }
         return ret;
     }
@@ -95,10 +102,8 @@ public class KinoticSecurityService implements SecurityService {
      */
     private Future<Participant> authenticateEmailPassword(String organizationId,
                                                           String applicationId,
-                                                          Map<String, String> authInfo) {
-        String email = authInfo.get("clientId");
-        String password = authInfo.get("clientSecret");
-
+                                                          String email,
+                                                          String password) {
         if (email == null || password == null) {
             return Future.failedFuture(new AuthenticationException("clientId and clientSecret headers are required for credential authentication"));
         }

--- a/kinotic-server/src/main/resources/application.yml
+++ b/kinotic-server/src/main/resources/application.yml
@@ -5,7 +5,10 @@ kinotic:
       # Clients permitted to start an authorization-code flow, by Client ID Metadata Document URL.
       # Listing any client closes the endpoint to every client not listed.
       allowedClientIds:
+        # Claude Code
         - https://claude.ai/oauth/claude-code-client-metadata
+        # Claude web, desktop, and mobile custom connectors
+        - https://claude.ai/oauth/mcp-oauth-client-metadata
   github:
     appId: 3584018
     appSlug: kinotic-ai

--- a/website/content/02.platform/05.system-security.md
+++ b/website/content/02.platform/05.system-security.md
@@ -125,6 +125,13 @@ Validation, per the draft: the URL must be `https` with a path component and no 
 
 `kinotic.domain.oauth.allowedClientIds` lists the document URLs that may start a flow, and is required — a deployment names the clients it accepts or fails to start. A `client_id` that is not listed is rejected, so clients are onboarded explicitly, the deployment pattern of §6.10. A host that validates against the rules above still needs its document URL added before it can connect.
 
+Each Anthropic surface presents its own document URL, and kinotic-server ships both:
+
+| Client | `client_id` |
+| --- | --- |
+| Claude Code | `https://claude.ai/oauth/claude-code-client-metadata` |
+| Claude web, desktop, and mobile custom connectors | `https://claude.ai/oauth/mcp-oauth-client-metadata` |
+
 ## Bootstrap
 
 `kinotic-migration` runs to completion before kinotic-server starts. Migrations are versioned SQL applied once per version: `V1__init.sql` creates the Elasticsearch indices, and `V2__kinotic_data_inserts.sql` seeds the curated social providers into `kinotic_org_signup_oidc_configuration`. A migration whose filename carries environment suffixes — `V3__kinotic_test_users.development.test.sql` — is applied only in those environments, which is how test fixtures stay out of production.

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -74,7 +74,7 @@ The issued token's `sub` is the user who approved the consent, so the host acts 
 }
 ```
 
-There is no registration endpoint. Dynamic Client Registration (RFC 7591) is not supported: a `client_id` is the HTTPS URL of the client's own metadata document, which the gateway fetches and validates per authorization request.
+There is no registration endpoint. Dynamic Client Registration (RFC 7591) is not supported: a `client_id` is the HTTPS URL of the client's own metadata document, which the gateway fetches and validates per authorization request. That URL must appear in `kinotic.domain.oauth.allowedClientIds`, which ships with the document URLs of [Claude Code and the Claude connectors](/platform/system-security#client-identity-is-a-domain-not-a-string); a host whose URL is absent gets `400 {"error":"invalid_request"}` from `/api/auth/oauth/authorize`.
 
 **Static headers** — for agent frameworks and scripts that can attach headers: `clientId`/`clientSecret` (plus `organizationId`/`applicationId` to select a scope), or `Authorization: Bearer <kinotic-jwt>`. A bearer token takes its scope from the token's own claims, which are not cross-checked against any scope headers sent alongside it.
 


### PR DESCRIPTION
## Summary

Refactors OAuth authentication to distinguish between credential-based and token-based flows, and documents the two Claude client URLs that ship as allowed OAuth clients.

## Changes

**kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/iam/KinoticSecurityService.java**

The `authenticate` method now routes requests based on the presence of credentials:

```java
// Before: always passed authInfo map to authenticateEmailPassword
ret = authenticateEmailPassword(organizationId, applicationId, authInfo);

// After: checks for Bearer token first, then credential headers
if (authHeader != null && authHeader.startsWith("Bearer ")) {
    ret = authenticateKinoticJwt(authHeader.substring(7));
} else if (email != null || password != null) {
    ret = authenticateEmailPassword(organizationId, applicationId, email, password);
} else {
    ret = Future.failedFuture(new AuthenticationException(
            "Authorization Bearer token, or clientId and clientSecret headers, are required"));
}
```

The `authenticateEmailPassword` method signature changed to accept `email` and `password` as separate parameters instead of the full `authInfo` map, moving extraction logic to the caller. This allows the method to be called only when credentials are actually present, rather than always attempting extraction.

The new else branch explicitly rejects requests with no credentials and documents why: MCP hosts probe POST /mcp with no credentials to collect the RFC 9728 challenge as part of the OAuth flow, so this is routine rather than malformed.

**kinotic-server/src/main/resources/application.yml**

Added the second Claude client URL to `allowedClientIds`:

```yaml
allowedClientIds:
  # Claude Code
  - https://claude.ai/oauth/claude-code-client-metadata
  # Claude web, desktop, and mobile custom connectors
  - https://claude.ai/oauth/mcp-oauth-client-metadata
```

**website/content/02.platform/05.system-security.md**

Added a table documenting the two shipped client URLs and their purposes, and clarified in the MCP tools documentation that unlisted client URLs receive `400 {"error":"invalid_request"}` from `/api/auth/oauth/authorize`.

## Implementation Details

The refactor preserves the existing validation logic (both email and password required) while making the control flow explicit: requests without credentials now fail immediately with a clear error message rather than attempting to extract null values and failing downstream. This supports the MCP OAuth probe pattern where clients send unauthenticated requests to discover the authorization endpoint.

https://claude.ai/code/session_01GMmWLSGyuEFhRiryPqN1f6