### PR TITLE
Clean up the e2e-tests TypeScript type-check baseline

### DIFF
--- a/kinotic-js/e2e-tests/src/vite-env.d.ts
+++ b/kinotic-js/e2e-tests/src/vite-env.d.ts
@@ -7,3 +7,10 @@ interface ImportMetaEnv {
 interface ImportMeta {
     readonly env: ImportMetaEnv
 }
+
+// vite/client stopped declaring `*.vue` modules in Vite 5, so tsc needs this shim to resolve SFC imports.
+declare module '*.vue' {
+    import type { DefineComponent } from 'vue'
+    const component: DefineComponent<{}, {}, any>
+    export default component
+}

--- a/kinotic-js/e2e-tests/test/TestHelpers.ts
+++ b/kinotic-js/e2e-tests/test/TestHelpers.ts
@@ -122,8 +122,8 @@ export async function createSchema(organizationId: string, applicationId: string
                                                                 new ConsoleLogger())
 
         const config = new KinoticProjectConfig()
-        config.organization = organizationId
-        config.application = applicationId
+        config.organizationId = organizationId
+        config.applicationId = applicationId
         config.entitiesPaths = [{
             path: path.resolve(__dirname, './domain'),
             repositoryPath: path.resolve(__dirname, './repository'),

--- a/kinotic-js/e2e-tests/test/domain/ClusterInfo.ts
+++ b/kinotic-js/e2e-tests/test/domain/ClusterInfo.ts
@@ -1,19 +1,19 @@
 export class ClusterInfo {
-    public localNodeId: string;
-    public serverNodeCount: number;
-    public topologyVersion: number;
-    public clusterState: string;
-    public nodes: NodeInfo[];
-    public active: boolean;
+    public localNodeId: string = '';
+    public serverNodeCount: number = 0;
+    public topologyVersion: number = 0;
+    public clusterState: string = '';
+    public nodes: NodeInfo[] = [];
+    public active: boolean = false;
 }
 
 export class NodeInfo {
-    public nodeId: string;
-    public order: number;
-    public local: boolean;
-    public addresses: string[];
-    public hostNames: string[];
-    public client: boolean;
-    public attributes: Record<string, any>;
-    public version: string;
+    public nodeId: string = '';
+    public order: number = 0;
+    public local: boolean = false;
+    public addresses: string[] = [];
+    public hostNames: string[] = [];
+    public client: boolean = false;
+    public attributes: Record<string, any> = {};
+    public version: string = '';
 }

--- a/kinotic-js/e2e-tests/test/native/AdminEntityService.test.ts
+++ b/kinotic-js/e2e-tests/test/native/AdminEntityService.test.ts
@@ -88,15 +88,15 @@ describe('Kinotic JS', () => {
             await expect(entityService.syncIndex()).resolves.toBeNull()
 
             // Find the 1st person
-            const foundPerson: PersonWithTenant = await logFailure(adminEntityService.findById({entityId: savedPerson.id as string, tenantId: 'tenant01'}), 'Failed to find person')
+            const foundPerson = await logFailure(adminEntityService.findById({entityId: savedPerson.id as string, tenantId: 'tenant01'}), 'Failed to find person')
             expect(foundPerson).toBeDefined()
-            expect(foundPerson.id).toBe(savedPerson.id)
+            expect(foundPerson!.id).toBe(savedPerson.id)
 
             // Update the person
             // Find the 1st person
-            const foundPerson2: PersonWithTenant = await logFailure(adminEntityService.findById({entityId: savedPerson2.id as string, tenantId: 'tenant02'}), 'Failed to find person')
+            const foundPerson2 = await logFailure(adminEntityService.findById({entityId: savedPerson2.id as string, tenantId: 'tenant02'}), 'Failed to find person')
             expect(foundPerson2).toBeDefined()
-            expect(foundPerson2.id).toBe(savedPerson2.id)
+            expect(foundPerson2!.id).toBe(savedPerson2.id)
 
             // Count the people
             await expect(adminEntityService.count(['tenant01', 'tenant02'])).resolves.toBe(2)

--- a/kinotic-js/e2e-tests/test/native/Versioned.test.ts
+++ b/kinotic-js/e2e-tests/test/native/Versioned.test.ts
@@ -78,14 +78,15 @@ describe('Kinotic JS', () => {
          expect(savedVehicle.version).toBeDefined()
 
          const loaded = await logFailure(entityService.findById(savedVehicle.id), 'Failed to find vehicle')
-         expect(savedVehicle.id).toEqual(loaded.id)
-         expect(savedVehicle.version).toEqual(loaded.version)
+         expect(loaded).not.toBeNull()
+         expect(savedVehicle.id).toEqual(loaded!.id)
+         expect(savedVehicle.version).toEqual(loaded!.version)
 
          // Count
          await expect(entityService.count()).resolves.toBe(1)
 
          // Delete
-         await expect(entityService.deleteById(loaded.id)).resolves.toBeNull()
+         await expect(entityService.deleteById(loaded!.id)).resolves.toBeNull()
      })
 
     it<LocalTestContext>('Test Optimistic Locking',

--- a/kinotic-js/e2e-tests/tsconfig.json
+++ b/kinotic-js/e2e-tests/tsconfig.json
@@ -23,5 +23,7 @@
     "types": ["vitest/globals"]
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue", "test/**/*.ts"],
+  /* Parked suites are excluded from execution, so they are excluded from type-checking until revived. */
+  "exclude": ["**/*.testx.ts", "test/k8s"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
`npx tsc --noEmit` in kinotic-js/e2e-tests reported 40 errors. CI never
saw them — vitest's esbuild transform does not type-check — so they
accumulated silently.

The one real bug: createSchema wrote config.organization and
config.application, but KinoticProjectConfig declares organizationId and
applicationId, so both ids vanished before reaching
EntityCodeGenerationService. It renders organizationId into the generated
BaseRepository's super(...) call, so generated repositories were being
constructed with an empty entityOrganizationId.

The rest are type-only: field initializers on ClusterInfo/NodeInfo for
TS2564, non-null assertions where findById returns T | null, and a
declare module '*.vue' shim that vite/client no longer provides. Parked
suites (**/*.testx.ts, test/k8s) are excluded from type-checking since
they are already excluded from execution.

Six errors remain by design: test/repository/* imports of
./generated/Base*Repository.js, which createSchema produces at test
runtime and therefore cannot exist on a clean checkout.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XJmMgyfQ6Uv5dZHiAwneBm