### PR TITLE
Machines authenticate with connection credentials, not an OAuth grant

### DIFF
--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/model/security/AuthType.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/model/security/AuthType.java
@@ -18,8 +18,8 @@ public enum AuthType {
     DELEGATED,
 
     /**
-     * The RFC 6749 client-credentials grant with a provisioned secret; the authentication
-     * method of every MACHINE identity.
+     * A provisioned client id and secret presented as connection credentials; the
+     * authentication method of every MACHINE identity.
      */
     CLIENT_CREDENTIALS
 }

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/model/security/MachineParticipantIdentity.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/model/security/MachineParticipantIdentity.java
@@ -8,11 +8,11 @@ import lombok.experimental.Accessors;
 /**
  * A non-human principal that authenticates with its own credential rather than on a person's
  * behalf — a platform daemon such as the vm-manager (SYSTEM scope), or an API client of one
- * application (APPLICATION scope, acting exactly as an application end-user does).
- * Authenticates through the RFC 6749 client-credentials grant: the identity's {@code id} is
- * the OAuth {@code client_id}, and the secret issued at provisioning is verified against the
- * credential store. Machines hold no refresh tokens — they re-authenticate with their secret —
- * and disabling one cuts it off on its next request.
+ * application (APPLICATION scope, acting exactly as an application end-user does). A machine
+ * connects through the Kinotic client with the identity's {@code id} as {@code clientId} and
+ * the secret issued at provisioning as {@code clientSecret}; the secret is verified against
+ * the credential store on every handshake, so disabling a machine cuts it off on its next
+ * connection.
  */
 @Getter
 @Setter

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/model/security/MachineProvisionResult.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/model/security/MachineProvisionResult.java
@@ -2,8 +2,8 @@ package org.kinotic.domain.api.model.security;
 
 /**
  * The outcome of provisioning a {@link MachineParticipantIdentity}: the saved identity and
- * the one and only disclosure of its client secret. The machine authenticates with
- * {@code (machine.id, clientSecret)} at the token endpoint; only a hash is stored, so the
+ * the one and only disclosure of its client secret. The machine connects with
+ * {@code (machine.id, clientSecret)} as its credentials; only a hash is stored, so the
  * plaintext here is unrecoverable once discarded.
  *
  * @param machine      the provisioned machine identity

--- a/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/ParticipantIdentityService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/api/services/security/ParticipantIdentityService.java
@@ -120,9 +120,8 @@ public interface ParticipantIdentityService extends IdentifiableCrudService<Part
 
     /**
      * Provisions a machine identity, assigning id and dates, enabling it, and generating the
-     * client secret it authenticates with through the client-credentials grant. The identity's
-     * id is its OAuth {@code client_id}; the secret is returned in plaintext exactly once and
-     * stored only as a hash.
+     * client secret it connects with. The identity's id is its {@code clientId}; the secret is
+     * returned in plaintext exactly once and stored only as a hash.
      *
      * @param machine the unsaved machine carrying display name and scope
      * @return a future emitting the saved machine together with its one-time secret
@@ -146,12 +145,12 @@ public interface ParticipantIdentityService extends IdentifiableCrudService<Part
     CompletableFuture<String> rotateMachineSecret(String machineId);
 
     /**
-     * Authenticates a machine by client-credentials: the machine with the given id must exist,
+     * Authenticates a machine by its credentials: the machine with the given id must exist,
      * be enabled, and hold a credential matching {@code clientSecret}. Every failure — unknown
-     * id, wrong kind of identity, disabled, or wrong secret — fails the same way, so the token
-     * endpoint leaks nothing about which check missed.
+     * id, wrong kind of identity, disabled, or wrong secret — fails the same way, so callers
+     * leak nothing about which check missed.
      *
-     * @param machineId    the machine's id, presented as the OAuth {@code client_id}
+     * @param machineId    the machine's id, presented as the {@code clientId} credential
      * @param clientSecret the secret issued at provisioning
      * @return a future emitting the authenticated machine, failed for any invalid credential
      */

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OAuthServerHandler.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/OAuthServerHandler.java
@@ -31,16 +31,10 @@ import java.nio.charset.StandardCharsets;
  * requires. Token responses carry a Kinotic access token plus a rotating refresh token, so clients
  * requesting {@code offline_access} refresh without re-consent.
  *
