### PR TITLE
Distinguish Deny from Approve on the OAuth consent page

### DIFF
--- a/kinotic-frontend/src/pages/login/OAuthConsent.vue
+++ b/kinotic-frontend/src/pages/login/OAuthConsent.vue
@@ -21,15 +21,17 @@
         <Button
           label="Approve"
           class="login-submit"
-          :loading="deciding"
-          @click="decide(true)"
+          :loading="deciding === 'approve'"
+          :disabled="deciding !== null"
+          @click="decide('approve')"
         />
         <Button
           label="Deny"
           class="login-submit consent-deny"
           severity="secondary"
-          :loading="deciding"
-          @click="decide(false)"
+          :loading="deciding === 'deny'"
+          :disabled="deciding !== null"
+          @click="decide('deny')"
         />
       </div>
     </div>
@@ -65,9 +67,12 @@ const oauthApproval = (Kinotic as unknown as { oauthApproval: OAuthApprovalProxy
  * (`/oauth/consent?request_id=<id>`); the signed-in user approves or denies, and either
  * decision returns the client's redirect URL this page navigates to.
  */
+type Decision = 'approve' | 'deny'
+
 const pending = ref<PendingOAuthAuthorization | null>(null)
 const failed = ref<string | null>(null)
-const deciding = ref(false)
+// which decision is in flight, so only the clicked button shows its spinner
+const deciding = ref<Decision | null>(null)
 
 const loginBackgroundArt = loginPageLeft
 const route = useRoute()
@@ -96,18 +101,18 @@ onMounted(async () => {
   }
 })
 
-async function decide(approve: boolean) {
+async function decide(decision: Decision) {
   const id = requestId.value
   if (!id) return
-  deciding.value = true
+  deciding.value = decision
   try {
-    const redirectUrl = approve
+    const redirectUrl = decision === 'approve'
       ? await oauthApproval.approve(id)
       : await oauthApproval.deny(id)
     window.location.href = redirectUrl
   } catch (err) {
     failed.value = err instanceof Error ? err.message : 'Could not complete the authorization'
-    deciding.value = false
+    deciding.value = null
   }
 }
 </script>
@@ -128,7 +133,18 @@ async function decide(approve: boolean) {
   font-family: monospace;
 }
 
-.consent-deny {
+/* Deny is the secondary action, but .login-submit in auth-pages.css paints the primary fill at
+ * a specificity PrimeVue's secondary severity cannot beat. Scoping adds the data-v attribute,
+ * which wins, and the surface matches the social buttons on the other auth pages. */
+.consent-deny.p-button {
   margin-top: 0.75rem;
+  background: var(--lp-provider-bg);
+  border: 1px solid var(--lp-provider-border);
+  color: var(--lp-provider-color);
+}
+
+.consent-deny.p-button:hover {
+  background: var(--lp-provider-bg-hover);
+  border-color: var(--lp-provider-border-hover);
 }
 </style>


### PR DESCRIPTION
Two defects on `/oauth/consent`, found while walking an MCP host through the authorization-code flow. Both are in `OAuthConsent.vue`; no server change.

## Clicking one button acted on both

```vue
<!-- before — one flag, two buttons -->
<Button label="Approve" class="login-submit"              :loading="deciding" @click="decide(true)" />
<Button label="Deny"    class="login-submit consent-deny" :loading="deciding" @click="decide(false)" />
```

`deciding` is a single boolean, so approving spun Deny's spinner too and disabled both — the page gave no indication of which decision was taken while the STOMP call was in flight.

```ts
// after — the flag records which decision is running
type Decision = 'approve' | 'deny'
const deciding = ref<Decision | null>(null)

:loading="deciding === 'approve'"   // only the clicked button spins
:disabled="deciding !== null"       // the other is blocked, not spinning
```

`decide` takes the `Decision` rather than a boolean, so the call site reads as the outcome it requests.

## Deny rendered as a second Approve

`severity="secondary"` sets PrimeVue's secondary tokens, but the shared class overrides them at a specificity those tokens cannot reach:

```css
/* auth-pages.css:155-162 — applies to both buttons */
.login-submit.p-button {
  background: var(--p-primary-500);
  color: #ffffff;
}
```

So the page offered two identical primary buttons for opposite outcomes. The scoped rule adds the `data-v` attribute, which wins, and dresses Deny in the neutral surface the social buttons already use on these pages — so it stays theme-aware in light and dark:

```css
.consent-deny.p-button {
  background: var(--lp-provider-bg);
  border: 1px solid var(--lp-provider-border);
  color: var(--lp-provider-color);
}
```

## Verification

`vue-tsc -b` passes. The tokens are defined for both themes at `KinoticPreset.ts:372-376` (light) and `:402-406` (dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMmWLSGyuEFhRiryPqN1f6

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMmWLSGyuEFhRiryPqN1f6)_