### PR TITLE
Return to the requested page after a social login

### DIFF
--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
@@ -45,6 +45,13 @@ public class AuthEndpointSupport {
     /** Access-token TTL for OAuth-issued tokens; clients refresh via the rotating refresh token. */
     private static final int ACCESS_TOKEN_TTL_SECONDS = 3600;
 
+    /**
+     * Session key holding the SPA path a completed social login returns to, placed by
+     * {@link #handleSocialStart} and consumed by {@link #redirectSuccess}. Carried on the session
+     * because IdP redirect URIs are registered exactly, so it cannot ride in the callback URL.
+     */
+    private static final String RETURN_PATH_SESSION_KEY = "loginReturnPath";
+
     private final KinoticDomainProperties domainProperties;
     private final KinoticJwtIssuer jwtIssuer;
     private final OrgSignupOidcConfigurationService orgSignupOidcConfigurationService;
@@ -96,14 +103,32 @@ public class AuthEndpointSupport {
     // ── Redirects ─────────────────────────────────────────────────────────────
 
     /**
-     * Establishes the browser session and redirects to the SPA. No token travels in the URL —
-     * the browser is authenticated by its session cookie.
+     * Establishes the browser session and redirects to the SPA — to the path the login started
+     * from when there was one, otherwise the SPA root. No token travels in the URL — the browser
+     * is authenticated by its session cookie.
      */
     public void redirectSuccess(RoutingContext ctx, IamUser user) {
+        // read before establishSession, which regenerates the session id
+        String returnPath = ctx.session().remove(RETURN_PATH_SESSION_KEY);
         establishSession(ctx, user);
         ctx.response().setStatusCode(302)
-           .putHeader("Location", appUrl("/"))
+           .putHeader("Location", appUrl(returnPath != null ? returnPath : "/"))
            .end();
+    }
+
+    /**
+     * The SPA path a completed login returns to, or {@code null} when the request named none or
+     * named one that is not a path within the SPA.
+     */
+    private static String safeReturnPath(String referer) {
+        String ret = null;
+        // concatenated onto appBaseUrl, so a value that could open an authority ("//host") or
+        // break out of the Location header is dropped rather than sanitized
+        if (referer != null && referer.startsWith("/") && !referer.startsWith("//")
+                && referer.indexOf('\\') < 0 && referer.chars().noneMatch(Character::isISOControl)) {
+            ret = referer;
+        }
+        return ret;
     }
 
     /** {@code 302 Location: <appBaseUrl><errorPath>?error=<code>}. */
@@ -244,6 +269,9 @@ public class AuthEndpointSupport {
      * Kinotic-curated configuration for that provider kind and redirects the browser to its IdP,
      * writing a {@code 400} for an unknown or disabled provider. The caller supplies the callback
      * URL the IdP returns to, which is what distinguishes a signup start from a login start.
+     * <p>
+     * A {@code referer} query parameter naming a path within the SPA is where the browser lands
+     * once the flow completes.
      */
     public void handleSocialStart(RoutingContext ctx, Function<String, String> callbackUrl) {
         String provider = ctx.pathParam("provider");
@@ -254,6 +282,8 @@ public class AuthEndpointSupport {
             respondError(ctx, 400, "Unknown platform provider: " + provider);
             return;
         }
+
+        String returnPath = safeReturnPath(ctx.request().getParam("referer"));
 
         Future.fromCompletionStage(orgSignupOidcConfigurationService.findEnabledByProvider(providerKind))
               .compose(config -> {
@@ -266,6 +296,10 @@ public class AuthEndpointSupport {
               .onSuccess(url -> {
                   // null means the compose above already answered the unknown-provider case
                   if (url != null) {
+                      if (returnPath != null) {
+                          // written after startFlow, which regenerates the session id
+                          ctx.session().put(RETURN_PATH_SESSION_KEY, returnPath);
+                      }
                       ctx.response().setStatusCode(302).putHeader("Location", url).end();
                   }
               })

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
@@ -133,6 +133,9 @@ public class AuthEndpointSupport {
 
     /** {@code 302 Location: <appBaseUrl><errorPath>?error=<code>}. */
     public void redirectError(RoutingContext ctx, String errorCode) {
+        // the flow that stored a return path ends here, so it must not outlive it and send an
+        // unrelated later login somewhere the user never asked for
+        ctx.session().remove(RETURN_PATH_SESSION_KEY);
         ctx.response().setStatusCode(302)
            .putHeader("Location", appUrl("/login")
                    + "?error=" + URLEncoder.encode(errorCode, StandardCharsets.UTF_8))
@@ -296,9 +299,13 @@ public class AuthEndpointSupport {
               .onSuccess(url -> {
                   // null means the compose above already answered the unknown-provider case
                   if (url != null) {
+                      // written after startFlow, which regenerates the session id. each start
+                      // defines where its own flow lands, so a path a previous one abandoned at
+                      // the IdP is replaced rather than inherited
                       if (returnPath != null) {
-                          // written after startFlow, which regenerates the session id
                           ctx.session().put(RETURN_PATH_SESSION_KEY, returnPath);
+                      } else {
+                          ctx.session().remove(RETURN_PATH_SESSION_KEY);
                       }
                       ctx.response().setStatusCode(302).putHeader("Location", url).end();
                   }

--- a/kinotic-frontend/src/pages/login/LoginPage.vue
+++ b/kinotic-frontend/src/pages/login/LoginPage.vue
@@ -8,7 +8,7 @@
           v-for="provider in providers"
           :key="provider"
           :provider="provider"
-          :action="apiUrl('/api/auth/org/login/social/start/' + provider)"
+          :action="socialStartUrl(provider)"
           intent="sign-in"
         />
         <div class="login-divider"><span>or</span></div>
@@ -95,6 +95,17 @@ onMounted(async () => {
   await loadProviders()
   nextTick(() => focusEmailInput())
 })
+
+/**
+ * The gateway endpoint that starts a social login, carrying the router guard's `referer` so the
+ * gateway can send the browser back there. The password path navigates client side, but a social
+ * login leaves the SPA entirely and returns through a gateway redirect.
+ */
+function socialStartUrl(provider: string): string {
+  const url = apiUrl('/api/auth/org/login/social/start/' + provider)
+  const referer = route.query.referer as string | undefined
+  return referer ? `${url}?referer=${encodeURIComponent(referer)}` : url
+}
 
 /** Every auth flow (login, signup, invite) redirects here with ?error=<code> on failure. */
 function consumeUrlError() {

--- a/website/content/02.platform/04.organization-management.md
+++ b/website/content/02.platform/04.organization-management.md
@@ -161,10 +161,14 @@ The SPA never exchanges the password for a token and never sends raw passwords o
 The buttons are populated from `GET /api/auth/org/login/providers`, which lists the unique provider keys present in the platform social configs (the invite-hint UI on `MembersPage` reads the same endpoint). Clicking a button:
 
 ```text
-1. POST /api/auth/org/login/social/start/github
+1. POST /api/auth/org/login/social/start/github?referer=<spa-path>
+   - the router guard bounced an unauthenticated navigation to /login?referer=<spa-path>,
+     and the login page forwards it here; a social login leaves the SPA, so the path
+     cannot be kept client side the way the password path keeps it
 2. OrganizationLoginHandler.handleSocialStart:
    - finds the platform OidcConfiguration with provider="github"
      (orgSignupOidcConfigurationService.findEnabledByProvider)
+   - stores referer on the session when it names a path within the SPA
    - same state/nonce/PKCE setup as signup, then 302 to the IdP
 3. IdP returns to GET /api/auth/org/login/social/callback/<configId>
 4. OrganizationLoginHandler.handleSocialCallback → AuthEndpointSupport.completeOidcLogin:
@@ -173,8 +177,9 @@ The buttons are populated from `GET /api/auth/org/login/providers`, which lists 
    - if none exists: 302 /login?error=no_account so the frontend can show
                      a "no account, sign up?" CTA (signup is a separate flow)
    - if one exists (matched by (oidcSubject, oidcConfigId) at org scope):
-       establishSession(ctx, user), then redirectSuccess → 302 to the SPA root
-       with Set-Cookie. No token travels in the URL.
+       establishSession(ctx, user), then redirectSuccess → 302 to the stored
+       referer, or the SPA root when the flow stored none, with Set-Cookie.
+       No token travels in the URL.
 5. The SPA loads with the session cookie set; userState.login() opens the realtime
    connection, authenticated by that cookie.
 ```


### PR DESCRIPTION
Follow-up to #363, which landed the `client_id` allowlist and auth-message fixes. This commit was pushed after that branch was deleted, so it missed the merge.

## The bug

Connecting an MCP host while signed out never reaches the consent page. The router guard bounces the navigation to `/login?referer=/oauth/consent?request_id=…`, but signing in with GitHub lands on `/applications` instead of returning to the consent page. Signing in first, then connecting, works — which is what narrows it to the login redirect.

Only the password path acted on `referer`, because it stays inside the SPA:

```ts
// LoginPage.vue:170-171
const referer = (route.query.referer as string | undefined) || '/applications'
await CONTINUUM_UI.navigate(referer)
```

The social button is a form post to the gateway, so the browser leaves the SPA and `referer` stays behind in the address bar. The gateway then had one destination for every completed OIDC login:

```java
// AuthEndpointSupport.redirectSuccess — before
ctx.response().setStatusCode(302)
   .putHeader("Location", appUrl("/"))     // → /applications, every time
   .end();
```

## The change

The path cannot ride in the callback URL — IdP redirect URIs are registered exactly — so it travels on the session, the same way `OidcFlowSession.inviteToken` already does.

- `LoginPage.vue` forwards `referer` to `/api/auth/org/login/social/start/:provider`.
- `handleSocialStart` stores it on the session before redirecting to the IdP.
- `redirectSuccess` consumes it, falling back to the SPA root.

Only a path within the SPA is accepted, since the value is concatenated onto `appBaseUrl` to build the `Location` header:

```java
// referer=//evil.com → dropped (would open an authority)
if (referer != null && referer.startsWith("/") && !referer.startsWith("//")
        && referer.indexOf('\\') < 0 && referer.chars().noneMatch(Character::isISOControl)) {
```

`InviteHandler` also calls `redirectSuccess` and stores nothing, so it keeps landing on `/` — unchanged.

## Verification

`:kinotic-domain:compileJava` and `vue-tsc -b` both pass. The walkthrough at `website/content/02.platform/04.organization-management.md:164` described the old redirect and is updated in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMmWLSGyuEFhRiryPqN1f6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMmWLSGyuEFhRiryPqN1f6)_