### PR TITLE
Mint MCP tool names as a base 36 XXHash128

### DIFF
--- a/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.kinotic.java-common-conventions.gradle
@@ -129,6 +129,7 @@ dependencyManagement {
         dependency "jakarta.json:jakarta.json-api:${jakartaJsonVersion}"
 
         dependency "net.openhft:chronicle-map:${chronicleMapVersion}"
+        dependency "net.openhft:zero-allocation-hashing:${zeroAllocationHashingVersion}"
 
         dependency "org.antlr:antlr4:${antlrVersion}"
         dependency "org.antlr:antlr4-runtime:${antlrVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,3 +45,4 @@ testContainersVersion=2.0.3
 vertxJackson3CodecVersion=0.1.0
 vertxStompLiteVersion=6.0.0
 vertxVersion=5.1.4
+zeroAllocationHashingVersion=0.27ea1

--- a/kinotic-core/build.gradle
+++ b/kinotic-core/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     implementation 'io.vertx:vertx-web'
     implementation 'io.vertx:vertx-web-client'
 
+    // XXHash128 for minting MCP tool names
+    implementation 'net.openhft:zero-allocation-hashing'
+
     // Apache Ignite
     implementation 'org.apache.ignite:ignite-core'
     implementation 'org.apache.ignite:ignite-calcite'

--- a/kinotic-core/src/main/java/org/kinotic/core/api/directory/McpToolDefinition.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/directory/McpToolDefinition.java
@@ -19,7 +19,7 @@ import tools.jackson.databind.node.ObjectNode;
 public class McpToolDefinition {
 
     /**
-     * The MCP tool name: the service's qualified name (with {@code ~} as {@code .}) plus the function, unique
+     * The MCP tool name: the base 36 XXHash128 of the service's qualified name plus the function, unique
      * system wide. The {@link #title} carries the human-readable display name.
      */
     private String name;

--- a/kinotic-core/src/main/java/org/kinotic/core/api/utils/KinoticUtil.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/utils/KinoticUtil.java
@@ -1,6 +1,10 @@
 package org.kinotic.core.api.utils;
 
+import net.openhft.hashing.LongTupleHashFunction;
+
+import java.math.BigInteger;
 import java.net.URLEncoder;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.function.Function;
@@ -14,6 +18,28 @@ public class KinoticUtil {
     public static String safeEncodeURI(String uri){
         String encoded = URLEncoder.encode(uri, StandardCharsets.UTF_8);
         return encoded.replace("_", "-");
+    }
+
+    /**
+     * Returns the MCP tool name for a service function: the XXHash128 of the service's qualified name plus
+     * the function name, in base 36. A qualified name is unique system wide, so its hash is too, and base 36
+     * keeps the result to 25 characters or fewer whatever the service is called. Tool names are minted here
+     * and never parsed back apart.
+     * @param qualifiedName the service's qualified name, as {@code ServiceIdentifier.qualifiedName()} returns
+     *                      it, such as {@code os-api~org.kinotic.os.api.services.ProjectService}
+     * @param functionName the name of the function the tool calls
+     * @return the tool name, made only of {@code [0-9a-z]}
+     */
+    public static String mcpToolName(String qualifiedName, String functionName) {
+        // MCP allows characters in a tool name that LLM hosts do not — a dot most commonly. A host rewrites
+        // each one, and then holds two names for the same tool: the advertised one and the callable one.
+        // Layers that compare the wrong pair (a permission grant recorded against one, checked against the
+        // other) break. Base 36 emits only [0-9a-z], so there is nothing left for a host to rewrite.
+        long[] hash = LongTupleHashFunction.xx128().hashChars(qualifiedName + "/" + functionName);
+        byte[] bytes = ByteBuffer.allocate(Long.BYTES * 2).putLong(hash[0]).putLong(hash[1]).array();
+        // signum 1 reads the 16 bytes as an unsigned 128-bit magnitude, so a high bit set in hash[0] stays a
+        // positive value rather than becoming a two's-complement negative one
+        return new BigInteger(1, bytes).toString(36);
     }
 
     public static int getRandomNumberInRange(int max) {

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -3,6 +3,7 @@ package org.kinotic.core.internal.api.directory;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.extern.slf4j.Slf4j;
+import net.openhft.hashing.LongTupleHashFunction;
 import org.apache.ignite.Ignite;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.crud.CursorPageable;
@@ -43,6 +44,8 @@ import org.springframework.util.ClassUtils;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -51,7 +54,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * The {@link ServiceDirectory}: publishes the contracts of services that opt in with
@@ -68,8 +70,6 @@ import java.util.regex.Pattern;
 public class DefaultServiceDirectory implements ServiceDirectory {
 
     private static final String LIVENESS_SINGLETON_NAME = "kinotic-service-liveness-updater";
-
-    private static final Pattern TOOL_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]{1,128}$");
 
     // A strategy pattern is used, to favor composition over inheritance
     private final ServiceDirectoryStrategy strategy;
@@ -297,8 +297,10 @@ public class DefaultServiceDirectory implements ServiceDirectory {
 
                 String toolName = toolName(serviceIdentifier, function.getName());
                 if (!toolNames.add(toolName)) {
-                    throw new IllegalStateException("Duplicate MCP tool name '" + toolName + "' for service "
-                                                            + serviceIdentifier);
+                    // the name is a hash, so it names nothing on its own — the function it was minted from
+                    // is what a reader needs to act on this
+                    throw new IllegalStateException("Duplicate MCP tool name '" + toolName + "' for function '"
+                                                            + function.getName() + "' on service " + serviceIdentifier);
                 }
 
                 tools.add(new McpToolDefinition()
@@ -372,24 +374,21 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     }
 
     /**
-     * Returns the tool name for the function: the service's qualified name plus the function, encoded to fit
-     * {@code ^[a-zA-Z0-9_-]{1,128}$}. The qualified name makes the tool name unique system wide;
-     * {@code title} carries the human-readable display name. Names are minted here, never parsed back apart.
+     * Returns the tool name for the function: the XXHash128 of the service's qualified name plus the
+     * function, in base 36. Hashing a qualified name that is already unique system wide keeps the tool name
+     * unique system wide, at 25 characters or fewer whatever the service is called; {@code title} carries
+     * the human-readable display name. Names are minted here, never parsed back apart.
      */
     private String toolName(ServiceIdentifier serviceIdentifier, String functionName) {
-        // MCP allows a dot in a tool name but LLM hosts do not, so a host rewrites one to an underscore and
-        // then holds two names for the same tool — the advertised one and the callable one. Layers that
-        // compare the wrong pair (a permission grant recorded against one, checked against the other) break.
-        // Minting the already-encoded form leaves the host nothing to rewrite.
-        String toolName = (serviceIdentifier.qualifiedName() + "_" + functionName)
-                .replaceAll("[^a-zA-Z0-9_-]", "_");
-        // a name long enough to overflow the 128-char limit must fail loudly, never truncate
-        if (!TOOL_NAME_PATTERN.matcher(toolName).matches()) {
-            throw new IllegalStateException("MCP tool name '" + toolName + "' for function '" + functionName
-                                                    + "' on service " + serviceIdentifier
-                                                    + " does not match the required pattern " + TOOL_NAME_PATTERN.pattern());
-        }
-        return toolName;
+        // MCP allows characters in a tool name that LLM hosts do not — a dot most commonly. A host rewrites
+        // each one, and then holds two names for the same tool: the advertised one and the callable one.
+        // Layers that compare the wrong pair (a permission grant recorded against one, checked against the
+        // other) break. Base 36 emits only [0-9a-z], so there is nothing left for a host to rewrite.
+        long[] hash = LongTupleHashFunction.xx128().hashChars(serviceIdentifier.qualifiedName() + "/" + functionName);
+        byte[] bytes = ByteBuffer.allocate(Long.BYTES * 2).putLong(hash[0]).putLong(hash[1]).array();
+        // signum 1 reads the 16 bytes as an unsigned 128-bit magnitude, so a high bit set in hash[0] stays a
+        // positive value rather than becoming a two's-complement negative one
+        return new BigInteger(1, bytes).toString(36);
     }
 
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -69,7 +69,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
 
     private static final String LIVENESS_SINGLETON_NAME = "kinotic-service-liveness-updater";
 
-    private static final Pattern TOOL_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_.-]{1,128}$");
+    private static final Pattern TOOL_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]{1,128}$");
 
     // A strategy pattern is used, to favor composition over inheritance
     private final ServiceDirectoryStrategy strategy;
@@ -372,14 +372,17 @@ public class DefaultServiceDirectory implements ServiceDirectory {
     }
 
     /**
-     * Returns the tool name for the function: the service's qualified name (with {@code ~} as {@code .}) plus
-     * the function, encoded to fit {@code ^[a-zA-Z0-9_.-]{1,128}$}. The qualified name makes the tool name
-     * unique system wide; {@code title} carries the human-readable display name. Names are minted here, never
-     * parsed back apart.
+     * Returns the tool name for the function: the service's qualified name plus the function, encoded to fit
+     * {@code ^[a-zA-Z0-9_-]{1,128}$}. The qualified name makes the tool name unique system wide;
+     * {@code title} carries the human-readable display name. Names are minted here, never parsed back apart.
      */
     private String toolName(ServiceIdentifier serviceIdentifier, String functionName) {
-        String toolName = (serviceIdentifier.qualifiedName().replace('~', '.') + "." + functionName)
-                .replaceAll("[^a-zA-Z0-9_.-]", "_");
+        // MCP allows a dot in a tool name but LLM hosts do not, so a host rewrites one to an underscore and
+        // then holds two names for the same tool — the advertised one and the callable one. Layers that
+        // compare the wrong pair (a permission grant recorded against one, checked against the other) break.
+        // Minting the already-encoded form leaves the host nothing to rewrite.
+        String toolName = (serviceIdentifier.qualifiedName() + "_" + functionName)
+                .replaceAll("[^a-zA-Z0-9_-]", "_");
         // a name long enough to overflow the 128-char limit must fail loudly, never truncate
         if (!TOOL_NAME_PATTERN.matcher(toolName).matches()) {
             throw new IllegalStateException("MCP tool name '" + toolName + "' for function '" + functionName

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -3,7 +3,6 @@ package org.kinotic.core.internal.api.directory;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import lombok.extern.slf4j.Slf4j;
-import net.openhft.hashing.LongTupleHashFunction;
 import org.apache.ignite.Ignite;
 import org.kinotic.core.api.annotations.Publish;
 import org.kinotic.core.api.crud.CursorPageable;
@@ -20,6 +19,7 @@ import org.kinotic.core.api.event.CRI;
 import org.kinotic.core.api.event.EventBusService;
 import org.kinotic.core.api.event.EventConstants;
 import org.kinotic.core.api.service.ServiceIdentifier;
+import org.kinotic.core.api.utils.KinoticUtil;
 import org.kinotic.idl.api.annotations.McpTool;
 import org.kinotic.idl.api.converter.IdlConverterFactory;
 import org.kinotic.idl.api.converter.jsonschema.McpJsonSchemaGenerator;
@@ -44,8 +44,6 @@ import org.springframework.util.ClassUtils;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.Method;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -295,7 +293,7 @@ public class DefaultServiceDirectory implements ServiceDirectory {
                                                             + " has a streaming return type, which MCP tools do not support");
                 }
 
-                String toolName = toolName(serviceIdentifier, function.getName());
+                String toolName = KinoticUtil.mcpToolName(serviceIdentifier.qualifiedName(), function.getName());
                 if (!toolNames.add(toolName)) {
                     // the name is a hash, so it names nothing on its own — the function it was minted from
                     // is what a reader needs to act on this
@@ -371,24 +369,6 @@ public class DefaultServiceDirectory implements ServiceDirectory {
             }
         }
         return resolver;
-    }
-
-    /**
-     * Returns the tool name for the function: the XXHash128 of the service's qualified name plus the
-     * function, in base 36. Hashing a qualified name that is already unique system wide keeps the tool name
-     * unique system wide, at 25 characters or fewer whatever the service is called; {@code title} carries
-     * the human-readable display name. Names are minted here, never parsed back apart.
-     */
-    private String toolName(ServiceIdentifier serviceIdentifier, String functionName) {
-        // MCP allows characters in a tool name that LLM hosts do not — a dot most commonly. A host rewrites
-        // each one, and then holds two names for the same tool: the advertised one and the callable one.
-        // Layers that compare the wrong pair (a permission grant recorded against one, checked against the
-        // other) break. Base 36 emits only [0-9a-z], so there is nothing left for a host to rewrite.
-        long[] hash = LongTupleHashFunction.xx128().hashChars(serviceIdentifier.qualifiedName() + "/" + functionName);
-        byte[] bytes = ByteBuffer.allocate(Long.BYTES * 2).putLong(hash[0]).putLong(hash[1]).array();
-        // signum 1 reads the 16 bytes as an unsigned 128-bit magnitude, so a high bit set in hash[0] stays a
-        // positive value rather than becoming a two's-complement negative one
-        return new BigInteger(1, bytes).toString(36);
     }
 
 }

--- a/kinotic-js/e2e-tests/test/native/Mcp.test.ts
+++ b/kinotic-js/e2e-tests/test/native/Mcp.test.ts
@@ -4,16 +4,14 @@ import {McpError} from '@modelcontextprotocol/sdk/types.js'
 import * as allure from 'allure-js-commons'
 import {afterAll, beforeAll, describe, expect, inject, it} from 'vitest'
 
-// Tool names are minted server side as the base-36 XXHash128 of '<qualified name>/<function>', so each
-// literal below is opaque and the comment is the only record of what it was minted from.
-// os-api~org.kinotic.os.api.services.ProjectService/findByRepoFullName
-const FIND_PROJECTS_BY_REPO = 'c90vhkooqs0jat647hhkbm4q2'
-// os-api~org.kinotic.os.api.services.ApplicationService/createApplicationIfNotExist
-const CREATE_APPLICATION = 'azmevsseuh9mx2u9p44qk8nfp'
-// os-api~org.kinotic.os.api.services.ProjectService/save — ProjectService inherits save from CrudService,
-// which declares save(T entity), while the implementation it inherits — AbstractCrudService.save(T value) —
-// names the same parameter 'value'.
-const SAVE_PROJECT = '5r16fc0u5r4ooklw689ps4x1y'
+// A tool name is the base-36 XXHash128 of '<qualified name>/<function>', minted server side by
+// KinoticUtil.mcpToolName, so it says nothing on its own. Tools are named here by the title the server
+// derives from the service and the function, and their minted names come from the listing.
+const FIND_PROJECTS_BY_REPO = 'Project Service Find by GitHub Repo'
+const CREATE_APPLICATION = 'Application Service Create Application If Not Exist'
+// ProjectService inherits save from CrudService, which declares save(T entity), while the implementation it
+// inherits — AbstractCrudService.save(T value) — names the same parameter 'value'.
+const SAVE_PROJECT = 'Project Service Save'
 
 /** APPLICATION-scope fixture application seeded for this suite by V5__e2e_app_fixtures. */
 const APP_ID = 'e2e-mcp'
@@ -29,8 +27,8 @@ async function connectMcpClient(authHeaders: Record<string, string>): Promise<Cl
     return client
 }
 
-async function toolNames(client: Client): Promise<string[]> {
-    return (await client.listTools()).tools.map(tool => tool.name)
+async function toolTitles(client: Client): Promise<string[]> {
+    return (await client.listTools()).tools.map(tool => tool.title ?? '')
 }
 
 describe('Kinotic JS', () => {
@@ -38,6 +36,17 @@ describe('Kinotic JS', () => {
     let systemClient: Client
     let organizationClient: Client
     let applicationClient: Client
+
+    /** Title to minted name, read from the system listing once every expected tool is published. */
+    const mintedNames = new Map<string, string>()
+
+    function toolName(title: string): string {
+        const name = mintedNames.get(title)
+        if (name === undefined) {
+            throw new Error(`No tool titled '${title}' in the listing`)
+        }
+        return name
+    }
 
     beforeAll(async () => {
         await allure.suite('e2e-tests/native')
@@ -53,12 +62,23 @@ describe('Kinotic JS', () => {
                                                     applicationId: APP_ID})
 
         // the directory publishes on server startup; wait for the listing to settle
+        const expected = [FIND_PROJECTS_BY_REPO, CREATE_APPLICATION, SAVE_PROJECT]
         const deadline = Date.now() + 30000
-        while (!(await toolNames(systemClient)).includes(FIND_PROJECTS_BY_REPO)) {
+        let titles: string[] = []
+        while (!expected.every(title => titles.includes(title))) {
             if (Date.now() > deadline) {
-                throw new Error(`Timed out waiting for ${FIND_PROJECTS_BY_REPO} to appear in the tool listing`)
+                throw new Error(`Timed out waiting for ${expected} in the tool listing, got: ${titles}`)
             }
-            await new Promise(resolve => setTimeout(resolve, 1000))
+            titles = await toolTitles(systemClient)
+            if (!expected.every(title => titles.includes(title))) {
+                await new Promise(resolve => setTimeout(resolve, 1000))
+            }
+        }
+
+        for (const tool of (await systemClient.listTools()).tools) {
+            if (tool.title !== undefined) {
+                mintedNames.set(tool.title, tool.name)
+            }
         }
     }, 120000)
 
@@ -69,35 +89,35 @@ describe('Kinotic JS', () => {
     }, 60000)
 
     it('lists tools following the zone visibility matrix', async () => {
-        expect(await toolNames(systemClient), 'system sees every zone').toContain(CREATE_APPLICATION)
+        expect(await toolTitles(systemClient), 'system sees every zone').toContain(CREATE_APPLICATION)
 
-        expect(await toolNames(organizationClient), 'org participants see os-api tools')
+        expect(await toolTitles(organizationClient), 'org participants see os-api tools')
             .toContain(FIND_PROJECTS_BY_REPO)
 
-        // a hashed name carries no zone prefix to filter on, so the known os-api tools are named directly
-        const applicationTools = await toolNames(applicationClient)
-        for (const osApiTool of [FIND_PROJECTS_BY_REPO, CREATE_APPLICATION, SAVE_PROJECT]) {
-            expect(applicationTools, 'app participants never see os-api tools').not.toContain(osApiTool)
-        }
+        // every os-api tool's title leads with its service's half, so this catches the os-api tools this
+        // suite never names as well as the three it does
+        const leaked = (await toolTitles(applicationClient))
+            .filter(title => title.startsWith('Project Service') || title.startsWith('Application Service'))
+        expect(leaked, 'app participants never see os-api tools').toHaveLength(0)
     })
 
     it('serves tool metadata and schemas from the service contract', async () => {
-        const tools = (await systemClient.listTools()).tools
-        const findProjects = tools.find(tool => tool.name === FIND_PROJECTS_BY_REPO)
+        const findProjects = (await systemClient.listTools()).tools
+            .find(tool => tool.name === toolName(FIND_PROJECTS_BY_REPO))
 
         expect(findProjects).toBeDefined()
         expect(findProjects!.description).toBe(
             "Looks up projects in the current participant's organization whose backing GitHub repo has the given "
             + 'owner/repo full name. Returns the empty list when no project in that organization is backed by the repo.')
-        // titles are two halves: the service's, derived from ProjectService here, then the function's
-        expect(findProjects!.title).toBe('Project Service Find by GitHub Repo')
         expect(findProjects!.annotations?.readOnlyHint).toBe(true)
+        // a name is a hash, so it carries nothing an LLM host would rewrite to a different name
+        expect(findProjects!.name).toMatch(/^[0-9a-z]+$/)
         // schema property names come from the compiled parameter names
         expect(Object.keys(findProjects!.inputSchema.properties ?? {})).toContain('repoFullName')
     })
 
     it('dispatches tools/call through the rpc path', async () => {
-        const result = await organizationClient.callTool({name: FIND_PROJECTS_BY_REPO,
+        const result = await organizationClient.callTool({name: toolName(FIND_PROJECTS_BY_REPO),
                                                           arguments: {repoFullName: 'kinotic-ai/no-such-repo'}})
         expect(result.isError).toBeFalsy()
         const content = result.content as Array<{ type: string, text?: string }>
@@ -106,14 +126,14 @@ describe('Kinotic JS', () => {
     })
 
     it('rejects arguments matching no parameter as a tool error', async () => {
-        const result = await organizationClient.callTool({name: FIND_PROJECTS_BY_REPO,
+        const result = await organizationClient.callTool({name: toolName(FIND_PROJECTS_BY_REPO),
                                                           arguments: {repoFullName: 'a/b', bogus: 'x'}})
         expect(result.isError).toBe(true)
     })
 
     it('publishes and binds the interface parameter name where the implementation renames it', async () => {
-        const save = (await systemClient.listTools()).tools.find(tool => tool.name === SAVE_PROJECT)
-        expect(save, `${SAVE_PROJECT} is not exposed as a tool`).toBeDefined()
+        const save = (await systemClient.listTools()).tools.find(tool => tool.name === toolName(SAVE_PROJECT))
+        expect(save, `'${SAVE_PROJECT}' is not exposed as a tool`).toBeDefined()
 
         // the interface's name, never the inherited implementation's 'value'
         expect(Object.keys(save!.inputSchema.properties ?? {})).toEqual(['entity'])
@@ -121,7 +141,7 @@ describe('Kinotic JS', () => {
         // taking the argument name from the schema is what makes this a round trip: publishing a name the
         // service does not bind fails here, whichever name that is
         const [publishedName] = Object.keys(save!.inputSchema.properties ?? {})
-        const result = await organizationClient.callTool({name: SAVE_PROJECT,
+        const result = await organizationClient.callTool({name: toolName(SAVE_PROJECT),
                                                           arguments: {[publishedName]: {}}})
 
         // an empty project still fails on its own business rules; only the binder's rejection is under test
@@ -131,7 +151,7 @@ describe('Kinotic JS', () => {
 
     it('refuses a call to a tool outside the caller zones', async () => {
         // resolution is scoped to the caller's zones, so the os-api tool does not exist for an app participant
-        await expect(applicationClient.callTool({name: FIND_PROJECTS_BY_REPO,
+        await expect(applicationClient.callTool({name: toolName(FIND_PROJECTS_BY_REPO),
                                                  arguments: {repoFullName: 'a/b'}}))
             .rejects.toThrowError(McpError)
     })

--- a/kinotic-js/e2e-tests/test/native/Mcp.test.ts
+++ b/kinotic-js/e2e-tests/test/native/Mcp.test.ts
@@ -4,13 +4,16 @@ import {McpError} from '@modelcontextprotocol/sdk/types.js'
 import * as allure from 'allure-js-commons'
 import {afterAll, beforeAll, describe, expect, inject, it} from 'vitest'
 
-// Tool names are minted server side: the service's qualified name, then the function name, with every
-// character outside [a-zA-Z0-9_-] encoded to an underscore
-const FIND_PROJECTS_BY_REPO = 'os-api_org_kinotic_os_api_services_ProjectService_findByRepoFullName'
-const CREATE_APPLICATION = 'os-api_org_kinotic_os_api_services_ApplicationService_createApplicationIfNotExist'
-// ProjectService inherits save from CrudService, which declares save(T entity), while the
-// implementation it inherits — AbstractCrudService.save(T value) — names the same parameter 'value'.
-const SAVE_PROJECT = 'os-api_org_kinotic_os_api_services_ProjectService_save'
+// Tool names are minted server side as the base-36 XXHash128 of '<qualified name>/<function>', so each
+// literal below is opaque and the comment is the only record of what it was minted from.
+// os-api~org.kinotic.os.api.services.ProjectService/findByRepoFullName
+const FIND_PROJECTS_BY_REPO = 'c90vhkooqs0jat647hhkbm4q2'
+// os-api~org.kinotic.os.api.services.ApplicationService/createApplicationIfNotExist
+const CREATE_APPLICATION = 'azmevsseuh9mx2u9p44qk8nfp'
+// os-api~org.kinotic.os.api.services.ProjectService/save — ProjectService inherits save from CrudService,
+// which declares save(T entity), while the implementation it inherits — AbstractCrudService.save(T value) —
+// names the same parameter 'value'.
+const SAVE_PROJECT = '5r16fc0u5r4ooklw689ps4x1y'
 
 /** APPLICATION-scope fixture application seeded for this suite by V5__e2e_app_fixtures. */
 const APP_ID = 'e2e-mcp'
@@ -71,9 +74,11 @@ describe('Kinotic JS', () => {
         expect(await toolNames(organizationClient), 'org participants see os-api tools')
             .toContain(FIND_PROJECTS_BY_REPO)
 
+        // a hashed name carries no zone prefix to filter on, so the known os-api tools are named directly
         const applicationTools = await toolNames(applicationClient)
-        expect(applicationTools.filter(name => name.startsWith('os-api_')),
-               'app participants never see os-api tools').toEqual([])
+        for (const osApiTool of [FIND_PROJECTS_BY_REPO, CREATE_APPLICATION, SAVE_PROJECT]) {
+            expect(applicationTools, 'app participants never see os-api tools').not.toContain(osApiTool)
+        }
     })
 
     it('serves tool metadata and schemas from the service contract', async () => {

--- a/kinotic-js/e2e-tests/test/native/Mcp.test.ts
+++ b/kinotic-js/e2e-tests/test/native/Mcp.test.ts
@@ -4,12 +4,13 @@ import {McpError} from '@modelcontextprotocol/sdk/types.js'
 import * as allure from 'allure-js-commons'
 import {afterAll, beforeAll, describe, expect, inject, it} from 'vitest'
 
-// Tool names are minted server side: the service's qualified name with '~' as '.', then the function name
-const FIND_PROJECTS_BY_REPO = 'os-api.org.kinotic.os.api.services.ProjectService.findByRepoFullName'
-const CREATE_APPLICATION = 'os-api.org.kinotic.os.api.services.ApplicationService.createApplicationIfNotExist'
+// Tool names are minted server side: the service's qualified name, then the function name, with every
+// character outside [a-zA-Z0-9_-] encoded to an underscore
+const FIND_PROJECTS_BY_REPO = 'os-api_org_kinotic_os_api_services_ProjectService_findByRepoFullName'
+const CREATE_APPLICATION = 'os-api_org_kinotic_os_api_services_ApplicationService_createApplicationIfNotExist'
 // ProjectService inherits save from CrudService, which declares save(T entity), while the
 // implementation it inherits — AbstractCrudService.save(T value) — names the same parameter 'value'.
-const SAVE_PROJECT = 'os-api.org.kinotic.os.api.services.ProjectService.save'
+const SAVE_PROJECT = 'os-api_org_kinotic_os_api_services_ProjectService_save'
 
 /** APPLICATION-scope fixture application seeded for this suite by V5__e2e_app_fixtures. */
 const APP_ID = 'e2e-mcp'
@@ -71,7 +72,7 @@ describe('Kinotic JS', () => {
             .toContain(FIND_PROJECTS_BY_REPO)
 
         const applicationTools = await toolNames(applicationClient)
-        expect(applicationTools.filter(name => name.startsWith('os-api.')),
+        expect(applicationTools.filter(name => name.startsWith('os-api_')),
                'app participants never see os-api tools').toEqual([])
     })
 

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/McpToolDirectoryTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/McpToolDirectoryTests.java
@@ -7,6 +7,7 @@ import org.kinotic.core.api.crud.Pageable;
 import org.kinotic.core.api.crud.Sort;
 import org.kinotic.core.api.directory.McpToolDefinition;
 import org.kinotic.core.api.directory.ServiceDirectory;
+import org.kinotic.core.api.utils.KinoticUtil;
 import org.kinotic.test.support.kinotic.KinoticTestBase;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,10 +22,11 @@ import java.util.List;
 @SpringBootTest
 public class McpToolDirectoryTests extends KinoticTestBase {
 
-    // base-36 XXHash128 of "os-api~org.kinotic.os.api.services.ProjectService/findByRepoFullName"
-    private static final String FIND_PROJECTS_BY_REPO = "c90vhkooqs0jat647hhkbm4q2";
-    // base-36 XXHash128 of "os-api~org.kinotic.os.api.services.ApplicationService/getOidcConfigurations"
-    private static final String GET_OIDC_CONFIGURATIONS = "ai2bnwxt71kuve8k1qsyu3hje";
+    private static final String PROJECT_SERVICE = "os-api~org.kinotic.os.api.services.ProjectService";
+    private static final String APPLICATION_SERVICE = "os-api~org.kinotic.os.api.services.ApplicationService";
+
+    private static final String FIND_PROJECTS_BY_REPO = KinoticUtil.mcpToolName(PROJECT_SERVICE, "findByRepoFullName");
+    private static final String GET_OIDC_CONFIGURATIONS = KinoticUtil.mcpToolName(APPLICATION_SERVICE, "getOidcConfigurations");
 
     @Autowired
     private ServiceDirectory serviceDirectory;

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/McpToolDirectoryTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/McpToolDirectoryTests.java
@@ -21,10 +21,10 @@ import java.util.List;
 @SpringBootTest
 public class McpToolDirectoryTests extends KinoticTestBase {
 
-    private static final String FIND_PROJECTS_BY_REPO =
-            "os-api_org_kinotic_os_api_services_ProjectService_findByRepoFullName";
-    private static final String GET_OIDC_CONFIGURATIONS =
-            "os-api_org_kinotic_os_api_services_ApplicationService_getOidcConfigurations";
+    // base-36 XXHash128 of "os-api~org.kinotic.os.api.services.ProjectService/findByRepoFullName"
+    private static final String FIND_PROJECTS_BY_REPO = "c90vhkooqs0jat647hhkbm4q2";
+    // base-36 XXHash128 of "os-api~org.kinotic.os.api.services.ApplicationService/getOidcConfigurations"
+    private static final String GET_OIDC_CONFIGURATIONS = "ai2bnwxt71kuve8k1qsyu3hje";
 
     @Autowired
     private ServiceDirectory serviceDirectory;

--- a/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/McpToolDirectoryTests.java
+++ b/kinotic-test/src/test/java/org/kinotic/test/tests/core/application/McpToolDirectoryTests.java
@@ -22,9 +22,9 @@ import java.util.List;
 public class McpToolDirectoryTests extends KinoticTestBase {
 
     private static final String FIND_PROJECTS_BY_REPO =
-            "os-api.org.kinotic.os.api.services.ProjectService.findByRepoFullName";
+            "os-api_org_kinotic_os_api_services_ProjectService_findByRepoFullName";
     private static final String GET_OIDC_CONFIGURATIONS =
-            "os-api.org.kinotic.os.api.services.ApplicationService.getOidcConfigurations";
+            "os-api_org_kinotic_os_api_services_ApplicationService_getOidcConfigurations";
 
     @Autowired
     private ServiceDirectory serviceDirectory;

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -109,14 +109,16 @@ A function with a streaming return type (`Flux`, `Publisher`) cannot be a tool �
 
 ## Tool naming
 
-The tool name is always minted from the service's qualified name and the function, with the zone's `~` becoming a dot:
+The tool name is always minted from the service's qualified name and the function, with every character outside `[a-zA-Z0-9_-]` encoded to an underscore:
 
 ```
 srv://app.acme-org.orders-app~com.acme.OrderService/findById
-  → app.acme-org.orders-app.com.acme.OrderService.findById
+  → app_acme-org_orders-app_com_acme_OrderService_findById
 ```
 
 Because a qualified name is unique system wide, so is the minted tool name — every caller scope, including system participants who see every zone, gets an unambiguous listing. The optional `title` is the place for a short human-friendly label. Names are never parsed back apart — resolution is a caller-scoped directory query, and authorization reads the zone from the tool's stored CRI. A name too long for the 128-character MCP limit fails registration rather than being truncated.
+
+The character set is narrower than MCP itself allows, and deliberately so. MCP permits a dot in a tool name, but LLM hosts do not — a host rewrites each one to an underscore, and then holds two names for the same tool: the one the server advertises and the one it calls. Any layer that compares the wrong pair breaks, and the failure is invisible from the server. A permission granted against the advertised name and checked against the callable one leaves a tool that prompts for approval, is approved, and reports that it still needs approval. Minting the already-encoded form leaves the host nothing to rewrite.
 
 ## The endpoint
 

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -109,16 +109,18 @@ A function with a streaming return type (`Flux`, `Publisher`) cannot be a tool �
 
 ## Tool naming
 
-The tool name is always minted from the service's qualified name and the function, with every character outside `[a-zA-Z0-9_-]` encoded to an underscore:
+The tool name is the XXHash128 of the service's qualified name plus the function, written in base 36:
 
 ```
-srv://app.acme-org.orders-app~com.acme.OrderService/findById
-  → app_acme-org_orders-app_com_acme_OrderService_findById
+app.acme-org.orders-app~com.acme.OrderService/findById
+  → 5nwldv2gqljeygvmd1ywjl2z7
 ```
 
-Because a qualified name is unique system wide, so is the minted tool name — every caller scope, including system participants who see every zone, gets an unambiguous listing. The optional `title` is the place for a short human-friendly label. Names are never parsed back apart — resolution is a caller-scoped directory query, and authorization reads the zone from the tool's stored CRI. A name too long for the 128-character MCP limit fails registration rather than being truncated.
+Because a qualified name is unique system wide, so is its hash — every caller scope, including system participants who see every zone, gets an unambiguous listing. Names are never parsed back apart: resolution is a caller-scoped directory query, and authorization reads the zone from the tool's stored CRI.
 
-The character set is narrower than MCP itself allows, and deliberately so. MCP permits a dot in a tool name, but LLM hosts do not — a host rewrites each one to an underscore, and then holds two names for the same tool: the one the server advertises and the one it calls. Any layer that compares the wrong pair breaks, and the failure is invisible from the server. A permission granted against the advertised name and checked against the callable one leaves a tool that prompts for approval, is approved, and reports that it still needs approval. Minting the already-encoded form leaves the host nothing to rewrite.
+A name is opaque, so `title` and `description` are what an LLM has to work with, and both are always served. Base 36 also bounds a name at 25 characters however long the service's package is, well inside the 128-character MCP limit.
+
+Hashing is what keeps a name safe to pass through an LLM host. MCP permits characters in a tool name that hosts do not — a dot most commonly — and a host rewrites each one, then holds two names for the same tool: the one the server advertises and the one it calls. Any layer that compares the wrong pair breaks, and the failure is invisible from the server. A permission granted against the advertised name and checked against the callable one leaves a tool that prompts for approval, is approved, and reports that it still needs approval. Base 36 emits only `[0-9a-z]`, so a host has nothing to rewrite.
 
 ## The endpoint
 

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -120,6 +120,12 @@ Because a qualified name is unique system wide, so is its hash — every caller 
 
 A name is opaque, so `title` and `description` are what an LLM has to work with, and both are always served. Base 36 also bounds a name at 25 characters however long the service's package is, well inside the 128-character MCP limit.
 
+`KinoticUtil.mcpToolName(qualifiedName, functionName)` mints the name, so anything that needs to name a tool it did not read from a listing computes the same value the directory stored:
+
+```java
+KinoticUtil.mcpToolName("os-api~org.kinotic.os.api.services.ProjectService", "findByRepoFullName")
+```
+
 Hashing is what keeps a name safe to pass through an LLM host. MCP permits characters in a tool name that hosts do not — a dot most commonly — and a host rewrites each one, then holds two names for the same tool: the one the server advertises and the one it calls. Any layer that compares the wrong pair breaks, and the failure is invisible from the server. A permission granted against the advertised name and checked against the callable one leaves a tool that prompts for approval, is approved, and reports that it still needs approval. Base 36 emits only `[0-9a-z]`, so a host has nothing to rewrite.
 
 ## The endpoint


### PR DESCRIPTION
Fixes the `MCP error -32003: MCP tool call requires approval` loop: a tool that prompts for approval, is approved, and still reports it needs approval.

## The bug

A tool name was minted straight from the service's qualified name:

```
srv://os-api~org.kinotic.os.api.services.ApplicationService/createApplicationIfNotExist
  → os-api~org.kinotic.os.api.services.ApplicationService_createApplicationIfNotExist
```

MCP permits `~` and `.` in a tool name. LLM hosts do not — a host rewrites every character outside `[A-Za-z0-9_-]`, so it ends up holding two names for the same tool:

```
os-api~org.kinotic.os.api.services.ApplicationService_createApplicationIfNotExist  // advertised
os-api_org_kinotic_os_api_services_ApplicationService_createApplicationIfNotExist  // callable
```

Any layer that compares the wrong pair breaks, and the failure is invisible server side — nothing reaches the gateway, so there is no error to log.

## The fix

`kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java`

```java
private String toolName(ServiceIdentifier serviceIdentifier, String functionName) {
    long[] hash = LongTupleHashFunction.xx128().hashChars(serviceIdentifier.qualifiedName() + "/" + functionName);
    byte[] bytes = ByteBuffer.allocate(Long.BYTES * 2).putLong(hash[0]).putLong(hash[1]).array();
    // signum 1 reads the 16 bytes as an unsigned 128-bit magnitude, so a high bit set in hash[0] stays a
    // positive value rather than becoming a two's-complement negative one
    return new BigInteger(1, bytes).toString(36);
}
```

```
os-api~org.kinotic.os.api.services.ApplicationService/createApplicationIfNotExist
  → azmevsseuh9mx2u9p44qk8nfp
```

Base 36 emits only `[0-9a-z]`, so a host has nothing to rewrite, and bounds a name at 25 characters however long the package is. The `TOOL_NAME_PATTERN` guard that used to check the minted form is deleted — the charset is now structural.

Hashing a qualified name that is already unique system wide keeps the tool name unique system wide. The duplicate-name error now names the function, since the hash names nothing on its own:

```java
throw new IllegalStateException("Duplicate MCP tool name '" + toolName + "' for function '"
                                        + function.getName() + "' on service " + serviceIdentifier);
```

## Trade-off

A name is opaque, so `title` and `description` carry everything an LLM reads. Both are always served — `title` is the service half plus the function half, `description` falls back to the method's Javadoc.

The e2e zone-visibility check lost the prefix filter it used to run, because a hashed name has no zone prefix:

```ts
// before — every os-api tool, by prefix
expect(applicationTools.filter(name => name.startsWith('os-api'))).toHaveLength(0)

// after — the three os-api tools this suite knows by name
for (const osApiTool of [FIND_PROJECTS_BY_REPO, CREATE_APPLICATION, SAVE_PROJECT]) {
    expect(applicationTools, 'app participants never see os-api tools').not.toContain(osApiTool)
}
```

## Dependency

`net.openhft:zero-allocation-hashing:0.27ea1`, wired per the repo convention — version property in `gradle.properties`, pinned in `buildSrc` `dependencyManagement`, declared without a version in `kinotic-core/build.gradle`. `dependencyInsight` on `compileClasspath` reports `0.27ea1 (selected by rule)`.

## Verified

- `:kinotic-core:compileJava`, `:kinotic-domain:compileJava`, `:kinotic-test:compileTestJava` — BUILD SUCCESSFUL
- Test constants in `Mcp.test.ts` and `McpToolDirectoryTests.java` are the real minted names, computed by running the same code against the resolved jar, each carrying a comment recording what it was minted from
- `website/content/02.platform/07.mcp-tools.md` **Tool naming** rewritten for the hash scheme; the obsolete "too long for the 128-character MCP limit" sentence is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEn3MypXHh9pwdqeVzFRDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEn3MypXHh9pwdqeVzFRDA)_