### PR TITLE
Create the machine-lifecycle test's application through the API

### DIFF
--- a/kinotic-js/e2e-tests/test/native/OAuthMcp.test.ts
+++ b/kinotic-js/e2e-tests/test/native/OAuthMcp.test.ts
@@ -248,9 +248,13 @@ describe('Kinotic JS', () => {
                 body: new URLSearchParams({grant_type: 'client_credentials', client_id: clientId, client_secret: clientSecret})
             })
 
-        // the signed-in org user provisions a machine for one of the org's applications
+        // the signed-in org user provisions a machine for one of the org's applications.
+        // The application is created through the API: migration-seeded kinotic_application
+        // rows are written with a plain _id, so the org-scoped composite-id lookup behind
+        // createMachine cannot see them.
+        await Kinotic.applications.createApplicationIfNotExist('e2e-machines', 'e2e fixture application for the machine lifecycle test')
         const machineService = new MachineService(Kinotic)
-        const created = await machineService.createMachine('e2e Lifecycle Machine', 'e2e-mcp')
+        const created = await machineService.createMachine('e2e Lifecycle Machine', 'e2e-machines')
         const machineId = created.machine.id!
         expect(created.clientSecret).toBeTruthy()
 
@@ -261,7 +265,7 @@ describe('Kinotic JS', () => {
         expect(await stompHandshake(stompUrl(), firstTokens.access_token)).toBe('open')
 
         // and the machine is listed for its application
-        const listed = await machineService.findMachines('e2e-mcp', Pageable.create(0, 50))
+        const listed = await machineService.findMachines('e2e-machines', Pageable.create(0, 50))
         expect(listed.content?.some(m => m.id === machineId)).toBe(true)
 
         // rotation kills the old secret and issues a working replacement


### PR DESCRIPTION
Fixes the remaining develop e2e failure (`Application not found: e2e-mcp` in the machine-lifecycle test).

Migration-seeded `kinotic_application` rows are written with a plain `_id` (`InsertStatementExecutor` uses the `id` column verbatim), but `AbstractOrganizationScopedRepository` stores documents under the composite `orgId-id` — so the org-scoped `findById` behind `createMachine` can never see a seeded application. The test now provisions its application with `createApplicationIfNotExist`, the same idiom every other e2e suite uses:

```typescript
await Kinotic.applications.createApplicationIfNotExist('e2e-machines', 'e2e fixture application for the machine lifecycle test')
const created = await machineService.createMachine('e2e Lifecycle Machine', 'e2e-machines')
```

Related finding, not addressed here: the seven `kinotic_application` inserts in `V5__e2e_app_fixtures.test.sql` are invisible to every org-scoped id lookup for the same reason — the entity suites work because they create their apps through the API anyway. They can be deleted as dead fixtures, or kinotic-sql can learn a composite-id/routing form if migrations ever need to seed org-scoped rows for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019q4gd6zWDMHoK9MF2oXZvh

---
_Generated by [Claude Code](https://claude.ai/code/session_019q4gd6zWDMHoK9MF2oXZvh)_