### PR TITLE
Switch vm-manager to CLIENT_CREDENTIALS machine identity auth

### DIFF
--- a/kinotic-js/workspace/bun.lock
+++ b/kinotic-js/workspace/bun.lock
@@ -108,7 +108,7 @@
     },
     "packages/vm-manager": {
       "name": "@kinotic-ai/vm-manager",
-      "version": "5.0.0-beta.4",
+      "version": "5.0.0-beta.5",
       "dependencies": {
         "@boxlite-ai/boxlite": "^0.9.7",
       },

--- a/kinotic-js/workspace/packages/vm-manager/.env.development
+++ b/kinotic-js/workspace/packages/vm-manager/.env.development
@@ -2,8 +2,8 @@
 KINOTIC_NODE_ID=dev-node-1
 KINOTIC_SERVER_HOST=localhost
 KINOTIC_SERVER_PORT=58503
-# The SYSTEM-scope admin seeded by the development migrations
-KINOTIC_CLIENT_ID=admin@kinotic.local
+# The SYSTEM-scope machine identity seeded by the development migrations
+KINOTIC_CLIENT_ID=00000000-0000-0000-0000-000000000011
 KINOTIC_CLIENT_SECRET=kinotic
 KINOTIC_HEARTBEAT_INTERVAL_MS=30000
 KINOTIC_VM_LOGS_DIR=/tmp/kinotic-vm-logs

--- a/kinotic-js/workspace/packages/vm-manager/.env.development
+++ b/kinotic-js/workspace/packages/vm-manager/.env.development
@@ -2,8 +2,9 @@
 KINOTIC_NODE_ID=dev-node-1
 KINOTIC_SERVER_HOST=localhost
 KINOTIC_SERVER_PORT=58503
-KINOTIC_SERVER_LOGIN=kinotic
-KINOTIC_SERVER_PASSCODE=kinotic
+# The SYSTEM-scope admin seeded by the development migrations
+KINOTIC_CLIENT_ID=admin@kinotic.local
+KINOTIC_CLIENT_SECRET=kinotic
 KINOTIC_HEARTBEAT_INTERVAL_MS=30000
 KINOTIC_VM_LOGS_DIR=/tmp/kinotic-vm-logs
 KINOTIC_LOKI_URL=http://localhost:3100

--- a/kinotic-js/workspace/packages/vm-manager/.env.example
+++ b/kinotic-js/workspace/packages/vm-manager/.env.example
@@ -5,9 +5,9 @@ KINOTIC_NODE_ID=
 KINOTIC_SERVER_HOST=localhost
 KINOTIC_SERVER_PORT=58503
 
-# Credentials the vm-manager authenticates with. It hosts its VmManager service in the system
-# zone, so these must belong to a SYSTEM-scope identity — one with no organization or
-# application. A machine identity presents its id, a user their email.
+# The machine identity the vm-manager authenticates with: its id as KINOTIC_CLIENT_ID and the
+# secret issued at provisioning as KINOTIC_CLIENT_SECRET. The machine must be SYSTEM scope — no
+# organization or application — since that is what may host the VmManager service in the system zone.
 KINOTIC_CLIENT_ID=
 KINOTIC_CLIENT_SECRET=
 

--- a/kinotic-js/workspace/packages/vm-manager/.env.example
+++ b/kinotic-js/workspace/packages/vm-manager/.env.example
@@ -4,8 +4,12 @@ KINOTIC_NODE_ID=
 # Kinotic server connection
 KINOTIC_SERVER_HOST=localhost
 KINOTIC_SERVER_PORT=58503
-KINOTIC_SERVER_LOGIN=kinotic
-KINOTIC_SERVER_PASSCODE=kinotic
+
+# Credentials the vm-manager authenticates with. It hosts its VmManager service in the system
+# zone, so these must belong to a SYSTEM-scope identity — one with no organization or
+# application. A machine identity presents its id, a user their email.
+KINOTIC_CLIENT_ID=
+KINOTIC_CLIENT_SECRET=
 
 # Heartbeat interval in milliseconds
 KINOTIC_HEARTBEAT_INTERVAL_MS=30000

--- a/kinotic-js/workspace/packages/vm-manager/package.json
+++ b/kinotic-js/workspace/packages/vm-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinotic-ai/vm-manager",
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "type": "module",
   "files": [
     "bin",

--- a/kinotic-js/workspace/packages/vm-manager/src/index.ts
+++ b/kinotic-js/workspace/packages/vm-manager/src/index.ts
@@ -69,7 +69,7 @@ async function start() {
     console.log(`Connected to Kinotic server at ${server?.host}:${server?.port}`)
 
     const nodeOrchestrator = new VmNodeOrchestrationServiceProxy(
-        Kinotic.serviceProxy(`${SYSTEM_ZONE}~org.kinotic.orchestrator.api.workload.VmNodeOrchestrationService`)
+        Kinotic.serviceProxy(`${SYSTEM_ZONE}~org.kinotic.orchestrator.api.services.VmNodeOrchestrationService`)
     )
 
     // Reattach to workloads a previous vm-manager process left running before the

--- a/kinotic-js/workspace/packages/vm-manager/src/internal/api/DefaultVmManager.ts
+++ b/kinotic-js/workspace/packages/vm-manager/src/internal/api/DefaultVmManager.ts
@@ -11,7 +11,9 @@ import type { Workload, VmProviderType } from '@kinotic-ai/os-api'
  * The {@link Scope} getter ensures this service registers with a scope equal to
  * the node's unique id, allowing the orchestrator to route requests to a specific node's VmManager.
  */
-@Publish('kinotic-ai.vm-manager')
+// Published as 'VmManager', not the class name, so the address matches the orchestrator's
+// VmManagerProxy: srv://<nodeId>@system~kinotic-ai.vm-manager.VmManager
+@Publish('kinotic-ai.vm-manager', 'VmManager')
 export class DefaultVmManager implements IVmManager {
 
     public readonly nodeId: string

--- a/kinotic-migration/src/main/resources/migrations/V3__kinotic_test_users.development.test.sql
+++ b/kinotic-migration/src/main/resources/migrations/V3__kinotic_test_users.development.test.sql
@@ -10,3 +10,10 @@ INSERT INTO kinotic_organization (id, name, description) VALUES ('kinotic-test',
 -- Seed the kinotic-test organization user (password: kinotic)
 INSERT INTO kinotic_participant_identity (id, type, email, displayName, authType, organizationId, enabled) VALUES ('00000000-0000-0000-0000-000000000002', 'USER', 'kinotic@kinotic.local', 'Kinotic Test', 'LOCAL', 'kinotic-test', true) WITH REFRESH;
 INSERT INTO kinotic_identity_credential (id, secretHash) VALUES ('00000000-0000-0000-0000-000000000002', '$2b$12$ztUtxd/6nRYTACObjRNnMOisx3QlNuP2GmabcBdrv4Vcd6Vs46GaG') WITH REFRESH;
+
+
+-- The vm-manager's machine identity: SYSTEM scope = no organizationId/applicationId, which is
+-- what lets it host its VmManager service in the system zone. It connects with the id below as
+-- clientId and 'kinotic' as clientSecret; a deployed vm-manager gets a provisioned secret instead.
+INSERT INTO kinotic_participant_identity (id, type, displayName, authType, enabled) VALUES ('00000000-0000-0000-0000-000000000011', 'MACHINE', 'Development VM Manager', 'CLIENT_CREDENTIALS', true) WITH REFRESH;
+INSERT INTO kinotic_identity_credential (id, secretHash) VALUES ('00000000-0000-0000-0000-000000000011', '$2b$12$ztUtxd/6nRYTACObjRNnMOisx3QlNuP2GmabcBdrv4Vcd6Vs46GaG') WITH REFRESH;

--- a/website/content/02.platform/11.reference/01.cri-format.md
+++ b/website/content/02.platform/11.reference/01.cri-format.md
@@ -144,6 +144,6 @@ cri.raw()           // 'srv://tenant-123@app.acme-org.orders-app~OrderService/pl
 | `srv://app-api~org.kinotic.persistence.api.services.JsonEntitiesRepository/save` | A specific method on a platform service |
 | `srv://app.acme-org.orders-app~OrderService/create#1.0.0` | A versioned method on an application's own service |
 | `srv://app.acme-org.orders-app.billing~InvoiceService` | A service in an application-declared sub-zone |
-| `srv://system~org.kinotic.orchestrator.api.workload.WorkloadOrchestrationService` | A platform-internal service |
+| `srv://system~org.kinotic.orchestrator.api.services.WorkloadOrchestrationService` | A platform-internal service |
 | `stream://app.acme-org.orders-app~temperature` | An application's event stream |
 | `srv://node1@system~kinotic-ai.vm-manager.VmManager` | A scoped system service targeting one node |


### PR DESCRIPTION
Replace vm-manager's login/passcode authentication with CLIENT_CREDENTIALS machine identity authentication using provisioned credentials.

## Summary

The vm-manager now authenticates as a SYSTEM-scope machine identity rather than a user account. This allows it to host services in the system zone and aligns with the orchestrator's service routing expectations.

## Changes

- **Authentication model**: Replace `KINOTIC_SERVER_LOGIN` and `KINOTIC_SERVER_PASSCODE` environment variables with `KINOTIC_CLIENT_ID` and `KINOTIC_CLIENT_SECRET` in `.env.example` and `.env.development`
  - Development uses seeded machine identity `00000000-0000-0000-0000-000000000011` with secret `kinotic`
  - Deployed instances use provisioned credentials at runtime

- **Database migrations**: Add SYSTEM-scope machine identity to development test data (`V3__kinotic_test_users.development.test.sql`)
  - Machine identity has no `organizationId` or `applicationId` (SYSTEM scope)
  - Uses `CLIENT_CREDENTIALS` auth type
  - Credential hash matches development secret for local testing

- **Service publication**: Update `DefaultVmManager` to publish with explicit service name `'VmManager'` instead of deriving from class name
  - Ensures address matches orchestrator's `VmManagerProxy` routing: `srv://<nodeId>@system~kinotic-ai.vm-manager.VmManager`

- **Orchestrator service reference**: Correct service path in `index.ts` from `org.kinotic.orchestrator.api.workload.VmNodeOrchestrationService` to `org.kinotic.orchestrator.api.services.VmNodeOrchestrationService`

- **Documentation**: Update CRI format example to reflect corrected orchestrator service namespace

## Implementation Details

The machine identity is seeded with the same credential hash as the development user (`kinotic`), allowing local testing without additional configuration. Production deployments receive unique provisioned secrets at provisioning time, stored in `KINOTIC_CLIENT_SECRET`.

https://claude.ai/code/session_01UmhTDNqb7o8ZD9i2t6PBmb