### PR TITLE
Replace inline docker login with docker/login-action

### DIFF
--- a/.github/actions/load-staged-images/action.yml
+++ b/.github/actions/load-staged-images/action.yml
@@ -16,8 +16,11 @@ runs:
   using: composite
   steps:
     - name: Log in to GitHub Container Registry
-      shell: bash
-      run: echo "${{ inputs.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.token }}
 
     # Both compose files pin kinoticai/<name>:${kinoticVersion} with pull_policy: missing, so the
     # local tag applied here is what the stack resolves — no registry lookup, no chance of picking up

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -57,11 +57,17 @@ jobs:
       - name: Build migration image
         run: ./gradlew :kinotic-migration:bootBuildImage
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Stage migration image on ghcr.io
         run: |
           version=$(grep -E '^kinoticVersion=' gradle.properties | cut -d= -f2)
           staged="ghcr.io/${{ github.repository_owner }}/kinotic-migration:sha-${{ github.sha }}"
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           docker tag "kinoticai/kinotic-migration:${version}" "$staged"
           docker push "$staged"
 
@@ -97,11 +103,17 @@ jobs:
       - name: Build server image
         run: ./gradlew :kinotic-server:bootBuildImage
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Stage server image on ghcr.io
         run: |
           version=$(grep -E '^kinoticVersion=' gradle.properties | cut -d= -f2)
           staged="ghcr.io/${{ github.repository_owner }}/kinotic-server:sha-${{ github.sha }}"
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           docker tag "kinoticai/kinotic-server:${version}" "$staged"
           docker push "$staged"
 
@@ -357,19 +369,36 @@ jobs:
     permissions:
       contents: read
       packages: read
+    env:
+      # Both registry logins and the promotion itself gate on this, so it is expressed once here
+      # rather than repeated on three steps. Deliberately independent of the publish job: a Sonatype
+      # outage should not hold back an image every suite has already validated. The ref guard keeps a
+      # workflow_dispatch run on some other branch from advancing the published tag to a build off
+      # that branch.
+      PROMOTE: ${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && needs.migration_image.result == 'success' && needs.build.result == 'success' && needs.kinotic_test.result == 'success' && needs.js_workspace_tests.result == 'success' && needs.e2e_tests.result == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      # Deliberately independent of the publish job: a Sonatype outage should not hold back an image
-      # every suite has already validated. The ref guard keeps a workflow_dispatch run on some other
-      # branch from advancing the published tag to a build off that branch.
+      - name: Log in to GitHub Container Registry
+        if: ${{ env.PROMOTE == 'true' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: ${{ env.PROMOTE == 'true' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
       - name: Promote validated images to Docker Hub
-        if: ${{ (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') && needs.migration_image.result == 'success' && needs.build.result == 'success' && needs.kinotic_test.result == 'success' && needs.js_workspace_tests.result == 'success' && needs.e2e_tests.result == 'success' }}
+        if: ${{ env.PROMOTE == 'true' }}
         run: |
           version=$(grep -E '^kinoticVersion=' gradle.properties | cut -d= -f2)
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-          echo "${{ secrets.DOCKER_HUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_HUB_USERNAME }}" --password-stdin
           for image in kinotic-migration kinotic-server; do
             staged="ghcr.io/${{ github.repository_owner }}/${image}:sha-${{ github.sha }}"
             docker pull "$staged"


### PR DESCRIPTION
Replaces inline `docker login` commands with the official `docker/login-action@v4` GitHub Action across the CI/CD pipeline.

**Changes:**

- **gradle-build.yml**: Replaced three inline `docker login` invocations (migration image staging, server image staging, and image promotion) with dedicated `docker/login-action` steps for GHCR and Docker Hub
- **load-staged-images/action.yml**: Replaced inline `docker login` with `docker/login-action` for GHCR authentication
- **Promotion logic refactoring**: Extracted the complex promotion condition into a reusable `PROMOTE` environment variable in the `promote_images` job, eliminating duplication across three separate steps (GHCR login, Docker Hub login, and promotion run)

**Implementation details:**

The promotion condition — gating on `develop`/`main` branch and all upstream job success — was previously repeated inline on the promotion step. It now lives in `env.PROMOTE` at the job level, allowing both registry login steps to gate on the same condition without duplication. This keeps the condition definition in one place and makes the intent clearer: login only when promotion will actually occur.

The `docker/login-action` approach is more secure (credentials never appear in shell history or logs) and aligns with GitHub Actions best practices.

https://claude.ai/code/session_0159HmWLxazNJnhCRg3uoB3K