### PR TITLE
Drop the unreachable kinotic_application rows from V5

### DIFF
--- a/kinotic-js/e2e-tests/test/native/AdminEntityService.test.ts
+++ b/kinotic-js/e2e-tests/test/native/AdminEntityService.test.ts
@@ -18,7 +18,7 @@ import {
 
 const TEST_ORG_ID = 'kinotic-test'
 const APP_TENANT = 'kinotic'
-// Seeded by the V5__e2e_app_fixtures migration, with the matching app user for APP_TENANT.
+// The app user for this (APP_ID, APP_TENANT) pair is seeded by the V5__e2e_app_fixtures migration.
 const APP_ID = 'e2e-admin-entity'
 
 interface LocalTestContext {

--- a/kinotic-js/e2e-tests/test/native/AdminNamedQuery.test.ts
+++ b/kinotic-js/e2e-tests/test/native/AdminNamedQuery.test.ts
@@ -17,8 +17,8 @@ import {
 
 const TEST_ORG_ID = 'kinotic-test'
 const APP_TENANT = 'kinotic'
-// Fixed application seeded with its APPLICATION-scoped user by V5__e2e_app_fixtures; the
-// app client logs in as app-<APP_ID>-<APP_TENANT>@test.local, which only exists for a seeded id.
+// Fixed id: the app client logs in as app-<APP_ID>-<APP_TENANT>@test.local, an APPLICATION-scoped
+// user that V5__e2e_app_fixtures seeds only for this applicationId.
 const APP_ID = 'e2e-admin-named-query'
 
 interface LocalTestContext {

--- a/kinotic-js/e2e-tests/test/native/DataStream.test.ts
+++ b/kinotic-js/e2e-tests/test/native/DataStream.test.ts
@@ -22,7 +22,7 @@ Object.assign(global, { WebSocket })
 
 const TEST_ORG_ID = 'kinotic-test'
 const APP_TENANT = 'kinotic'
-// Seeded by the V5__e2e_app_fixtures migration, with the matching app user for APP_TENANT.
+// The app user for this (APP_ID, APP_TENANT) pair is seeded by the V5__e2e_app_fixtures migration.
 const APP_ID = 'e2e-datastream'
 
 interface LocalTestContext {

--- a/kinotic-js/e2e-tests/test/native/EntityService.test.ts
+++ b/kinotic-js/e2e-tests/test/native/EntityService.test.ts
@@ -20,8 +20,8 @@ import {
 
 const TEST_ORG_ID = 'kinotic-test'
 const APP_TENANT = 'kinotic'
-// Fixed application seeded with its APPLICATION-scoped user by V5__e2e_app_fixtures; the
-// app client logs in as app-<APP_ID>-<APP_TENANT>@test.local, which only exists for a seeded id.
+// Fixed id: the app client logs in as app-<APP_ID>-<APP_TENANT>@test.local, an APPLICATION-scoped
+// user that V5__e2e_app_fixtures seeds only for this applicationId.
 const APP_ID = 'e2e-entity-service'
 
 interface LocalTestContext {

--- a/kinotic-js/e2e-tests/test/native/Mcp.test.ts
+++ b/kinotic-js/e2e-tests/test/native/Mcp.test.ts
@@ -13,7 +13,7 @@ const CREATE_APPLICATION = 'Application Service Create Application If Not Exist'
 // inherits — AbstractCrudService.save(T value) — names the same parameter 'value'.
 const SAVE_PROJECT = 'Project Service Save'
 
-/** APPLICATION-scope fixture application seeded for this suite by V5__e2e_app_fixtures. */
+/** applicationId of the APPLICATION-scope user seeded for this suite by V5__e2e_app_fixtures. */
 const APP_ID = 'e2e-mcp'
 const ORGANIZATION_ID = 'kinotic-test'
 

--- a/kinotic-js/e2e-tests/test/native/NamedQuery.test.ts
+++ b/kinotic-js/e2e-tests/test/native/NamedQuery.test.ts
@@ -17,7 +17,7 @@ import {
 
 const TEST_ORG_ID = 'kinotic-test'
 const APP_TENANT = 'kinotic'
-// Seeded by the V5__e2e_app_fixtures migration, with the matching app user for APP_TENANT.
+// The app user for this (APP_ID, APP_TENANT) pair is seeded by the V5__e2e_app_fixtures migration.
 const APP_ID = 'e2e-named-query'
 
 interface LocalTestContext {

--- a/kinotic-js/e2e-tests/test/native/Versioned.test.ts
+++ b/kinotic-js/e2e-tests/test/native/Versioned.test.ts
@@ -18,7 +18,7 @@ import {
 
 const TEST_ORG_ID = 'kinotic-test'
 const APP_TENANT = 'kinotic'
-// Seeded by the V5__e2e_app_fixtures migration, with the matching app user for APP_TENANT.
+// The app user for this (APP_ID, APP_TENANT) pair is seeded by the V5__e2e_app_fixtures migration.
 const APP_ID = 'e2e-versioned'
 
 interface LocalTestContext {

--- a/kinotic-migration/src/main/resources/migrations/V5__e2e_app_fixtures.test.sql
+++ b/kinotic-migration/src/main/resources/migrations/V5__e2e_app_fixtures.test.sql
@@ -1,17 +1,9 @@
--- Fixture applications and APPLICATION-scope users for the kinotic-js e2e suites that act
--- through an application client. One application per suite: EntityDefinition ids derive from
+-- APPLICATION-scope users for the kinotic-js e2e suites that act through an application
+-- client. One applicationId per suite: EntityDefinition ids derive from
 -- organizationId.applicationId.entityName, so suites running in parallel need distinct
--- applications to avoid colliding on the same entity name. Password for every user: kinotic.
+-- applicationIds to avoid colliding on the same entity name. Password for every user: kinotic.
 -- Applies only when the migration app runs with the 'test' profile — the e2e compose stack
 -- sets it; a local stack must add it to seed these fixtures.
-
-INSERT INTO kinotic_application (id, organizationId, description) VALUES ('e2e-datastream', 'kinotic-test', 'e2e fixture application for the DataStream suite') WITH REFRESH;
-INSERT INTO kinotic_application (id, organizationId, description) VALUES ('e2e-admin-entity', 'kinotic-test', 'e2e fixture application for the AdminEntityService suite') WITH REFRESH;
-INSERT INTO kinotic_application (id, organizationId, description) VALUES ('e2e-named-query', 'kinotic-test', 'e2e fixture application for the NamedQuery suite') WITH REFRESH;
-INSERT INTO kinotic_application (id, organizationId, description) VALUES ('e2e-versioned', 'kinotic-test', 'e2e fixture application for the Versioned suite') WITH REFRESH;
-INSERT INTO kinotic_application (id, organizationId, description) VALUES ('e2e-entity-service', 'kinotic-test', 'e2e fixture application for the EntityService suite') WITH REFRESH;
-INSERT INTO kinotic_application (id, organizationId, description) VALUES ('e2e-admin-named-query', 'kinotic-test', 'e2e fixture application for the AdminNamedQuery suite') WITH REFRESH;
-INSERT INTO kinotic_application (id, organizationId, description) VALUES ('e2e-mcp', 'kinotic-test', 'e2e fixture application for the Mcp suite') WITH REFRESH;
 
 INSERT INTO kinotic_participant_identity (id, type, email, displayName, authType, organizationId, applicationId, tenantId, enabled) VALUES ('00000000-0000-0000-0000-000000000003', 'USER', 'app-e2e-datastream-kinotic@test.local', 'e2e DataStream App User', 'LOCAL', 'kinotic-test', 'e2e-datastream', 'kinotic', true) WITH REFRESH;
 INSERT INTO kinotic_participant_identity (id, type, email, displayName, authType, organizationId, applicationId, tenantId, enabled) VALUES ('00000000-0000-0000-0000-000000000004', 'USER', 'app-e2e-admin-entity-kinotic@test.local', 'e2e AdminEntityService App User', 'LOCAL', 'kinotic-test', 'e2e-admin-entity', 'kinotic', true) WITH REFRESH;


### PR DESCRIPTION
InsertStatementExecutor indexes a row under the plain value of its id column
with default routing, while ApplicationRepository inherits
AbstractOrganizationScopedRepository, which addresses documents by the
composite _id organizationId-id routed on organizationId. The seven seeded
applications were therefore invisible to findById, requireById, findAll and
search alike — kinotic_application has three shards, so even the org-filtered
search is pinned to a shard the rows never landed on.

Nothing read them: the suites use the id only to derive entity names and to
pick the seeded app user, and OAuthMcp already provisions its application
through createApplicationIfNotExist (#382). The APPLICATION-scope identities
and credentials in the same migration are unaffected — ParticipantIdentityRepository
extends AbstractRepository, which keys on the raw id.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014R9fPfjy6UG4oZHLrCzBb1