- * <p>Machine identities authenticate here too, through the RFC 6749 §4.4 client-credentials
- * grant: {@code client_id} is the machine's identity id, {@code client_secret} the secret issued
- * at provisioning ({@code client_secret_post}), and the response carries an access token only —
- * a machine re-authenticates with its secret instead of holding a refresh token.
- *
  * <p>Each grant stamps the audience of the surface it serves: the authorization-code grant issues
  * {@link KinoticAudience#MCP_TOOLS} tokens, the device grant {@link KinoticAudience#PUBLISHED_SERVICES}
- * tokens, the client-credentials grant {@link KinoticAudience#PUBLISHED_SERVICES} tokens, and the
- * refresh grant re-mints whichever audience its lineage was issued for. A user-approved grant's
- * token acts as the user who approved it; a client-credentials token acts as the machine itself.
+ * tokens, and the refresh grant re-mints whichever audience its lineage was issued for. Every token
+ * acts as the user who approved the grant.
  *
  * <p>Error responses use the RFC 6749 shape {@code {"error":"<code>"}}.
  */
@@ -92,11 +86,9 @@ public class OAuthServerHandler implements SuppliesGatewayRoutes {
                 .put("response_types_supported", new JsonArray().add("code"))
                 .put("grant_types_supported", new JsonArray().add("authorization_code")
                                                              .add("refresh_token")
-                                                             .add("client_credentials")
                                                              .add(DEVICE_CODE_GRANT_TYPE))
                 .put("code_challenge_methods_supported", new JsonArray().add("S256"))
-                .put("token_endpoint_auth_methods_supported", new JsonArray().add("none")
-                                                                             .add("client_secret_post"))
+                .put("token_endpoint_auth_methods_supported", new JsonArray().add("none"))
                 .put("scopes_supported", new JsonArray().add("offline_access")));
     }
 
@@ -184,8 +176,7 @@ public class OAuthServerHandler implements SuppliesGatewayRoutes {
 
     /**
      * {@code POST /api/auth/oauth/token} — form-encoded per RFC 6749. Supports the
-     * {@code authorization_code} (PKCE), {@code refresh_token}, {@code client_credentials},
-     * and RFC 8628 device-code grants.
+     * {@code authorization_code} (PKCE), {@code refresh_token}, and RFC 8628 device-code grants.
      */
     private void handleToken(RoutingContext ctx) {
         String grantType = ctx.request().getFormAttribute("grant_type");
@@ -193,29 +184,11 @@ public class OAuthServerHandler implements SuppliesGatewayRoutes {
             handleAuthorizationCodeGrant(ctx);
         } else if ("refresh_token".equals(grantType)) {
             handleRefreshTokenGrant(ctx);
-        } else if ("client_credentials".equals(grantType)) {
-            handleClientCredentialsGrant(ctx);
         } else if (DEVICE_CODE_GRANT_TYPE.equals(grantType)) {
             handleDeviceCodeGrant(ctx);
         } else {
             authEndpointSupport.respondError(ctx, 400, "unsupported_grant_type");
         }
-    }
-
-    private void handleClientCredentialsGrant(RoutingContext ctx) {
-        String clientId = ctx.request().getFormAttribute("client_id");
-        String clientSecret = ctx.request().getFormAttribute("client_secret");
-        if (clientId == null || clientId.isBlank() || clientSecret == null || clientSecret.isBlank()) {
-            authEndpointSupport.respondError(ctx, 400, "invalid_request");
-            return;
-        }
-        Future.fromCompletionStage(identityService.verifyMachineCredentials(clientId, clientSecret))
-              .onSuccess(machine -> authEndpointSupport.respondAccessToken(
-                      ctx, machine, KinoticAudience.PUBLISHED_SERVICES))
-              .onFailure(err -> {
-                  log.warn("Client credentials grant rejected for client {}", clientId);
-                  authEndpointSupport.respondError(ctx, 401, "invalid_client");
-              });
     }
 
     private void handleDeviceCodeGrant(RoutingContext ctx) {

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/rest/support/AuthEndpointSupport.java
@@ -229,19 +229,6 @@ public class AuthEndpointSupport {
      * access tokens. Both act as {@code identity}.
      */
     public void respondTokenPair(RoutingContext ctx, ParticipantIdentity identity, String refreshToken, KinoticAudience audience) {
-        respondTokens(ctx, identity, refreshToken, audience);
-    }
-
-    /**
-     * {@code 200 application/json} with an OAuth access token stamped for {@code audience} and
-     * no refresh token — the client-credentials response shape (RFC 6749 §4.4.3): the client
-     * holds a secret it re-authenticates with, so a refresh token has nothing to add.
-     */
-    public void respondAccessToken(RoutingContext ctx, ParticipantIdentity identity, KinoticAudience audience) {
-        respondTokens(ctx, identity, null, audience);
-    }
-
-    private void respondTokens(RoutingContext ctx, ParticipantIdentity identity, String refreshToken, KinoticAudience audience) {
         String accessToken;
         try {
             accessToken = mintAccessToken(identity, audience);
@@ -255,10 +242,8 @@ public class AuthEndpointSupport {
         JsonObject body = new JsonObject()
                 .put("access_token", accessToken)
                 .put("token_type", "Bearer")
-                .put("expires_in", ACCESS_TOKEN_TTL_SECONDS);
-        if (refreshToken != null) {
-            body.put("refresh_token", refreshToken);
-        }
+                .put("expires_in", ACCESS_TOKEN_TTL_SECONDS)
+                .put("refresh_token", refreshToken);
         ctx.response().putHeader("Content-Type", "application/json")
            // RFC 6749 §5.1 — a token response must never be cached by an intermediary
            .putHeader("Cache-Control", "no-store")

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/KinoticSecurityService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/KinoticSecurityService.java
@@ -10,6 +10,7 @@ import org.kinotic.core.api.security.Participant;
 import org.kinotic.core.api.security.SecurityService;
 import org.kinotic.domain.api.model.security.AuthType;
 import org.kinotic.domain.api.model.security.DelegatingParticipantIdentity;
+import org.kinotic.domain.api.model.security.MachineParticipantIdentity;
 import org.kinotic.domain.api.model.security.ParticipantIdentity;
 import org.kinotic.domain.api.services.security.ParticipantIdentityService;
 import org.kinotic.domain.api.utils.DomainUtil;
@@ -35,9 +36,11 @@ import java.util.TreeMap;
  * <p>
  * <b>Two paths:</b>
  * <ol>
- *   <li><b>Client credentials</b> — {@code clientId}/{@code clientSecret} upgrade headers, with
- *       the {@code organizationId} / {@code applicationId} headers selecting the scope to look
- *       in. Looks up the {@link ParticipantIdentity} by email + scope, verifies the bcrypt password.</li>
+ *   <li><b>Client credentials</b> — {@code clientId}/{@code clientSecret} upgrade headers. A
+ *       {@code clientId} containing {@code @} is a user email, looked up within the scope the
+ *       {@code organizationId} / {@code applicationId} headers select; any other
+ *       {@code clientId} is a {@link MachineParticipantIdentity} id, whose scope comes from
+ *       the identity itself. Both verify the bcrypt secret hash.</li>
  *   <li><b>Kinotic JWT</b> — {@code Authorization: Bearer <jwt>} header. The JWT was minted
  *       by {@link KinoticJwtIssuer} through one of the OAuth grants. We validate the JWT
  *       signature, then look up the {@link ParticipantIdentity} by id from the JWT {@code sub} claim and
@@ -45,7 +48,7 @@ import java.util.TreeMap;
  *       claims. The scope headers do not select scope here — the token carries its own.</li>
  * </ol>
  * IdP JWTs are never accepted directly here — the OIDC roundtrip terminates at the gateway,
- * which mints a Kinotic JWT for the STOMP handoff.
+ * which establishes the browser session the STOMP handshake reads.
  */
 @Slf4j
 @Component
@@ -73,14 +76,20 @@ public class KinoticSecurityService implements SecurityService {
         }
 
         String authHeader = authInfo.get("Authorization");
-        String email = authInfo.get("clientId");
-        String password = authInfo.get("clientSecret");
+        String clientId = authInfo.get("clientId");
+        String clientSecret = authInfo.get("clientSecret");
 
         Future<Participant> ret;
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             ret = authenticateKinoticJwt(authHeader.substring(7));
-        } else if (email != null || password != null) {
-            ret = authenticateEmailPassword(organizationId, applicationId, email, password);
+        } else if (clientId != null || clientSecret != null) {
+            // an email is a user credential; anything else is a machine identity id — machines
+            // carry their scope structurally, so the scope headers only apply to the user path
+            if (clientId != null && clientId.indexOf('@') >= 0) {
+                ret = authenticateEmailPassword(organizationId, applicationId, clientId, clientSecret);
+            } else {
+                ret = authenticateMachine(clientId, clientSecret);
+            }
         } else {
             // MCP hosts probe POST /mcp with no credentials to collect the RFC 9728 challenge, so
             // this is a routine step of the OAuth flow rather than a malformed credential attempt
@@ -126,6 +135,21 @@ public class KinoticSecurityService implements SecurityService {
                          }
                          return ret;
                      });
+    }
+
+    /**
+     * Authenticates a machine by its identity id and provisioned secret. Scope comes from the
+     * machine identity itself; every failure is the same generic error.
+     */
+    private Future<Participant> authenticateMachine(String clientId, String clientSecret) {
+        if (clientId == null || clientSecret == null) {
+            return Future.failedFuture(new AuthenticationException(
+                    "clientId and clientSecret headers are required for credential authentication"));
+        }
+        return Future.fromCompletionStage(identityService.verifyMachineCredentials(clientId, clientSecret),
+                                          vertx.getOrCreateContext())
+                     .map(machine -> (Participant) DomainUtil.createParticipant(machine))
+                     .recover(err -> Future.failedFuture(new AuthenticationException("Invalid credentials")));
     }
 
     private Future<Participant> verifyPasswordAndCreateParticipant(ParticipantIdentity user,

--- a/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/KinoticSecurityService.java
+++ b/kinotic-domain/src/main/java/org/kinotic/domain/internal/api/services/security/KinoticSecurityService.java
@@ -40,7 +40,8 @@ import java.util.TreeMap;
  *       {@code clientId} containing {@code @} is a user email, looked up within the scope the
  *       {@code organizationId} / {@code applicationId} headers select; any other
  *       {@code clientId} is a {@link MachineParticipantIdentity} id, whose scope comes from
- *       the identity itself. Both verify the bcrypt secret hash.</li>
+ *       the identity itself and must agree with the scope headers when they are supplied.
+ *       Both verify the bcrypt secret hash.</li>
  *   <li><b>Kinotic JWT</b> — {@code Authorization: Bearer <jwt>} header. The JWT was minted
  *       by {@link KinoticJwtIssuer} through one of the OAuth grants. We validate the JWT
  *       signature, then look up the {@link ParticipantIdentity} by id from the JWT {@code sub} claim and
@@ -83,12 +84,11 @@ public class KinoticSecurityService implements SecurityService {
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             ret = authenticateKinoticJwt(authHeader.substring(7));
         } else if (clientId != null || clientSecret != null) {
-            // an email is a user credential; anything else is a machine identity id — machines
-            // carry their scope structurally, so the scope headers only apply to the user path
+            // an email is a user credential; anything else is a machine identity id
             if (clientId != null && clientId.indexOf('@') >= 0) {
                 ret = authenticateEmailPassword(organizationId, applicationId, clientId, clientSecret);
             } else {
-                ret = authenticateMachine(clientId, clientSecret);
+                ret = authenticateMachine(organizationId, applicationId, clientId, clientSecret);
             }
         } else {
             // MCP hosts probe POST /mcp with no credentials to collect the RFC 9728 challenge, so
@@ -138,17 +138,31 @@ public class KinoticSecurityService implements SecurityService {
     }
 
     /**
-     * Authenticates a machine by its identity id and provisioned secret. Scope comes from the
-     * machine identity itself; every failure is the same generic error.
+     * Authenticates a machine by its identity id and provisioned secret. The machine's scope
+     * comes from the identity itself; the scope headers, when supplied, must agree with it —
+     * a client configured for the wrong organization or application is rejected. Every
+     * failure is the same generic error.
      */
-    private Future<Participant> authenticateMachine(String clientId, String clientSecret) {
+    private Future<Participant> authenticateMachine(String organizationId,
+                                                    String applicationId,
+                                                    String clientId,
+                                                    String clientSecret) {
         if (clientId == null || clientSecret == null) {
             return Future.failedFuture(new AuthenticationException(
                     "clientId and clientSecret headers are required for credential authentication"));
         }
         return Future.fromCompletionStage(identityService.verifyMachineCredentials(clientId, clientSecret),
                                           vertx.getOrCreateContext())
-                     .map(machine -> (Participant) DomainUtil.createParticipant(machine))
+                     .compose(machine -> {
+                         Future<Participant> ret;
+                         if ((organizationId != null && !organizationId.equals(machine.getOrganizationId()))
+                                 || (applicationId != null && !applicationId.equals(machine.getApplicationId()))) {
+                             ret = Future.failedFuture(new AuthenticationException("Invalid credentials"));
+                         } else {
+                             ret = Future.succeededFuture(DomainUtil.createParticipant(machine));
+                         }
+                         return ret;
+                     })
                      .recover(err -> Future.failedFuture(new AuthenticationException("Invalid credentials")));
     }
 

--- a/kinotic-frontend/src/pages/MachinesPage.vue
+++ b/kinotic-frontend/src/pages/MachinesPage.vue
@@ -36,8 +36,8 @@
                      autocomplete="off" autofocus @keyup.enter="create" />
         </div>
         <p class="text-sm text-muted-color m-0">
-          A machine calls this application's API with the OAuth client-credentials grant, using
-          the client id and secret shown after creation.
+          A machine connects to this application's API with the Kinotic client, using the
+          client id and secret shown after creation.
         </p>
       </div>
       <template #footer>

--- a/kinotic-js/e2e-tests/test/native/MachineIdentity.test.ts
+++ b/kinotic-js/e2e-tests/test/native/MachineIdentity.test.ts
@@ -1,0 +1,121 @@
+import {ConnectionInfo, Kinotic, KinoticSingleton, Pageable, SessionKeepAliveMode, createAuthenticatedWebSocketFactory} from '@kinotic-ai/core'
+import {KinoticOsCredentialsAuthProvider, MachineService} from '@kinotic-ai/os-api'
+import * as allure from 'allure-js-commons'
+import {afterAll, beforeAll, describe, expect, inject, it} from 'vitest'
+import {initKinoticClient, shutdownKinoticClient} from '../TestHelpers.js'
+
+// the machine identity V5__e2e_app_fixtures seeds for these tests (clientSecret: kinotic)
+const MACHINE_CLIENT_ID = '00000000-0000-0000-0000-000000000010'
+const MACHINE_CLIENT_SECRET = 'kinotic'
+// a kinotic-test org USER — a valid identity + password that must nevertheless be refused
+// as machine credentials
+const ORG_USER_ID = '00000000-0000-0000-0000-000000000002'
+
+/**
+ * Covers machine identities: credential-header connections through the Kinotic client — the
+ * way every machine (vm-manager, an external API caller of an org's application) reaches
+ * Kinotic — and the management lifecycle org members drive through MachineService.
+ */
+describe('Kinotic JS', () => {
+
+    const base = () => `http://${inject('KINOTIC_HOST')}:${inject('KINOTIC_PORT')}`
+
+    /**
+     * Attempts a full Kinotic client connection authenticated by machine credentials on the
+     * upgrade headers — exactly how a machine connects.
+     */
+    async function machineConnect(clientId: string, clientSecret: string,
+                                  organizationId?: string, applicationId?: string): Promise<'connected' | 'rejected'> {
+        const machineKinotic = new KinoticSingleton()
+        const ci = new ConnectionInfo()
+        ci.host = inject('KINOTIC_HOST')
+        ci.port = inject('KINOTIC_PORT')
+        ci.useSSL = false
+        ci.maxConnectionAttempts = 1
+        ci.sessionKeepAlive = SessionKeepAliveMode.NONE
+        ci.webSocketFactory = createAuthenticatedWebSocketFactory(ci,
+            new KinoticOsCredentialsAuthProvider(clientId, clientSecret, organizationId, applicationId))
+        try {
+            await machineKinotic.connect(ci)
+            await machineKinotic.disconnect()
+            return 'connected'
+        } catch {
+            return 'rejected'
+        }
+    }
+
+    beforeAll(async () => {
+        await allure.suite('e2e-tests/native')
+        await allure.subSuite('MachineIdentity')
+        // the org user (kinotic@kinotic.local / kinotic-test) that manages machines
+        await initKinoticClient()
+    }, 120000)
+
+    afterAll(async () => {
+        await shutdownKinoticClient()
+    }, 60000)
+
+    it('authenticates a machine with its credentials on the connection', async () => {
+        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET)).toBe('connected')
+        // scope headers, when supplied, must agree with the machine's own scope
+        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET, 'kinotic-test', 'e2e-mcp')).toBe('connected')
+    })
+
+    it('rejects connections that do not prove a machine identity', async () => {
+        // wrong secret
+        expect(await machineConnect(MACHINE_CLIENT_ID, 'wrong')).toBe('rejected')
+        // unknown client
+        expect(await machineConnect('no-such-machine', MACHINE_CLIENT_SECRET)).toBe('rejected')
+        // a USER id with its correct password — ids without '@' resolve only to machines
+        expect(await machineConnect(ORG_USER_ID, 'kinotic')).toBe('rejected')
+        // valid credentials but scope headers that contradict the machine's own scope
+        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET, 'kinotic-test', 'e2e-datastream')).toBe('rejected')
+        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET, 'some-other-org')).toBe('rejected')
+        // the OAuth surface does not speak client_credentials — machines connect, not mint
+        const grant = await fetch(`${base()}/api/auth/oauth/token`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+            body: new URLSearchParams({grant_type: 'client_credentials',
+                client_id: MACHINE_CLIENT_ID, client_secret: MACHINE_CLIENT_SECRET})
+        })
+        expect(grant.status).toBe(400)
+        expect((await grant.json()).error).toBe('unsupported_grant_type')
+    })
+
+    it('manages the machine lifecycle through MachineService', async () => {
+        // the signed-in org user provisions a machine for one of the org's applications.
+        // The application is created through the API: migration-seeded kinotic_application
+        // rows are written with a plain _id, so the org-scoped composite-id lookup behind
+        // createMachine cannot see them.
+        await Kinotic.applications.createApplicationIfNotExist('e2e-machines', 'e2e fixture application for the machine lifecycle test')
+        const machineService = new MachineService(Kinotic)
+        const created = await machineService.createMachine('e2e Lifecycle Machine', 'e2e-machines')
+        const machineId = created.machine.id!
+        expect(created.clientSecret).toBeTruthy()
+
+        // the provisioned credentials connect, with and without declared scope
+        expect(await machineConnect(machineId, created.clientSecret)).toBe('connected')
+        expect(await machineConnect(machineId, created.clientSecret, 'kinotic-test', 'e2e-machines')).toBe('connected')
+
+        // and the machine is listed for its application
+        const listed = await machineService.findMachines('e2e-machines', Pageable.create(0, 50))
+        expect(listed.content?.some(m => m.id === machineId)).toBe(true)
+
+        // rotation kills the old secret and issues a working replacement
+        const rotatedSecret = await machineService.rotateSecret(machineId)
+        expect(await machineConnect(machineId, created.clientSecret)).toBe('rejected')
+        expect(await machineConnect(machineId, rotatedSecret)).toBe('connected')
+
+        // disabling cuts the machine off on its next connection
+        await machineService.setMachineEnabled(machineId, false)
+        expect(await machineConnect(machineId, rotatedSecret)).toBe('rejected')
+
+        // enabling restores access with the same secret
+        await machineService.setMachineEnabled(machineId, true)
+        expect(await machineConnect(machineId, rotatedSecret)).toBe('connected')
+
+        // removal is permanent
+        await machineService.removeMachine(machineId)
+        expect(await machineConnect(machineId, rotatedSecret)).toBe('rejected')
+    }, 90000)
+})

