### PR TITLE
Serve openWorldHint on every MCP tool

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/api/directory/McpToolAnnotations.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/api/directory/McpToolAnnotations.java
@@ -19,4 +19,6 @@ public class McpToolAnnotations {
     private boolean destructiveHint;
 
     private boolean idempotentHint;
+
+    private boolean openWorldHint;
 }

--- a/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/api/directory/DefaultServiceDirectory.java
@@ -316,7 +316,8 @@ public class DefaultServiceDirectory implements ServiceDirectory {
                                   .setAnnotations(new McpToolAnnotations()
                                                           .setReadOnlyHint(decorator.isReadOnlyHint())
                                                           .setDestructiveHint(decorator.isDestructiveHint())
-                                                          .setIdempotentHint(decorator.isIdempotentHint())));
+                                                          .setIdempotentHint(decorator.isIdempotentHint())
+                                                          .setOpenWorldHint(decorator.isOpenWorldHint())));
             }
         }
 

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/annotations/McpTool.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/annotations/McpTool.java
@@ -42,7 +42,7 @@ public @interface McpTool {
     String title() default "";
 
     /**
-     * Indicates the tool does not modify its environment. All three hints are read together from the
+     * Indicates the tool does not modify its environment. All four hints are read together from the
      * method's annotation, exactly as it writes them. A function with no annotation of its own is hinted by
      * the words in its name instead: {@code save} or {@code delete} make it destructive and idempotent, a
      * name ending in {@code IfNotExist} makes it idempotent, {@code create} or {@code send} leave all three
@@ -59,5 +59,13 @@ public @interface McpTool {
      * Indicates repeated calls with the same arguments have no additional effect.
      */
     boolean idempotentHint() default false;
+
+    /**
+     * Indicates the tool reaches a system outside the platform, such as a third-party API. A function that
+     * works against the platform's own data leaves this false, which is what an MCP host reads to decide how
+     * much scrutiny a call deserves. MCP itself defaults this hint to true, so a tool that never states it
+     * would otherwise be served as if it called out to the world.
+     */
+    boolean openWorldHint() default false;
 
 }

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/annotations/McpToolInfo.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/annotations/McpToolInfo.java
@@ -44,4 +44,12 @@ public @interface McpToolInfo {
      */
     boolean idempotentHint() default false;
 
+    /**
+     * Indicates the tool reaches a system outside the platform, such as a third-party API. A function that
+     * works against the platform's own data leaves this false, which is what an MCP host reads to decide how
+     * much scrutiny a call deserves. MCP itself defaults this hint to true, so a tool that never states it
+     * would otherwise be served as if it called out to the world.
+     */
+    boolean openWorldHint() default false;
+
 }

