### PR TITLE
Raise the portal's os-api floor to 5.0.0-beta.7

### DIFF
--- a/kinotic-frontend/apps/portal/package.json
+++ b/kinotic-frontend/apps/portal/package.json
@@ -15,7 +15,7 @@
     "@kinotic-ai/core": "^5.0.0-beta.3",
     "@kinotic-ai/frontend-common": "workspace:*",
     "@kinotic-ai/idl": "^5.0.0-beta.0",
-    "@kinotic-ai/os-api": "^5.0.0-beta.6",
+    "@kinotic-ai/os-api": "^5.0.0-beta.7",
     "@kinotic-ai/persistence": "^5.0.0-beta.3",
     "@mdi/js": "^7.4.47",
     "@primeuix/themes": "^2.0.3",

--- a/kinotic-frontend/pnpm-lock.yaml
+++ b/kinotic-frontend/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: ^5.0.0-beta.0
         version: 5.0.0-beta.1
       '@kinotic-ai/os-api':
-        specifier: ^5.0.0-beta.6
-        version: 5.0.0-beta.6(@kinotic-ai/core@5.0.0-beta.4)
+        specifier: ^5.0.0-beta.7
+        version: 5.0.0-beta.7(@kinotic-ai/core@5.0.0-beta.4)
       '@kinotic-ai/persistence':
         specifier: ^5.0.0-beta.3
         version: 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.4)
@@ -326,8 +326,8 @@ packages:
     peerDependencies:
       '@kinotic-ai/core': '>=5.0.0-beta.4'
 
-  '@kinotic-ai/os-api@5.0.0-beta.6':
-    resolution: {integrity: sha512-Ql93/ijxUiMZg6zR9JQU50oI2ozAH2+nI/R/tM8qSRvXoFmuhKvfHMJ9gZguAyXu1G4790jdjVDVahJ5RSM6Gw==}
+  '@kinotic-ai/os-api@5.0.0-beta.7':
+    resolution: {integrity: sha512-IUKefs7x1lFcu2wwXRh51A2Yso4smL4Cg16nYeO4zvaEmmkmyrbQME17NXkmFUFcefSopQyZPV/yLTAaMLtmXA==}
     peerDependencies:
       '@kinotic-ai/core': '>=5.0.0-beta.4'
 
@@ -1700,7 +1700,7 @@ snapshots:
       '@kinotic-ai/persistence': 5.0.0-beta.4(@kinotic-ai/core@5.0.0-beta.4)
       rxjs: 7.8.2
 
-  '@kinotic-ai/os-api@5.0.0-beta.6(@kinotic-ai/core@5.0.0-beta.4)':
+  '@kinotic-ai/os-api@5.0.0-beta.7(@kinotic-ai/core@5.0.0-beta.4)':
     dependencies:
       '@kinotic-ai/core': 5.0.0-beta.4
       '@kinotic-ai/idl': 5.0.0-beta.1


### PR DESCRIPTION
Follow-up to #398. The portal calls the three-argument `completeInstall` that ships in `@kinotic-ai/os-api@5.0.0-beta.7`, so builds against the previously locked beta.6 failed type-check — this is what turned develop's CodeQL `Analyze (java-kotlin)` autobuild red after the squash-merge:

```
apps/portal build: src/pages/GitHubInstallCallback.vue(52,101): error TS2554: Expected 2 arguments, but got 3.
```

beta.7 is now published, so this raises the portal's floor to `^5.0.0-beta.7` and re-resolves the lockfile. Full `pnpm build` of the frontend workspace passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRocpXFV9Hgrj2WuBDEcze

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRocpXFV9Hgrj2WuBDEcze)_