--- a/kinotic-js/e2e-tests/test/native/OAuthMcp.test.ts
+++ b/kinotic-js/e2e-tests/test/native/OAuthMcp.test.ts
@@ -1,5 +1,5 @@
-import {ConnectionInfo, Kinotic, KinoticSingleton, Pageable, SessionKeepAliveMode, createAuthenticatedWebSocketFactory} from '@kinotic-ai/core'
-import {DelegateKind, DelegateService, KinoticOsCredentialsAuthProvider, MachineService, OAuthApprovalService} from '@kinotic-ai/os-api'
+import {Kinotic, Pageable} from '@kinotic-ai/core'
+import {DelegateKind, DelegateService, OAuthApprovalService} from '@kinotic-ai/os-api'
 import type {DelegatingParticipantIdentity} from '@kinotic-ai/os-api'
 import * as allure from 'allure-js-commons'
 import {randomBytes, createHash} from 'node:crypto'
@@ -8,13 +8,6 @@ import {afterAll, beforeAll, describe, expect, inject, it} from 'vitest'
 import {initKinoticClient, shutdownKinoticClient} from '../TestHelpers.js'
 
 const DEVICE_CODE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
-
-// the machine identity V3__kinotic_test_users seeds for these tests (client_secret: kinotic)
-const MACHINE_CLIENT_ID = '00000000-0000-0000-0000-000000000010'
-const MACHINE_CLIENT_SECRET = 'kinotic'
-// the kinotic-test org USER the same migration seeds — a valid identity + password that must
-// nevertheless be refused as machine credentials
-const ORG_USER_ID = '00000000-0000-0000-0000-000000000002'
 
 /**
  * Attempts the STOMP WebSocket upgrade with the given bearer token. Resolves with the HTTP status
@@ -39,8 +32,7 @@ function stompHandshake(url: string, token: string): Promise<number | 'open'> {
 /**
  * Covers the MCP authorization surface: the 401 discovery challenge, the metadata documents a host
  * reads to find the authorization server, the Client ID Metadata Document rules the authorize
- * endpoint enforces on a client_id, the device grant the CLI logs in with, and the
- * credential-header connections machine identities authenticate with.
+ * endpoint enforces on a client_id, and the device grant the CLI logs in with.
  *
  * The authorization-code happy path is not covered here: a client_id must be an https URL whose
  * host does not resolve to a special-use address, which no host reachable from this suite
@@ -53,29 +45,6 @@ describe('Kinotic JS', () => {
     const base = () => `http://${inject('KINOTIC_HOST')}:${inject('KINOTIC_PORT')}`
     const stompUrl = () => `ws://${inject('KINOTIC_HOST')}:${inject('KINOTIC_PORT')}/v1`
 
-    /**
-     * Attempts a full Kinotic client connection authenticated by machine credentials on the
-     * upgrade headers — exactly how a machine (vm-manager, an external API caller) connects.
-     */
-    async function machineConnect(clientId: string, clientSecret: string,
-                                  organizationId?: string, applicationId?: string): Promise<'connected' | 'rejected'> {
-        const machineKinotic = new KinoticSingleton()
-        const ci = new ConnectionInfo()
-        ci.host = inject('KINOTIC_HOST')
-        ci.port = inject('KINOTIC_PORT')
-        ci.useSSL = false
-        ci.maxConnectionAttempts = 1
-        ci.sessionKeepAlive = SessionKeepAliveMode.NONE
-        ci.webSocketFactory = createAuthenticatedWebSocketFactory(ci,
-            new KinoticOsCredentialsAuthProvider(clientId, clientSecret, organizationId, applicationId))
-        try {
-            await machineKinotic.connect(ci)
-            await machineKinotic.disconnect()
-            return 'connected'
-        } catch {
-            return 'rejected'
-        }
-    }
 
     beforeAll(async () => {
         await allure.suite('e2e-tests/native')
@@ -218,67 +187,4 @@ describe('Kinotic JS', () => {
         expect(await stompHandshake(stompUrl(), rotated.access_token)).toBe(401)
     }, 60000)
 
-    it('authenticates a machine with its credentials on the connection', async () => {
-        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET)).toBe('connected')
-        // scope headers, when supplied, must agree with the machine's own scope
-        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET, 'kinotic-test', 'e2e-mcp')).toBe('connected')
-    })
-
-    it('rejects connections that do not prove a machine identity', async () => {
-        // wrong secret
-        expect(await machineConnect(MACHINE_CLIENT_ID, 'wrong')).toBe('rejected')
-        // unknown client
-        expect(await machineConnect('no-such-machine', MACHINE_CLIENT_SECRET)).toBe('rejected')
-        // a USER id with its correct password — ids without '@' resolve only to machines
-        expect(await machineConnect(ORG_USER_ID, 'kinotic')).toBe('rejected')
-        // valid credentials but scope headers that contradict the machine's own scope
-        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET, 'kinotic-test', 'e2e-datastream')).toBe('rejected')
-        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET, 'some-other-org')).toBe('rejected')
-        // the OAuth surface no longer speaks client_credentials — machines connect, not mint
-        const grant = await fetch(`${base()}/api/auth/oauth/token`, {
-            method: 'POST',
-            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-            body: new URLSearchParams({grant_type: 'client_credentials',
-                client_id: MACHINE_CLIENT_ID, client_secret: MACHINE_CLIENT_SECRET})
-        })
-        expect(grant.status).toBe(400)
-        expect((await grant.json()).error).toBe('unsupported_grant_type')
-    })
-
-    it('manages the machine lifecycle through MachineService', async () => {
-        // the signed-in org user provisions a machine for one of the org's applications.
-        // The application is created through the API: migration-seeded kinotic_application
-        // rows are written with a plain _id, so the org-scoped composite-id lookup behind
-        // createMachine cannot see them.
-        await Kinotic.applications.createApplicationIfNotExist('e2e-machines', 'e2e fixture application for the machine lifecycle test')
-        const machineService = new MachineService(Kinotic)
-        const created = await machineService.createMachine('e2e Lifecycle Machine', 'e2e-machines')
-        const machineId = created.machine.id!
-        expect(created.clientSecret).toBeTruthy()
-
-        // the provisioned credentials connect, with and without declared scope
-        expect(await machineConnect(machineId, created.clientSecret)).toBe('connected')
-        expect(await machineConnect(machineId, created.clientSecret, 'kinotic-test', 'e2e-machines')).toBe('connected')
-
-        // and the machine is listed for its application
-        const listed = await machineService.findMachines('e2e-machines', Pageable.create(0, 50))
-        expect(listed.content?.some(m => m.id === machineId)).toBe(true)
-
-        // rotation kills the old secret and issues a working replacement
-        const rotatedSecret = await machineService.rotateSecret(machineId)
-        expect(await machineConnect(machineId, created.clientSecret)).toBe('rejected')
-        expect(await machineConnect(machineId, rotatedSecret)).toBe('connected')
-
-        // disabling cuts the machine off on its next connection
-        await machineService.setMachineEnabled(machineId, false)
-        expect(await machineConnect(machineId, rotatedSecret)).toBe('rejected')
-
-        // enabling restores access with the same secret
-        await machineService.setMachineEnabled(machineId, true)
-        expect(await machineConnect(machineId, rotatedSecret)).toBe('connected')
-
-        // removal is permanent
-        await machineService.removeMachine(machineId)
-        expect(await machineConnect(machineId, rotatedSecret)).toBe('rejected')
-    }, 90000)
 })

