### PR TITLE
Accept prerelease versions in the repo-provisioner template test

### DIFF
--- a/kinotic-github/src/test/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisionerTest.java
+++ b/kinotic-github/src/test/java/org/kinotic/github/internal/api/services/GitHubProjectRepoProvisionerTest.java
@@ -113,8 +113,10 @@ class GitHubProjectRepoProvisionerTest {
         // binary files ride as blobs created out of band
         assertEquals("blob-sha", tree.get("assets/logo.png").sha());
         // npm package versions come from the build-generated resource, and override the
-        // spawn.json global the template declares them with
-        assertLinesMatch(List.of("\\^\\d+\\.\\d+\\.\\d+", "\\^\\d+\\.\\d+\\.\\d+"),
+        // spawn.json global the template declares them with; prerelease suffixes
+        // (e.g. ^5.0.0-beta.1) are valid published versions
+        assertLinesMatch(List.of("\\^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z.-]+)?",
+                                 "\\^\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z.-]+)?"),
                          tree.get("versions.txt").content().lines().toList());
         assertTrue(!tree.get("versions.txt").content().contains("^0.0.1"));
 


### PR DESCRIPTION
Fixes the develop build failure in `:kinotic-github:test` after #379 landed.

`GitHubProjectRepoProvisionerTest` asserts that rendered project templates carry the real published npm versions from the build-generated `npmPackageVersions` resource rather than the template's `^0.0.1` placeholder — but the pattern only accepted plain `^X.Y.Z`, and the workspace packages now publish as `^5.0.0-beta.1`:

```
expected: `\^\d+\.\d+\.\d+`
  actual: `^5.0.0-beta.1`
```

The pattern now accepts an optional prerelease suffix (`\^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?`); the assertion's intent is unchanged. All 14 tests in `kinotic-github` pass, and it's the module's only plain-semver assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019q4gd6zWDMHoK9MF2oXZvh

---
_Generated by [Claude Code](https://claude.ai/code/session_019q4gd6zWDMHoK9MF2oXZvh)_