### PR TITLE
Fix @Publish version resolution for orchestrator services

### DIFF
--- a/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
+++ b/kinotic-core/src/main/java/org/kinotic/core/internal/ServiceRegistrationBeanPostProcessor.java
@@ -125,7 +125,7 @@ public class ServiceRegistrationBeanPostProcessor implements DestructionAwareBea
                             String version = MetaUtil.getVersion(inter);
 
                             if (!StringUtils.isNotBlank(version)) {
-                                throw new FatalBeanException("Version must be specified on the Published interface " + inter.getName() + " or an ancestor package.");
+                                throw new FatalBeanException("Version must be specified on the Published interface " + inter.getName() + " or in its package's package-info.java.");
                             }
 
                             // A service is addressable in its declared zone; with no declaration

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/package-info.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/services/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Orchestrator service contracts, including the interfaces published for remote access.
+ */
+@Version("1.0.0")
+@Zone(DomainUtil.SYSTEM_ZONE)
+package org.kinotic.orchestrator.api.services;
+
+import org.kinotic.core.api.annotations.Version;
+import org.kinotic.core.api.annotations.Zone;
+import org.kinotic.domain.api.utils.DomainUtil;

--- a/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/workload/package-info.java
+++ b/kinotic-orchestrator/src/main/java/org/kinotic/orchestrator/api/workload/package-info.java
@@ -3,7 +3,7 @@
  */
 @Version("1.0.0")
 @Zone(DomainUtil.SYSTEM_ZONE)
-package org.kinotic.orchestrator.api;
+package org.kinotic.orchestrator.api.workload;
 
 import org.kinotic.core.api.annotations.Version;
 import org.kinotic.core.api.annotations.Zone;


### PR DESCRIPTION
Fixes the post-merge CI failures from #378 (`Version must be specified on the Published interface org.kinotic.orchestrator.api.services.VmNodeOrchestrationService`). All 56 kinotic-test failures and the JS e2e `/health` timeouts cascaded from this one context-boot failure.

## Root cause

The #378 package restructure moved the two `@Publish`'d interfaces from `api/workload` (which carried `@Version`/`@Zone` in its `package-info.java`) into `api/services` (which had none). The follow-up fix in `fdee3c2a4` placed the `package-info.java` at the module's `api` root — exactly what the exception message suggested — but the resolution code never walks ancestor packages, only the interface's own package:

```java
// kinotic-core/.../internal/utils/MetaUtil.java:213
public static String getVersion(Class<?> clazz){
    ...
    Package pkg = clazz.getPackage();   // exact package only — never ancestors
    if(pkg != null){
        version = AnnotationUtils.findAnnotation(pkg, Version.class);
```

## Changes

- **Add `api/services/package-info.java`** with `@Version("1.0.0")` / `@Zone(DomainUtil.SYSTEM_ZONE)`, covering `VmNodeOrchestrationService` and `WorkloadOrchestrationService` — mirroring the kinotic-os-api pattern of annotating each publishing package.
- **Restore `api/workload/package-info.java`** — `VmManagerProxy` resolves version/zone through the same `MetaUtil` path (`DefaultServiceRegistry.java:149`); a null there doesn't fail the boot, it silently targets an unversioned/unzoned address no vm-manager registers.
- **Correct the exception message** at `ServiceRegistrationBeanPostProcessor.java:128` to say "or in its package's package-info.java" instead of "or an ancestor package", so it stops recommending a fix the resolver doesn't support.

## Verification

`:kinotic-core`, `:kinotic-orchestrator`, and `:kinotic-os-api` compile; all 26 orchestrator grind tests pass; `:kinotic-orchestrator:javadoc` is clean. The full context-boot proof needs the docker/ES-backed kinotic-test suite, which this environment can't run — CI on this PR is the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFtG5a1XKYRtZEMzDRjz5k

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFtG5a1XKYRtZEMzDRjz5k)_