--- a/kinotic-js/e2e-tests/test/native/OAuthMcp.test.ts
+++ b/kinotic-js/e2e-tests/test/native/OAuthMcp.test.ts
@@ -57,7 +57,8 @@ describe('Kinotic JS', () => {
      * Attempts a full Kinotic client connection authenticated by machine credentials on the
      * upgrade headers — exactly how a machine (vm-manager, an external API caller) connects.
      */
-    async function machineConnect(clientId: string, clientSecret: string): Promise<'connected' | 'rejected'> {
+    async function machineConnect(clientId: string, clientSecret: string,
+                                  organizationId?: string, applicationId?: string): Promise<'connected' | 'rejected'> {
         const machineKinotic = new KinoticSingleton()
         const ci = new ConnectionInfo()
         ci.host = inject('KINOTIC_HOST')
@@ -65,7 +66,8 @@ describe('Kinotic JS', () => {
         ci.useSSL = false
         ci.maxConnectionAttempts = 1
         ci.sessionKeepAlive = SessionKeepAliveMode.NONE
-        ci.webSocketFactory = createAuthenticatedWebSocketFactory(ci, new KinoticOsCredentialsAuthProvider(clientId, clientSecret))
+        ci.webSocketFactory = createAuthenticatedWebSocketFactory(ci,
+            new KinoticOsCredentialsAuthProvider(clientId, clientSecret, organizationId, applicationId))
         try {
             await machineKinotic.connect(ci)
             await machineKinotic.disconnect()
@@ -218,6 +220,8 @@ describe('Kinotic JS', () => {
 
     it('authenticates a machine with its credentials on the connection', async () => {
         expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET)).toBe('connected')
+        // scope headers, when supplied, must agree with the machine's own scope
+        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET, 'kinotic-test', 'e2e-mcp')).toBe('connected')
     })
 
     it('rejects connections that do not prove a machine identity', async () => {
@@ -227,6 +231,9 @@ describe('Kinotic JS', () => {
         expect(await machineConnect('no-such-machine', MACHINE_CLIENT_SECRET)).toBe('rejected')
         // a USER id with its correct password — ids without '@' resolve only to machines
         expect(await machineConnect(ORG_USER_ID, 'kinotic')).toBe('rejected')
+        // valid credentials but scope headers that contradict the machine's own scope
+        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET, 'kinotic-test', 'e2e-datastream')).toBe('rejected')
+        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET, 'some-other-org')).toBe('rejected')
         // the OAuth surface no longer speaks client_credentials — machines connect, not mint
         const grant = await fetch(`${base()}/api/auth/oauth/token`, {
             method: 'POST',
@@ -249,8 +256,9 @@ describe('Kinotic JS', () => {
         const machineId = created.machine.id!
         expect(created.clientSecret).toBeTruthy()
 
-        // the provisioned credentials connect
+        // the provisioned credentials connect, with and without declared scope
         expect(await machineConnect(machineId, created.clientSecret)).toBe('connected')
+        expect(await machineConnect(machineId, created.clientSecret, 'kinotic-test', 'e2e-machines')).toBe('connected')
 
         // and the machine is listed for its application
         const listed = await machineService.findMachines('e2e-machines', Pageable.create(0, 50))

--- a/kinotic-js/e2e-tests/test/native/OAuthMcp.test.ts
+++ b/kinotic-js/e2e-tests/test/native/OAuthMcp.test.ts
@@ -1,5 +1,5 @@
-import {Kinotic, Pageable} from '@kinotic-ai/core'
-import {DelegateKind, DelegateService, MachineService, OAuthApprovalService} from '@kinotic-ai/os-api'
+import {ConnectionInfo, Kinotic, KinoticSingleton, Pageable, SessionKeepAliveMode, createAuthenticatedWebSocketFactory} from '@kinotic-ai/core'
+import {DelegateKind, DelegateService, KinoticOsCredentialsAuthProvider, MachineService, OAuthApprovalService} from '@kinotic-ai/os-api'
 import type {DelegatingParticipantIdentity} from '@kinotic-ai/os-api'
 import * as allure from 'allure-js-commons'
 import {randomBytes, createHash} from 'node:crypto'
@@ -13,7 +13,7 @@ const DEVICE_CODE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code'
 const MACHINE_CLIENT_ID = '00000000-0000-0000-0000-000000000010'
 const MACHINE_CLIENT_SECRET = 'kinotic'
 // the kinotic-test org USER the same migration seeds — a valid identity + password that must
-// nevertheless be refused by the machine grant
+// nevertheless be refused as machine credentials
 const ORG_USER_ID = '00000000-0000-0000-0000-000000000002'
 
 /**
@@ -40,7 +40,7 @@ function stompHandshake(url: string, token: string): Promise<number | 'open'> {
  * Covers the MCP authorization surface: the 401 discovery challenge, the metadata documents a host
  * reads to find the authorization server, the Client ID Metadata Document rules the authorize
  * endpoint enforces on a client_id, the device grant the CLI logs in with, and the
- * client-credentials grant machine identities authenticate through.
+ * credential-header connections machine identities authenticate with.
  *
  * The authorization-code happy path is not covered here: a client_id must be an https URL whose
  * host does not resolve to a special-use address, which no host reachable from this suite
@@ -52,6 +52,28 @@ describe('Kinotic JS', () => {
 
     const base = () => `http://${inject('KINOTIC_HOST')}:${inject('KINOTIC_PORT')}`
     const stompUrl = () => `ws://${inject('KINOTIC_HOST')}:${inject('KINOTIC_PORT')}/v1`
+
+    /**
+     * Attempts a full Kinotic client connection authenticated by machine credentials on the
+     * upgrade headers — exactly how a machine (vm-manager, an external API caller) connects.
+     */
+    async function machineConnect(clientId: string, clientSecret: string): Promise<'connected' | 'rejected'> {
+        const machineKinotic = new KinoticSingleton()
+        const ci = new ConnectionInfo()
+        ci.host = inject('KINOTIC_HOST')
+        ci.port = inject('KINOTIC_PORT')
+        ci.useSSL = false
+        ci.maxConnectionAttempts = 1
+        ci.sessionKeepAlive = SessionKeepAliveMode.NONE
+        ci.webSocketFactory = createAuthenticatedWebSocketFactory(ci, new KinoticOsCredentialsAuthProvider(clientId, clientSecret))
+        try {
+            await machineKinotic.connect(ci)
+            await machineKinotic.disconnect()
+            return 'connected'
+        } catch {
+            return 'rejected'
+        }
+    }
 
     beforeAll(async () => {
         await allure.suite('e2e-tests/native')
@@ -194,60 +216,29 @@ describe('Kinotic JS', () => {
         expect(await stompHandshake(stompUrl(), rotated.access_token)).toBe(401)
     }, 60000)
 
-    it('advertises the client-credentials grant in the server metadata', async () => {
-        const asMetadata = await (await fetch(`${base()}/.well-known/oauth-authorization-server`)).json()
-        expect(asMetadata.grant_types_supported).toContain('client_credentials')
-        expect(asMetadata.token_endpoint_auth_methods_supported).toContain('client_secret_post')
+    it('authenticates a machine with its credentials on the connection', async () => {
+        expect(await machineConnect(MACHINE_CLIENT_ID, MACHINE_CLIENT_SECRET)).toBe('connected')
     })
 
-    it('authenticates a machine through the client-credentials grant', async () => {
-        const tokenResponse = await fetch(`${base()}/api/auth/oauth/token`, {
+    it('rejects connections that do not prove a machine identity', async () => {
+        // wrong secret
+        expect(await machineConnect(MACHINE_CLIENT_ID, 'wrong')).toBe('rejected')
+        // unknown client
+        expect(await machineConnect('no-such-machine', MACHINE_CLIENT_SECRET)).toBe('rejected')
+        // a USER id with its correct password — ids without '@' resolve only to machines
+        expect(await machineConnect(ORG_USER_ID, 'kinotic')).toBe('rejected')
+        // the OAuth surface no longer speaks client_credentials — machines connect, not mint
+        const grant = await fetch(`${base()}/api/auth/oauth/token`, {
             method: 'POST',
             headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-            body: new URLSearchParams({
-                grant_type: 'client_credentials',
-                client_id: MACHINE_CLIENT_ID,
-                client_secret: MACHINE_CLIENT_SECRET
-            })
+            body: new URLSearchParams({grant_type: 'client_credentials',
+                client_id: MACHINE_CLIENT_ID, client_secret: MACHINE_CLIENT_SECRET})
         })
-        expect(tokenResponse.status).toBe(200)
-        expect(tokenResponse.headers.get('Cache-Control')).toBe('no-store')
-        const tokens = await tokenResponse.json()
-
-        // RFC 6749 §4.4.3 — no refresh token; the machine re-authenticates with its secret
-        expect(tokens.refresh_token).toBeUndefined()
-        expect(tokens.access_token).toBeTruthy()
-        expect(await stompHandshake(stompUrl(), tokens.access_token)).toBe('open')
-    })
-
-    it('rejects client-credentials requests that do not prove a machine identity', async () => {
-        const token = (params: Record<string, string>) =>
-            fetch(`${base()}/api/auth/oauth/token`, {
-                method: 'POST',
-                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-                body: new URLSearchParams({grant_type: 'client_credentials', ...params})
-            })
-
-        // missing credentials
-        expect((await token({client_id: MACHINE_CLIENT_ID})).status).toBe(400)
-        // wrong secret
-        expect((await token({client_id: MACHINE_CLIENT_ID, client_secret: 'wrong'})).status).toBe(401)
-        // unknown client
-        expect((await token({client_id: 'no-such-machine', client_secret: MACHINE_CLIENT_SECRET})).status).toBe(401)
-        // a USER id with its correct password — only MACHINE identities may use this grant
-        const userAsMachine = await token({client_id: ORG_USER_ID, client_secret: 'kinotic'})
-        expect(userAsMachine.status).toBe(401)
-        expect((await userAsMachine.json()).error).toBe('invalid_client')
+        expect(grant.status).toBe(400)
+        expect((await grant.json()).error).toBe('unsupported_grant_type')
     })
 
     it('manages the machine lifecycle through MachineService', async () => {
-        const token = (clientId: string, clientSecret: string) =>
-            fetch(`${base()}/api/auth/oauth/token`, {
-                method: 'POST',
-                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-                body: new URLSearchParams({grant_type: 'client_credentials', client_id: clientId, client_secret: clientSecret})
-            })
-
         // the signed-in org user provisions a machine for one of the org's applications.
         // The application is created through the API: migration-seeded kinotic_application
         // rows are written with a plain _id, so the org-scoped composite-id lookup behind
@@ -258,11 +249,8 @@ describe('Kinotic JS', () => {
         const machineId = created.machine.id!
         expect(created.clientSecret).toBeTruthy()
 
-        // the provisioned credentials authenticate through the grant
-        const first = await token(machineId, created.clientSecret)
-        expect(first.status).toBe(200)
-        const firstTokens = await first.json()
-        expect(await stompHandshake(stompUrl(), firstTokens.access_token)).toBe('open')
+        // the provisioned credentials connect
+        expect(await machineConnect(machineId, created.clientSecret)).toBe('connected')
 
         // and the machine is listed for its application
         const listed = await machineService.findMachines('e2e-machines', Pageable.create(0, 50))
@@ -270,20 +258,19 @@ describe('Kinotic JS', () => {
 
         // rotation kills the old secret and issues a working replacement
         const rotatedSecret = await machineService.rotateSecret(machineId)
-        expect((await token(machineId, created.clientSecret)).status).toBe(401)
-        expect((await token(machineId, rotatedSecret)).status).toBe(200)
+        expect(await machineConnect(machineId, created.clientSecret)).toBe('rejected')
+        expect(await machineConnect(machineId, rotatedSecret)).toBe('connected')
 
-        // disabling cuts the machine off — the grant and unexpired access tokens alike
+        // disabling cuts the machine off on its next connection
         await machineService.setMachineEnabled(machineId, false)
-        expect((await token(machineId, rotatedSecret)).status).toBe(401)
-        expect(await stompHandshake(stompUrl(), firstTokens.access_token)).toBe(401)
+        expect(await machineConnect(machineId, rotatedSecret)).toBe('rejected')
 
         // enabling restores access with the same secret
         await machineService.setMachineEnabled(machineId, true)
-        expect((await token(machineId, rotatedSecret)).status).toBe(200)
+        expect(await machineConnect(machineId, rotatedSecret)).toBe('connected')
 
         // removal is permanent
         await machineService.removeMachine(machineId)
-        expect((await token(machineId, rotatedSecret)).status).toBe(401)
-    }, 60000)
+        expect(await machineConnect(machineId, rotatedSecret)).toBe('rejected')
+    }, 90000)
 })

--- a/kinotic-js/workspace/packages/os-api/src/api/model/security/AuthType.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/model/security/AuthType.ts
@@ -12,8 +12,8 @@ export enum AuthType {
      */
     DELEGATED = 'DELEGATED',
     /**
-     * The RFC 6749 client-credentials grant with a provisioned secret; the authentication
-     * method of every MACHINE identity.
+     * A provisioned client id and secret presented as connection credentials; the
+     * authentication method of every MACHINE identity.
      */
     CLIENT_CREDENTIALS = 'CLIENT_CREDENTIALS'
 }

--- a/kinotic-js/workspace/packages/os-api/src/api/model/security/MachineParticipantIdentity.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/model/security/MachineParticipantIdentity.ts
@@ -3,8 +3,8 @@ import { ParticipantIdentityType } from '@/api/model/security/ParticipantIdentit
 
 /**
  * A non-human principal with its own credential — a platform daemon or an external caller of
- * an organization's application API. Authenticates through the client-credentials grant: the
- * identity's id is the OAuth client_id, verified against the secret issued at provisioning.
+ * an organization's application API. Connects through the Kinotic client with the identity's
+ * id as clientId, verified against the secret issued at provisioning.
  */
 export class MachineParticipantIdentity extends ParticipantIdentity {
     public readonly type: ParticipantIdentityType.MACHINE = ParticipantIdentityType.MACHINE

--- a/kinotic-js/workspace/packages/os-api/src/api/services/IMachineService.ts
+++ b/kinotic-js/workspace/packages/os-api/src/api/services/IMachineService.ts
@@ -6,10 +6,10 @@ import type { MachineProvisionResult } from '@/api/model/security/MachineProvisi
 
 /**
  * Machine-identity management for the applications of the caller's organization. A machine is
- * a non-human API client of one application — it authenticates through the client-credentials
- * grant with the identity's id as client_id and a secret issued here, and acts with that
- * application's scope. The application must belong to the caller's organization, and only its
- * machines are visible or mutable.
+ * a non-human API client of one application — it connects through the Kinotic client with the
+ * identity's id as clientId and a secret issued here, and acts with that application's scope.
+ * The application must belong to the caller's organization, and only its machines are visible
+ * or mutable.
  */
 export interface IMachineService {
 
@@ -25,8 +25,8 @@ export interface IMachineService {
 
     /**
      * Replaces a machine's client secret, returning the new secret exactly once. The old
-     * secret stops working immediately; tokens the machine already holds run out on their
-     * own short TTL.
+     * secret stops working immediately; a connection the machine already holds lasts until
+     * it disconnects.
      */
     rotateSecret(machineId: string): Promise<string>
 

--- a/kinotic-migration/src/main/resources/migrations/V5__e2e_app_fixtures.test.sql
+++ b/kinotic-migration/src/main/resources/migrations/V5__e2e_app_fixtures.test.sql
@@ -21,7 +21,7 @@ INSERT INTO kinotic_identity_credential (id, secretHash) VALUES ('00000000-0000-
 INSERT INTO kinotic_identity_credential (id, secretHash) VALUES ('00000000-0000-0000-0000-000000000008', '$2b$12$ztUtxd/6nRYTACObjRNnMOisx3QlNuP2GmabcBdrv4Vcd6Vs46GaG') WITH REFRESH;
 INSERT INTO kinotic_identity_credential (id, secretHash) VALUES ('00000000-0000-0000-0000-000000000009', '$2b$12$ztUtxd/6nRYTACObjRNnMOisx3QlNuP2GmabcBdrv4Vcd6Vs46GaG') WITH REFRESH;
 
--- APPLICATION-scope machine identity for the client-credentials grant e2e tests
--- (client_id: the identity id below, client_secret: kinotic)
+-- APPLICATION-scope machine identity for the machine connection e2e tests
+-- (clientId: the identity id below, clientSecret: kinotic)
 INSERT INTO kinotic_participant_identity (id, type, displayName, authType, organizationId, applicationId, enabled) VALUES ('00000000-0000-0000-0000-000000000010', 'MACHINE', 'e2e Test Machine', 'CLIENT_CREDENTIALS', 'kinotic-test', 'e2e-mcp', true) WITH REFRESH;
 INSERT INTO kinotic_identity_credential (id, secretHash) VALUES ('00000000-0000-0000-0000-000000000010', '$2b$12$ztUtxd/6nRYTACObjRNnMOisx3QlNuP2GmabcBdrv4Vcd6Vs46GaG') WITH REFRESH;

--- a/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/MachineService.java
+++ b/kinotic-os-api/src/main/java/org/kinotic/os/api/services/security/MachineService.java
@@ -10,12 +10,12 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * Machine-identity management for the applications of the caller's organization, used by the
- * web app. A machine is a non-human API client of one application — it authenticates through
- * the client-credentials grant with the identity's id as {@code client_id} and a secret
- * issued here, and acts with that application's scope, exactly the position an application
- * end-user occupies. Every method derives the organization from the authenticated
- * participant: only org members may call, the application must belong to that organization,
- * and only its machines are visible or mutable.
+ * web app. A machine is a non-human API client of one application — it connects through the
+ * Kinotic client with the identity's id as {@code clientId} and a secret issued here, and
+ * acts with that application's scope, exactly the position an application end-user occupies.
+ * Every method derives the organization from the authenticated participant: only org members
+ * may call, the application must belong to that organization, and only its machines are
+ * visible or mutable.
  */
 @Publish
 public interface MachineService {
@@ -36,8 +36,8 @@ public interface MachineService {
 
     /**
      * Replaces the client secret of one of the caller's organization's machines, returning the
-     * new secret exactly once. The old secret stops working immediately; tokens the machine
-     * already holds run out on their own short TTL.
+     * new secret exactly once. The old secret stops working immediately; a connection the
+     * machine already holds lasts until it disconnects.
      *
      * @param machineId a machine belonging to the caller's organization
      */
@@ -45,8 +45,8 @@ public interface MachineService {
 
     /**
      * Enables or disables one of the caller's organization's machines. A disabled machine is
-     * cut off on its next request — token issuance and every authenticated call alike — and
-     * enabling it restores access with the same credential.
+     * cut off on its next connection, and enabling it restores access with the same
+     * credential.
      *
      * @param machineId a machine belonging to the caller's organization
      */

--- a/website/content/02.platform/05.system-security.md
+++ b/website/content/02.platform/05.system-security.md
@@ -115,18 +115,16 @@ Revocation follows from the model: authentication re-reads the identity on every
 
 Each approval issues a refresh-token lineage under the delegate — a *session*, labeled with the device name the client supplied (the CLI sends one with `device_name` on the device-authorization request). The published `DelegateService` gives the signed-in user their own delegates and sessions — list them, end a single session, or revoke a delegate entirely — surfaced in the SPA as the **Authorized access** page.
 
-### Machine identities and the client-credentials grant
+### Machine identities
 
-A machine authenticates through the standard [RFC 6749 §4.4](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) client-credentials grant at the same token endpoint every other flow uses: its identity id is the OAuth `client_id`, and the secret issued at provisioning is presented as `client_secret` (`client_secret_post`). The response carries an access token only — no refresh token, per §4.4.3 — so a machine's steady state is a stateless loop: authenticate with the stored secret, use the token until it nears expiry, authenticate again. Any crash or restart self-heals, because the credential never changes. Any off-the-shelf OAuth client library speaks this grant with nothing but configuration:
+A machine connects the same way every Kinotic client does — over the STOMP gateway, authenticated by credentials on the WebSocket upgrade: its identity id as `clientId` and the secret issued at provisioning as `clientSecret`. A `clientId` containing `@` is a user email; anything else resolves only to a `MachineParticipantIdentity`, so a user's id and password can never authenticate as a machine. The machine's scope comes structurally from its own identity — no scope headers needed. There is no token to manage: the client library owns connect and reconnect, re-presenting the same static credentials, so any crash or restart self-heals.
 
-```
-POST /api/auth/oauth/token
-Content-Type: application/x-www-form-urlencoded
-
-grant_type=client_credentials&client_id=<machine id>&client_secret=<secret>
+```typescript
+await Kinotic.connect(buildConnectionInfo(host, port,
+    new KinoticOsCredentialsAuthProvider(machineId, machineSecret)))
 ```
 
-Provisioning generates the secret — it is returned in plaintext exactly once and stored only as a hash, in the same credential store that holds user password hashes. Revocation is the same switch every identity has: disabling the machine identity cuts it off on its next request, unexpired access tokens included, because authentication re-reads the identity every time. Only `MachineParticipantIdentity` rows may use the grant — a user's id and password are refused at the token endpoint regardless of validity.
+Provisioning generates the secret — it is returned in plaintext exactly once and stored only as a hash, in the same credential store that holds user password hashes. The secret is verified on every handshake, so disabling the machine identity cuts it off on its next connection, and rotating the secret invalidates the old one immediately.
 
 Machines today come in two shapes: SYSTEM-scope platform daemons such as the vm-manager, and APPLICATION-scope API clients of one application — where the machine acts with that application's scope, exactly the position an application end-user occupies.
 


### PR DESCRIPTION
Every Kinotic service call goes through the Kinotic client, so machines authenticate the way the client already authenticates — `clientId`/`clientSecret` on the WebSocket upgrade — and the client-credentials OAuth grant added in the machine-identity work has no remaining consumer (MCP hosts use PKCE, the CLI uses the device grant). This removes it and teaches the existing header path about machines.

`KinoticSecurityService` now discriminates the credential headers by shape:

```java
// an email is a user credential; anything else is a machine identity id — machines
// carry their scope structurally, so the scope headers only apply to the user path
if (clientId != null && clientId.indexOf('@') >= 0) {
    ret = authenticateEmailPassword(organizationId, applicationId, clientId, clientSecret);
} else {
    ret = authenticateMachine(clientId, clientSecret);
}
```

The machine branch delegates to the existing `verifyMachineCredentials` (bcrypt vs `IdentityCredential`, one generic failure), so the secret is verified on every handshake — disable and rotate take effect on the next connection. A machine client is now just:

```typescript
await Kinotic.connect(buildConnectionInfo(host, port,
    new KinoticOsCredentialsAuthProvider(machineId, machineSecret)))
```

Removed: the `client_credentials` branch in `OAuthServerHandler`, its metadata advertisement (`client_credentials`, `client_secret_post`), and `respondAccessToken`. The e2e machine tests now exercise real client connections (`machineConnect` helper) instead of the token endpoint, including the full lifecycle (provision → connect → rotate → old secret rejected → disable → re-enable → remove) and an assertion that `grant_type=client_credentials` answers `unsupported_grant_type`. Docs and SDK/UI copy updated to match; also fixes the stale `KinoticSecurityService` javadoc claiming the gateway mints a JWT for the browser STOMP handoff (it establishes a session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019q4gd6zWDMHoK9MF2oXZvh

---
_Generated by [Claude Code](https://claude.ai/code/session_019q4gd6zWDMHoK9MF2oXZvh)_