--- a/kinotic-idl/src/main/java/org/kinotic/idl/api/schema/decorators/McpToolC3Decorator.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/api/schema/decorators/McpToolC3Decorator.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * Marks a function as a Model Context Protocol tool.
  * A function carrying this decorator is exposed to LLM callers as an MCP tool, using {@link #description} as the
- * tool's LLM-facing contract and the three hints as MCP tool behavior annotations.
+ * tool's LLM-facing contract and the four hints as MCP tool behavior annotations.
  */
 @Getter
 @Setter
@@ -44,6 +44,11 @@ public final class McpToolC3Decorator extends C3Decorator {
      * Indicates repeated calls with the same arguments have no additional effect.
      */
     private boolean idempotentHint = false;
+
+    /**
+     * Indicates the tool reaches a system outside the platform, such as a third-party API.
+     */
+    private boolean openWorldHint = false;
 
     public McpToolC3Decorator() {
         this.targets = List.of(DecoratorTarget.FUNCTION);

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/DefaultSchemaFactory.java
@@ -211,7 +211,8 @@ public class DefaultSchemaFactory implements SchemaFactory {
                     .setDescription(description)
                     .setReadOnlyHint(hints.readOnly())
                     .setDestructiveHint(hints.destructive())
-                    .setIdempotentHint(hints.idempotent());
+                    .setIdempotentHint(hints.idempotent())
+                    .setOpenWorldHint(hints.openWorld());
         }
         return ret;
     }

--- a/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/McpToolHints.java
+++ b/kinotic-idl/src/main/java/org/kinotic/idl/internal/directory/McpToolHints.java
@@ -13,18 +13,21 @@ import java.util.stream.Collectors;
 /**
  * The behavior hints served as a tool's MCP annotations.
  */
-record McpToolHints(boolean readOnly, boolean destructive, boolean idempotent) {
+record McpToolHints(boolean readOnly, boolean destructive, boolean idempotent, boolean openWorld) {
+
+    // a name says nothing about whether a function calls out to another system, and a Kinotic service runs
+    // against the platform's own data, so every name-derived value below leaves openWorld false
 
     /**
      * Hints for a tool whose behavior nothing is known about.
      */
-    static final McpToolHints NONE = new McpToolHints(false, false, false);
+    static final McpToolHints NONE = new McpToolHints(false, false, false, false);
 
-    static final McpToolHints READ_ONLY = new McpToolHints(true, false, false);
+    static final McpToolHints READ_ONLY = new McpToolHints(true, false, false, false);
 
-    static final McpToolHints DESTRUCTIVE_AND_IDEMPOTENT = new McpToolHints(false, true, true);
+    static final McpToolHints DESTRUCTIVE_AND_IDEMPOTENT = new McpToolHints(false, true, true, false);
 
-    static final McpToolHints IDEMPOTENT = new McpToolHints(false, false, true);
+    static final McpToolHints IDEMPOTENT = new McpToolHints(false, false, true, false);
 
     private static final Set<String> READ_ONLY_VERBS = Set.of("count", "exists", "fetch", "find", "get",
                                                               "has", "is", "list", "load", "query", "read",
@@ -45,13 +48,15 @@ record McpToolHints(boolean readOnly, boolean destructive, boolean idempotent) {
     static McpToolHints of(McpTool annotation) {
         return new McpToolHints(annotation.readOnlyHint(),
                                 annotation.destructiveHint(),
-                                annotation.idempotentHint());
+                                annotation.idempotentHint(),
+                                annotation.openWorldHint());
     }
 
     static McpToolHints of(McpToolInfo annotation) {
         return new McpToolHints(annotation.readOnlyHint(),
                                 annotation.destructiveHint(),
-                                annotation.idempotentHint());
+                                annotation.idempotentHint(),
+                                annotation.openWorldHint());
     }
 
     /**

--- a/kinotic-js/e2e-tests/test/native/Mcp.test.ts
+++ b/kinotic-js/e2e-tests/test/native/Mcp.test.ts
@@ -110,6 +110,8 @@ describe('Kinotic JS', () => {
             "Looks up projects in the current participant's organization whose backing GitHub repo has the given "
             + 'owner/repo full name. Returns the empty list when no project in that organization is backed by the repo.')
         expect(findProjects!.annotations?.readOnlyHint).toBe(true)
+        // served explicitly because MCP defaults it to true, which reads as a call that leaves the platform
+        expect(findProjects!.annotations?.openWorldHint).toBe(false)
         // a name is a hash, so it carries nothing an LLM host would rewrite to a different name
         expect(findProjects!.name).toMatch(/^[0-9a-z]+$/)
         // schema property names come from the compiled parameter names

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/ProjectService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/ProjectService.java
@@ -45,6 +45,7 @@ public interface ProjectService extends ApplicationScopedCrudService<Project, St
      * @return a {@link CompletableFuture} emitting the updated project
      * @throws IllegalStateException when the project is not awaiting an initialization retry
      */
+    @McpTool(openWorldHint = true)
     CompletableFuture<Project> retryRepoInitialization(String projectId);
 
 }

--- a/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
+++ b/kinotic-os-api/src/test/java/org/kinotic/os/api/services/McpServiceSchemaTest.java
@@ -106,6 +106,32 @@ public class McpServiceSchemaTest {
         Assertions.assertEquals("Project Service Create Project If Not Exist", createIfNotExist.getTitle());
     }
 
+    @Test
+    public void openWorldHintSeparatesFunctionsThatCallOut() {
+        NamespaceDefinition namespaceDefinition =
+                schemaFactory().createForServices(List.of(new ServiceDeclaration(ProjectService.class, DefaultProjectService.class)));
+
+        ServiceDefinition service = namespaceDefinition.getServices()
+                                                       .stream()
+                                                       .findFirst()
+                                                       .orElseThrow();
+
+        // MCP defaults openWorldHint to true, so every function that only touches the platform's own data
+        // has to say false for a host to read it as the closed-domain call it is
+        Assertions.assertFalse(mcpTool(service, "findByRepoFullName").isOpenWorldHint());
+        Assertions.assertFalse(mcpTool(service, "createProjectIfNotExist").isOpenWorldHint());
+        Assertions.assertFalse(mcpTool(service, "deleteById").isOpenWorldHint());
+
+        // retryRepoInitialization delegates to the repo provisioner, which reaches GitHub
+        McpToolC3Decorator retry = mcpTool(service, "retryRepoInitialization");
+        Assertions.assertTrue(retry.isOpenWorldHint());
+        // the @McpTool that states the open world states the rest of the hints too, matching what the
+        // function name implied on its own
+        Assertions.assertFalse(retry.isReadOnlyHint());
+        Assertions.assertFalse(retry.isDestructiveHint());
+        Assertions.assertFalse(retry.isIdempotentHint());
+    }
+
     private static McpToolC3Decorator mcpTool(ServiceDefinition service, String functionName) {
         McpToolC3Decorator ret = service.getFunctions()
                                         .stream()

--- a/website/content/02.platform/07.mcp-tools.md
+++ b/website/content/02.platform/07.mcp-tools.md
@@ -53,7 +53,7 @@ The input schema's property names are the service interface's Java parameter nam
 
 ## Describing a function without exposing it
 
-`@McpToolInfo` carries the same metadata as `@McpTool` — `title`, `description`, and the three hints — but never makes a tool. A base interface uses it to state what its functions *are*, leaving the decision to expose them to whichever service extends it:
+`@McpToolInfo` carries the same metadata as `@McpTool` — `title`, `description`, and the four hints — but never makes a tool. A base interface uses it to state what its functions *are*, leaving the decision to expose them to whichever service extends it:
 
 ```java
 public interface CrudService<T, ID> {
@@ -81,7 +81,7 @@ Nothing is borrowed from the further declaration either: `@McpTool(title = "Stor
 
 ## Hints
 
-The three hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`) are served as MCP tool annotations. They follow the rule above with no string-shaped escape: a boolean has no blank value, so the winning declaration's hints are exactly what is served, including when it declares none.
+The four hints (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) are served as MCP tool annotations. They follow the rule above with no string-shaped escape: a boolean has no blank value, so the winning declaration's hints are exactly what is served, including when it declares none.
 
 `@McpTool(description = "Appends an audit entry")` on a method named `saveAuditEntry` therefore serves `destructiveHint: false` — the annotation is present, so it decides, and it declares nothing destructive. And because a type-level `@McpTool` supplies no hints, `readOnlyHint = true` there can no longer mislabel the mutating functions a sweep catches.
 
@@ -104,6 +104,15 @@ notifyPeople             all three false          — no rule matches
 ```
 
 The adds-or-acts row exists only to be reached before the reads row. `getOrCreatePerson` both reads and creates, and matching it there is what stops `readOnlyHint = true` from being served for a call that creates a person. All three `false` is not "unknown" — it is the honest answer, and it tells a host the tool may modify something and is not safe to run unattended.
+
+Every hint is always written to the wire, which matters most for `openWorldHint`: [MCP defaults it to `true`](https://modelcontextprotocol.io/specification/2025-11-25/server/tools), so a tool that omits it is read as one that may call out to any external system, and hosts weigh that when deciding whether a call needs approval. A Kinotic function works against the platform's own data, so the served default is `false`; a function that does reach a third-party system says so:
+
+```java
+@McpTool(openWorldHint = true)
+CompletableFuture<Project> retryRepoInitialization(String projectId);
+```
+
+Nothing in a function's name says whether it calls out, so `openWorldHint` is never inferred — only a declaration sets it.
 
 A function with a streaming return type (`Flux`, `Publisher`) cannot be a tool — registration fails with an error naming the function. Single-value async returns (`CompletableFuture`, `Mono`) are fine.
 


### PR DESCRIPTION
Every tool was advertised to MCP hosts as one that may call out to any external system, because the gateway never wrote `openWorldHint` and the spec defaults it to `true`.

## The gap

`McpToolAnnotations` carried three of MCP's four behavior hints:

```java
public class McpToolAnnotations {
    private boolean readOnlyHint;
    private boolean destructiveHint;
    private boolean idempotentHint;
    // openWorldHint never written
}
```

[The MCP schema](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-11-25/schema.ts) is explicit about what an omitted hint means:

```ts
/**
 * If true, this tool may interact with an "open world" of external
 * entities. If false, the tool's domain of interaction is closed.
 *
 * Default: true
 */
openWorldHint?: boolean;
```

So a read-only `findById` over the platform's own Elasticsearch was served as an open-world call — the risk-maximizing reading, and one input a host weighs when deciding whether a call needs approval.

## The fix

The hint is added to both annotations and written on every tool:

```java
// McpTool.java / McpToolInfo.java
boolean openWorldHint() default false;
```

```java
// DefaultServiceDirectory.java:318
.setAnnotations(new McpToolAnnotations()
                        .setReadOnlyHint(decorator.isReadOnlyHint())
                        .setDestructiveHint(decorator.isDestructiveHint())
                        .setIdempotentHint(decorator.isIdempotentHint())
                        .setOpenWorldHint(decorator.isOpenWorldHint()));
```

A Kinotic function works against the platform's own data, so `false` is the served default. Nothing in a function's name says whether it calls out, so the name heuristics never infer it — every name-derived value leaves it false:

```java
static final McpToolHints READ_ONLY = new McpToolHints(true, false, false, false);
```

One exposed function today genuinely is open-world. `ProjectService.retryRepoInitialization` delegates to `repoProvisioner.reinitialize`, which reaches GitHub:

```java
@McpTool(openWorldHint = true)
CompletableFuture<Project> retryRepoInitialization(String projectId);
```

Its other three hints are unchanged by the new annotation — the name heuristic already resolved `retry` to all-false through `ADDITIVE_VERBS`, which is what the annotation now states.

## Verified

`:kinotic-idl:test` and `:kinotic-os-api:test` BUILD SUCCESSFUL, including a new case that pins both sides of the split:

```java
Assertions.assertFalse(mcpTool(service, "findByRepoFullName").isOpenWorldHint());
Assertions.assertFalse(mcpTool(service, "createProjectIfNotExist").isOpenWorldHint());
Assertions.assertTrue(mcpTool(service, "retryRepoInitialization").isOpenWorldHint());
```

`Mcp.test.ts` asserts the hint reaches the wire, and `website/content/02.platform/07.mcp-tools.md` documents why the served default departs from MCP's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEn3MypXHh9pwdqeVzFRDA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEn3MypXHh9pwdqeVzFRDA)_