### PR TITLE
Test against the staged gateway image instead of always pulling

### DIFF
--- a/kinotic-js/workspace/packages/core/test/DisableStickySession_GatewayRestart.test.ts
+++ b/kinotic-js/workspace/packages/core/test/DisableStickySession_GatewayRestart.test.ts
@@ -1,7 +1,7 @@
 import {afterAll, beforeAll, describe, expect, it} from 'vitest'
 import {WebSocket} from 'ws'
 import {ConnectedInfo, ConnectionInfo, KinoticSingleton, SessionKeepAliveMode} from '../src'
-import {GenericContainer, PullPolicy, type StartedTestContainer, Wait} from 'testcontainers'
+import {GenericContainer, type StartedTestContainer, Wait} from 'testcontainers'
 import { authedWebSocketFactory, logFailure, validateConnectedInfo } from './TestHelper'
 import { TestService } from './ITestService'
 import {KINOTIC_DOCKER_IMAGE} from './TestHelper.js'
@@ -22,7 +22,6 @@ describe('Kinotic JS', () => {
             container = await new GenericContainer(KINOTIC_DOCKER_IMAGE)
                 .withExposedPorts({container: 58503, host: 58599})
                 .withEnvironment({SPRING_PROFILES_ACTIVE: "clienttest"})
-                .withPullPolicy(PullPolicy.alwaysPull())
                 .withWaitStrategy(Wait.forHttp('/health', 58503).forStatusCodeMatching(c => c === 200 || c === 204))
                 .withName('disable-sticky-session-reconnect-test')
                 .start()
@@ -65,7 +64,6 @@ describe('Kinotic JS', () => {
             container = await new GenericContainer(KINOTIC_DOCKER_IMAGE)
                 .withExposedPorts({container: 58503, host: 58599})
                 .withEnvironment({SPRING_PROFILES_ACTIVE: "clienttest"})
-                .withPullPolicy(PullPolicy.alwaysPull())
                 .withWaitStrategy(Wait.forHttp('/health', 58503).forStatusCodeMatching(c => c === 200 || c === 204))
                 .withName('disable-sticky-session-reconnect-test')
                 .start()

--- a/kinotic-js/workspace/packages/core/test/KinoticUnavailable.test.ts
+++ b/kinotic-js/workspace/packages/core/test/KinoticUnavailable.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest'
 import {WebSocket} from 'ws'
 import {ConnectedInfo, ConnectionInfo, Kinotic, KinoticSingleton, SessionKeepAliveMode} from '../src'
-import { GenericContainer, PullPolicy, type StartedTestContainer, Wait } from 'testcontainers'
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers'
 import {TestService} from './ITestService.js'
 import { authedWebSocketFactory, logFailure, validateConnectedInfo } from './TestHelper'
 import {KINOTIC_DOCKER_IMAGE} from './TestHelper.js'
@@ -47,7 +47,6 @@ describe('Kinotic JS', () => {
                container = await new GenericContainer(KINOTIC_DOCKER_IMAGE)
                    .withExposedPorts({container: 58503, host: 58590})
                    .withEnvironment({SPRING_PROFILES_ACTIVE: "clienttest"})
-                   .withPullPolicy(PullPolicy.alwaysPull())
                    .withWaitStrategy(Wait.forHttp('/health', 58503).forStatusCodeMatching(c => c === 200 || c === 204))
                    .withName('maxretries-container')
                    .start()

--- a/kinotic-js/workspace/packages/core/test/setup.ts
+++ b/kinotic-js/workspace/packages/core/test/setup.ts
@@ -1,4 +1,4 @@
-import {GenericContainer, PullPolicy, Wait} from 'testcontainers'
+import {GenericContainer, Wait} from 'testcontainers'
 import type {StartedTestContainer} from 'testcontainers'
 import type {TestProject} from 'vitest/node'
 import {KINOTIC_DOCKER_IMAGE} from './TestHelper.js'
@@ -17,7 +17,6 @@ export async function setup(project: TestProject) {
         container = await new GenericContainer(KINOTIC_DOCKER_IMAGE)
             .withExposedPorts(58503)
             .withEnvironment({SPRING_PROFILES_ACTIVE: "clienttest"})
-            .withPullPolicy(PullPolicy.alwaysPull())
             // /health is the gateway readiness endpoint on the STOMP port; it returns 204 with no
             // health procedures registered (clienttest) and 200 once they are, so accept either.
             .withWaitStrategy(Wait.forHttp('/health', 58503).forStatusCodeMatching(c => c === 200 || c === 204))


### PR DESCRIPTION
Fixes the `JS Workspace Tests` failure on develop (`manifest for kinoticai/kinotic-server:5.0.0-SNAPSHOT not found`).

The `@kinotic-ai/core` suite starts the gateway with `PullPolicy.alwaysPull()` (global setup plus the gateway-restart and unavailable suites), which forces a Docker Hub pull on every container start:

```typescript
container = await new GenericContainer(KINOTIC_DOCKER_IMAGE)
    ...
    .withPullPolicy(PullPolicy.alwaysPull())   // ← bypasses the locally staged image
```

That defeats the CI staging design: the workflow stages the image built from the commit on ghcr.io and retags it locally exactly so suites validate *that* image, with Docker Hub promotion gated on every suite passing. With a `-SNAPSHOT` version the Hub tag can never exist, which surfaced the flaw as a 404 — but the deeper defect predates the version bump: `alwaysPull` meant the suite had been validating the **last-promoted Docker Hub image**, not the staged image of the commit under test.

Removing the pull policy restores testcontainers' default (pull only when the image is missing locally): CI resolves the staged tag, local runs resolve the `bootBuildImage` output, and a genuinely missing image still fails loudly with the pull 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019q4gd6zWDMHoK9MF2oXZvh

---
_Generated by [Claude Code](https://claude.ai/code/session_019q4gd6zWDMHoK9MF2oXZvh)_